### PR TITLE
version 0.0.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ Returns a 4-tuple of `(flat_true, flat_false, which, treedef)`.
 
 See also `equinox.merge` to reconstitute the PyTree again.
 
-This function is useful when working with JAX libraries that only support PyTrees of trainable parameters, and not more general PyTrees: the model can be split into its trainable and nontrainable components and passed into the library that way. See the example [`modules_to_initapply`](./examples/modules_to_initapply.py).
+This function is useful when working with JAX libraries that only support PyTrees of trainable parameters, and not more general PyTrees: the model can be split into its trainable and nontrainable components and passed into the library that way. See the example [`modules_to_initapply.py`](./examples/modules_to_initapply.py).
 
 ```python
 equinox.merge(flat_true, flat_false, which, treedef)

--- a/equinox/__init__.py
+++ b/equinox/__init__.py
@@ -1,5 +1,5 @@
 from . import nn
-from .filters import is_array_like, is_inexact_array
+from .filters import is_array_like, is_inexact_array, merge, split
 from .gradf import gradf, value_and_grad_f
 from .jitf import jitf
 from .module import Module
@@ -7,4 +7,4 @@ from .tree import tree_at, tree_equal
 from .update import apply_updates
 
 
-__version__ = "0.0.1"
+__version__ = "0.0.2"

--- a/equinox/gradf.py
+++ b/equinox/gradf.py
@@ -2,7 +2,7 @@ import functools as ft
 
 import jax
 
-from .filters import merge, split, split_tree, validate_filters
+from .filters import merge, split, validate_filters
 
 
 def value_and_grad_f(fun, *, filter_fn=None, filter_tree=None, argnums=0, **gradkwargs):
@@ -33,9 +33,11 @@ def value_and_grad_f(fun, *, filter_fn=None, filter_tree=None, argnums=0, **grad
             arg = args[i]
             if filter_fn is None:
                 # implies filter_tree is not None
-                arg_grad, arg_nograd, which, treedef = split_tree(arg, filter_tree[j])
+                arg_grad, arg_nograd, which, treedef = split(
+                    arg, filter_tree=filter_tree[j]
+                )
             else:
-                arg_grad, arg_nograd, which, treedef = split(arg, filter_fn)
+                arg_grad, arg_nograd, which, treedef = split(arg, filter_fn=filter_fn)
             args[i] = arg_grad
             notes[i] = (arg_nograd, which, treedef)
         value, grad = f_value_and_grad(*args, notes, **kwargs)

--- a/equinox/module.py
+++ b/equinox/module.py
@@ -9,7 +9,7 @@ from .tree import tree_equal
 # dataclasses.astuple operates recursively, which destroys information about
 # nested tree_dataclasses. In contrast this is just a shallow tuplification.
 def _dataclass_astuple(cls):
-    return tuple(getattr(cls, field.name) for field in fields(cls))
+    return tuple(getattr(cls, field.name) for field in fields(cls) if field.init)
 
 
 def _allow_setattr(fields):

--- a/examples/modules_to_initapply.py
+++ b/examples/modules_to_initapply.py
@@ -3,15 +3,13 @@
 # Existing JAX neural network libraries have sometimes followed the "init/apply"
 # approach, in which the parameters of a network are initialised with `init`, and then
 # the forward pass through a model is specified with `apply`. For example Stax follows
-# this approach
+# this approach.
 #
 # As a corollary, the parameters returned from `init` are sometimes assumed to all be
 # JIT-able or grad-able, e.g. by third-party libraries.
 # (In contrast Equinox is more general: it (a) doesn't assume that you necessarily
 # want to take gradients with respect to all your parameters, and (b) doesn't even
 # mandate that all your parameters are JAX arrays.)
-# For example this typically means that activation functions are hardcoded inside the
-# `apply` function rather than being a parameter that can be changed.
 #
 # If need be -- e.g. third party library compatibility -- then Equinox can be made to
 # fit this style very easily, like so.

--- a/examples/modules_to_initapply.py
+++ b/examples/modules_to_initapply.py
@@ -1,0 +1,61 @@
+##############
+#
+# Existing JAX neural network libraries have sometimes followed the "init/apply"
+# approach, in which the parameters of a network are initialised with `init`, and then
+# the forward pass through a model is specified with `apply`. For example Stax follows
+# this approach
+#
+# As a corollary, the parameters returned from `init` are sometimes assumed to all be
+# JIT-able or grad-able, e.g. by third-party libraries.
+# (In contrast Equinox is more general: it (a) doesn't assume that you necessarily
+# want to take gradients with respect to all your parameters, and (b) doesn't even
+# mandate that all your parameters are JAX arrays.)
+# For example this typically means that activation functions are hardcoded inside the
+# `apply` function rather than being a parameter that can be changed.
+#
+# If need be -- e.g. third party library compatibility -- then Equinox can be made to
+# fit this style very easily, like so.
+#
+##############
+
+import jax
+import jax.numpy as jnp
+import jax.random as jrandom
+
+import equinox as eqx
+
+
+# Made to look a bit like a Stax model.
+def make_mlp(in_size, out_size, width_size, depth, *, key):
+    mlp = eqx.nn.MLP(in_size, out_size, width_size, depth, key=key)
+    grad_params, nongrad_params, which, treedef = eqx.split(
+        mlp, filter_fn=eqx.is_inexact_array
+    )
+
+    def init_fn():
+        return grad_params
+
+    def apply_fn(params, x):
+        model = eqx.merge(params, nongrad_params, which, treedef)
+        return model(x)
+
+    return init_fn, apply_fn
+
+
+def main(in_size=2, seed=5678):
+    key = jrandom.PRNGKey(seed)
+
+    init_fn, apply_fn = make_mlp(
+        in_size=in_size, out_size=1, width_size=8, depth=1, key=key
+    )
+
+    x = jnp.arange(in_size)  # sample data
+    params = init_fn()
+    y1 = apply_fn(params, x)
+    params = jax.tree_map(lambda p: p + 1, params)  # "stochastic gradient descent"
+    y2 = apply_fn(params, x)
+    assert y1 != y2
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -37,7 +37,7 @@ def test_is_array_like(getkey):
         assert eqx.is_array_like(o) == r
 
 
-def test_split_and_merge(getkey):
+def test_splitfn_and_merge(getkey):
     filter_fn = lambda x: isinstance(x, int)
     for pytree in (
         [
@@ -51,13 +51,13 @@ def test_split_and_merge(getkey):
         ],
         [1, 1, 1, 1, "hi"],
     ):  # has repeated elements
-        int_args, notint_args, which, treedef = eqx.filters.split(pytree, filter_fn)
+        int_args, notint_args, which, treedef = eqx.split(pytree, filter_fn=filter_fn)
         for arg in int_args:
             assert isinstance(arg, int)
         for arg in notint_args:
             assert not isinstance(arg, int)
         assert sum(which) == 4
-        re_pytree = eqx.filters.merge(int_args, notint_args, which, treedef)
+        re_pytree = eqx.merge(int_args, notint_args, which, treedef)
         assert re_pytree == pytree
 
 
@@ -75,8 +75,8 @@ def test_splittree_and_merge(getkey):
             [1, 1, [1, 1, {"a": 1, "b": 1, "c": linear}]],
         )
     ):  # has repeated elements
-        keep_args, notkeep_args, which, treedef = eqx.filters.split_tree(
-            pytree, filter_tree
+        keep_args, notkeep_args, which, treedef = eqx.split(
+            pytree, filter_tree=filter_tree
         )
         if i == 0:
             assert set(notkeep_args) == {2, 3, True, 4}
@@ -84,10 +84,10 @@ def test_splittree_and_merge(getkey):
             assert notkeep_args == [1, 1, 1, 1]
         assert sum(which) == 4
 
-        re_pytree = eqx.filters.merge(keep_args, notkeep_args, which, treedef)
+        re_pytree = eqx.merge(keep_args, notkeep_args, which, treedef)
         assert re_pytree == pytree
 
     filter_tree = [True, [False, False]]
     pytree = [True, None]
     with pytest.raises(ValueError):
-        eqx.filters.split_tree(pytree, filter_tree)
+        eqx.split(pytree, filter_tree=filter_tree)


### PR DESCRIPTION
- Added `split` and `merge` to the public interface.
- It is now valid to annotate Module attributes with `dataclasses.field(init=False)`.
- Added example on how to use Equinox in an init/apply manner.