### PR TITLE
Create a Parameter container to specify trainable parameter

### DIFF
--- a/equinox/module.py
+++ b/equinox/module.py
@@ -3,6 +3,8 @@ from dataclasses import dataclass, fields
 
 import jax
 
+from equinox.custom_types import Array
+
 from .tree import tree_equal
 
 
@@ -91,10 +93,15 @@ class Module(metaclass=_ModuleMeta):
             f = getattr(self, field.name)
             if isinstance(f, Module):
                 mask.append(f.parameters())
-            elif field.name.startswith('_'):
-                mask.append(False)
             else:
-                mask.append(True)
+                mask.append(False)
         ans = cls.__new__(cls, *mask)
         cls.__dataclass_init__(ans, *mask)
         return ans
+
+
+class Parameter(Module):
+    value: Array
+
+    def parameters(self):
+        return Parameter(True)

--- a/equinox/module.py
+++ b/equinox/module.py
@@ -83,3 +83,18 @@ class _ModuleMeta(abc.ABCMeta):
 class Module(metaclass=_ModuleMeta):
     def __eq__(self, other):
         return tree_equal(self, other)
+
+    def parameters(self):
+        cls = self.__class__
+        mask = []
+        for field in fields(cls):
+            f = getattr(self, field.name)
+            if isinstance(f, Module):
+                mask.append(f.parameters())
+            elif field.name.startswith('_'):
+                mask.append(False)
+            else:
+                mask.append(True)
+        ans = cls.__new__(cls, *mask)
+        cls.__dataclass_init__(ans, *mask)
+        return ans

--- a/equinox/nn/linear.py
+++ b/equinox/nn/linear.py
@@ -4,29 +4,27 @@ from typing import Optional
 import jax.random as jrandom
 
 from ..custom_types import Array
-from ..module import Module
+from ..module import Module, Parameter
 
 
 class Linear(Module):
-    weight: Array
+    weight: Parameter
     bias: Optional[Array]
 
     def __init__(self, in_features, out_features, use_bias=True, *, key):
         super().__init__()
         wkey, bkey = jrandom.split(key, 2)
         lim = 1 / math.sqrt(in_features)
-        self.weight = jrandom.uniform(
-            wkey, (out_features, in_features), minval=-lim, maxval=lim
-        )
+        self.weight = Parameter(jrandom.uniform(wkey, (out_features, in_features), minval=-lim, maxval=lim))
         if use_bias:
-            self.bias = jrandom.uniform(bkey, (out_features,), minval=-lim, maxval=lim)
+            self.bias = Parameter(jrandom.uniform(bkey, (out_features,), minval=-lim, maxval=lim))
         else:
             self.bias = None
 
     def __call__(self, x, *, key=None):
-        x = self.weight @ x
+        x = self.weight.value @ x
         if self.bias is not None:
-            x = x + self.bias
+            x = x + self.bias.value
         return x
 
 

--- a/equinox/nn/rnn.py
+++ b/equinox/nn/rnn.py
@@ -6,7 +6,7 @@ import jax.numpy as jnp
 import jax.random as jrandom
 
 from ..custom_types import Array
-from ..module import Module
+from ..module import Module, Parameter
 
 
 class GRUCell(Module):
@@ -21,19 +21,11 @@ class GRUCell(Module):
         ihkey, hhkey, bkey, bkey2 = jrandom.split(key, 4)
         lim = math.sqrt(1 / hidden_size)
 
-        self.weight_ih = jrandom.uniform(
-            ihkey, (3 * hidden_size, input_size), minval=-lim, maxval=lim
-        )
-        self.weight_hh = jrandom.uniform(
-            hhkey, (3 * hidden_size, hidden_size), minval=-lim, maxval=lim
-        )
+        self.weight_ih = Parameter(jrandom.uniform(ihkey, (3 * hidden_size, input_size), minval=-lim, maxval=lim))
+        self.weight_hh = Parameter(jrandom.uniform(hhkey, (3 * hidden_size, hidden_size), minval=-lim, maxval=lim))
         if bias:
-            self.bias = jrandom.uniform(
-                bkey, (3 * hidden_size,), minval=-lim, maxval=lim
-            )
-            self.bias_n = jrandom.uniform(
-                bkey2, (hidden_size,), minval=-lim, maxval=lim
-            )
+            self.bias = Parameter(jrandom.uniform(bkey, (3 * hidden_size,), minval=-lim, maxval=lim))
+            self.bias_n = Parameter(jrandom.uniform(bkey2, (hidden_size,), minval=-lim, maxval=lim))
         else:
             self.bias = None
             self.bias_n = None
@@ -43,10 +35,10 @@ class GRUCell(Module):
             bias = 0
             bias_n = 0
         else:
-            bias = self.bias
-            bias_n = self.bias_n
-        igates = jnp.split(self.weight_ih @ input + bias, 3)
-        hgates = jnp.split(self.weight_hh @ hidden, 3)
+            bias = self.bias.value
+            bias_n = self.bias_n.value
+        igates = jnp.split(self.weight_ih.value @ input + bias, 3)
+        hgates = jnp.split(self.weight_hh.value @ hidden, 3)
         reset = jnn.sigmoid(igates[0] + hgates[0])
         inp = jnn.sigmoid(igates[1] + hgates[1])
         new = jnn.tanh(igates[2] + reset * (hgates[2] + bias_n))
@@ -64,24 +56,18 @@ class LSTMCell(Module):
         ihkey, hhkey, bkey = jrandom.split(key, 3)
         lim = math.sqrt(1 / hidden_size)
 
-        self.weight_ih = jrandom.uniform(
-            ihkey, (4 * hidden_size, input_size), minval=-lim, maxval=lim
-        )
-        self.weight_hh = jrandom.uniform(
-            hhkey, (4 * hidden_size, hidden_size), minval=-lim, maxval=lim
-        )
+        self.weight_ih = Parameter(jrandom.uniform(ihkey, (4 * hidden_size, input_size), minval=-lim, maxval=lim))
+        self.weight_hh = Parameter(jrandom.uniform(hhkey, (4 * hidden_size, hidden_size), minval=-lim, maxval=lim))
         if bias is None:
-            self.bias = jrandom.uniform(
-                bkey, (4 * hidden_size,), minval=-lim, maxval=lim
-            )
+            self.bias = Parameter(jrandom.uniform(bkey, (4 * hidden_size,), minval=-lim, maxval=lim))
         else:
             self.bias = None
 
     def __call__(self, input, hidden, *, key=None):
         h, c = hidden
-        lin = self.weight_ih @ input + self.weight_hh @ h
+        lin = self.weight_ih.value @ input + self.weight_hh.value @ h
         if self.bias is not None:
-            lin = lin + self.bias
+            lin = lin + self.bias.value
         i, f, g, o = jnp.split(lin, 4)
         i = jnn.sigmoid(i)
         f = jnn.sigmoid(f)

--- a/examples/frozen_layer.py
+++ b/examples/frozen_layer.py
@@ -30,7 +30,7 @@ def main(
     # Let's train just the final layer of the MLP, and leave the others frozen.
     filter_tree = jax.tree_map(lambda _: False, model)
     filter_tree = eqx.tree_at(
-        lambda tree: (tree.layers[-1].weight, tree.layers[-1].bias),
+        lambda tree: (tree.layers[-1].weight.value, tree.layers[-1].bias.value),
         filter_tree,
         replace=(True, True),
     )

--- a/examples/train_rnn.py
+++ b/examples/train_rnn.py
@@ -81,6 +81,7 @@ def main(
         # Trains with respect to binary cross-entropy
         return -jnp.mean(y * jnp.log(pred_y) + (1 - y) * jnp.log(1 - pred_y))
 
+    # import pdb; pdb.set_trace()
     vag = eqx.value_and_grad_f(loss, filter_tree=model.parameters())
 
     optim = optax.adam(learning_rate)


### PR DESCRIPTION
The problem of having a filter function to decide if a parameter is trainable is that, for `batch_norm` or any non-trainable real value tensor, we currently cannot decide if its parameters are trainable or not.

My proposal is: to have a `Parameter` class which is a sub-class of `Module` to indicate if a tensor is a trainable parameter or not.  The model is still a pytree but now can store `requires_grad` information like Pytorch.

I just want to see if you are interested in this proposal. If not, just say so!


Adding a new method `parameters` to `Module` class. This method returns a Boolean tree of the model to indicate if a leave is trainable. The output of this method is used as the `filter_tree` parameter of `gradf` function.

In order to JIT compile an `update` function, which inputs a model and outputs an updated model, I added two helper methods.
* `remove_unjitable_fields`  replace all non-tensor fields of the tree by `None`. 
* `update` update all tensor values (non-None) of the tree.