### PR TITLE
make gradf return None for non-trainable parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,9 @@ Precisely one of `filter_fn` or `filter_tree` must be passed.<br>
 See also `equinox.is_inexact_array` as usually a good choice of `filter_fn`: this will differentiate all floating-point arrays.<br>
 See also `equinox.tree_at` for an easy way to create the `filter_tree` argument.
 
-Note that as the returned gradients must have the same structure as the inputs, then all nondifferentiable components of the input PyTrees will have gradient `0`. If the nondifferentiable component is an arbitrary Python object that does not support addition, then doing a simple `jax.tree_map(lambda m, g: m - lr * g, model, grad)` may fail. As such Equinox provides `equinox.apply_updates` as a simple convenience: it will only apply the update if the gradient is nonzero. See below.
+Note that as the returned gradients must have the same structure as the inputs, then all nondifferentiable components of the input PyTrees will have gradient `None`. 
+Doing a simple `jax.tree_map(lambda m, g: m - lr * g, model, grad)` will fail. 
+As such Equinox provides `equinox.apply_updates` as a simple convenience: it will only apply the update if the gradient is not `None`. See below.
 
 ```python
 equinox.value_and_grad_f(fun, *, filter_fn=None, filter_tree=None, **kwargs)
@@ -241,7 +243,7 @@ Performs a training update to a model.
 - `model` must be a PyTree;
 - `updates` must be a PyTree with the same structure.
 
-It essentially performs `jax.tree_map(lambda m, u: m + u, modelm updates)`. However anywhere `updates` is zero then no update is made at all, so as to handle nondifferentiable parts of `model` that may not have addition defined (e.g. activation functions).
+It essentially performs `jax.tree_map(lambda m, u: m + u, model, updates)`. However anywhere `updates` is `None` then no update is made at all, so as to handle nondifferentiable parts of `model`.
 
 The returned value is the updated model. (`model` is *not* mutated in place, as is usual in JAX and functional programming.)
 

--- a/equinox/gradf.py
+++ b/equinox/gradf.py
@@ -43,8 +43,8 @@ def value_and_grad_f(fun, *, filter_fn=None, filter_tree=None, argnums=0, **grad
         for j, i in enumerate(argnums):
             g = grad[j]
             arg_nograd, which, treedef = notes[i]
-            zero = [0.0 for _ in arg_nograd]
-            grad[j] = merge(g, zero, which, treedef)
+            none_grad = [None for _ in arg_nograd]
+            grad[j] = merge(g, none_grad, which, treedef)
         if unwrap:
             (grad,) = grad
         return value, grad

--- a/equinox/update.py
+++ b/equinox/update.py
@@ -1,5 +1,4 @@
 import jax
-import jax.numpy as jnp
 
 from .custom_types import PyTree
 

--- a/equinox/update.py
+++ b/equinox/update.py
@@ -5,12 +5,9 @@ from .custom_types import PyTree
 
 
 def _apply_update(p, u):
-    u = jnp.asarray(u)
-    if jnp.count_nonzero(u) == 0:
+    if u is None:
         return p
     else:
-        p = jnp.asarray(p)
-        u = u.astype(p.dtype)
         return p + u
 
 

--- a/examples/train_mlp.py
+++ b/examples/train_mlp.py
@@ -77,10 +77,7 @@ def main(
     for step, (x, y) in zip(range(steps), data):
         value, grads = loss(model, x, y)
         updates, opt_state = optim.update(grads, opt_state)
-        # Essentially equivalent to optax.apply_updates, it just doesn't try to update anything with a zero gradient.
-        # Anything we filtered out above will have a zero gradient. But in general some of the things we filtered out
-        # might not even be jnp.arrays, and might not even have a notion of addition. We don't want to try adding zero
-        # to arbitrary Python objects.
+        # Essentially equivalent to optax.apply_updates, it just doesn't try to update anything with a `None` gradient.
         model = eqx.apply_updates(model, updates)
         print(step, value)
     return value  # Final loss

--- a/tests/test_gradf.py
+++ b/tests/test_gradf.py
@@ -33,8 +33,8 @@ def test_gradf_filter_fn(getkey):
         return jnp.sum(x)
 
     grad_g2a, grad_g2b = g2(a, b)
-    assert jnp.all(grad_g2a == 0)
-    assert jnp.all(grad_g2b == 0)
+    assert grad_g2a is None
+    assert grad_g2b is None
 
     @ft.partial(eqx.gradf, argnums=1, filter_fn=lambda _: True)
     def h(x, y):
@@ -66,9 +66,9 @@ def test_gradf_filter_fn(getkey):
     assert jnp.all(gb == 1)
 
     gtrue, ghi, gobject, ga = j([True, "hi", object(), a])
-    assert gtrue == 0
-    assert ghi == 0
-    assert gobject == 0
+    assert gtrue is None
+    assert ghi is None
+    assert gobject is None
     assert jnp.all(ga == 1)
 
     gtrue, gdict, (g5, g1), gnp = j(
@@ -79,14 +79,14 @@ def test_gradf_filter_fn(getkey):
             np.array([2.0, 3.0]),
         ]
     )
-    assert gtrue == 0
+    assert gtrue is None
     assert list(gdict.keys()) == ["hi"]
     assert isinstance(gdict["hi"], eqx.nn.Linear)
     assert jnp.all(gdict["hi"].weight == 1)
     assert jnp.all(gdict["hi"].bias == 1)
-    assert g5 == 0
-    assert g1 == 0
-    assert gnp == 0
+    assert g5 is None
+    assert g1 is None
+    assert gnp is None
 
     @ft.partial(eqx.gradf, filter_fn=eqx.is_array_like)
     def k(x):
@@ -101,8 +101,8 @@ def test_gradf_filter_fn(getkey):
     assert jnp.all(gb == 1)
 
     ghi, gobject, ga = k(["hi", object(), a])
-    assert ghi == 0
-    assert gobject == 0
+    assert ghi is None
+    assert gobject is None
     assert jnp.all(ga == 1)
 
     gdict, (g1,), gnp = k(
@@ -128,7 +128,7 @@ def test_gradf_filter_tree(getkey):
 
     ga, gb = f([a, b])
     assert jnp.all(ga == 1)
-    assert gb == 0
+    assert gb is None
 
     @ft.partial(eqx.gradf, argnums=(0, 1), filter_tree=[True, False])
     def g(x, y):
@@ -136,7 +136,7 @@ def test_gradf_filter_tree(getkey):
 
     ga, gb = g(a, b)
     assert jnp.all(ga == 1)
-    assert gb == 0
+    assert gb is None
 
     @ft.partial(eqx.gradf, argnums=0, filter_tree={"a": True, "b": False})
     def h1(x, y):
@@ -148,11 +148,11 @@ def test_gradf_filter_tree(getkey):
 
     grad = h1({"a": a, "b": b}, c)
     assert jnp.allclose(grad["a"], jnp.sum(b) * c)
-    assert grad["b"] == 0
+    assert grad["b"] is None
 
     grad = h2(c, {"a": a, "b": b})
     assert jnp.allclose(grad["a"], jnp.sum(b) * c)
-    assert grad["b"] == 0
+    assert grad["b"] is None
 
     with pytest.raises(ValueError):
         grad = h1(c, {"a": a, "b": b})
@@ -173,7 +173,7 @@ def test_gradf_filter_tree(getkey):
     gradc, graddict = j({"a": a, "b": b}, 2.0, c)
     assert jnp.allclose(gradc, jnp.sum(a) * jnp.sum(b) * 2)
     assert jnp.allclose(graddict["a"], jnp.sum(b) * jnp.sum(c) * 2)
-    assert graddict["b"] == 0
+    assert graddict["b"] is None
 
 
 def test_both_filter():

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,14 +1,14 @@
 import jax.numpy as jnp
+import pytest
 
 import equinox as eqx
 
 
 def test_apply_updates1():
-    o = object()
-    params = [o, jnp.array([2])]
-    grads = [0, 1]
+    params = [jnp.array([5]), jnp.array([2])]
+    grads = [-1, 1]
     new_params = eqx.apply_updates(params, grads)
-    assert new_params == [o, jnp.array([3])]
+    assert new_params == [jnp.array([4]), jnp.array([3])]
 
 
 def test_apply_updates2():
@@ -21,3 +21,11 @@ def test_apply_updates2():
     grads = eqx.gradf(f, filter_fn=lambda x: x == 3)(params)
     new_params = eqx.apply_updates(params, grads)
     assert new_params == [o, jnp.array([4.0]), jnp.array([2.0])]
+
+
+def test_apply_updates3():
+    o = object()
+    params = [o, jnp.array([2])]
+    grads = [0, 1]
+    with pytest.raises(TypeError):
+        eqx.apply_updates(params, grads)


### PR DESCRIPTION
Currently, `gradf` returns `0` for non-trainable parameters. A better approach is to return `None` instead. 