### PR TITLE
Updated array filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,13 +127,15 @@ equinox.gradf                    equinox.tree_at
 equinox.value_and_grad_f         equinox.tree_equal   
 
 # Filters                        # Neural networks
-equinox.is_inexact_array         equinox.nn.Linear
+equinox.is_array                 equinox.nn.Linear
 equinox.is_array_like            equinox.nn.Identity
-equinox.split                    equinox.nn.Dropout
-equinox.merge                    equinox.nn.GRUCell
-                                 equinox.nn.LSTMCell
-# Module                         equinox.nn.Sequential
-equinox.Module                   equinox.nn.MLP
+equinox.is_inexact_array         equinox.nn.Dropout
+equinox.is_inexact_array_like    equinox.nn.GRUCell
+equinox.split                    equinox.nn.LSTMCell
+equinox.merge                    equinox.nn.Sequential
+                                 equinox.nn.MLP
+# Module
+equinox.Module
 ```
 
 ### Filtered transformations
@@ -180,14 +182,24 @@ Wraps `jax.value_and_grad`. Arguments are as `equinox.gradf`.
 Any function `Any -> bool` can be used as a filter. We provide some convenient common choices.
 
 ```python
+equinox.is_array(element)
+```
+Returns `True` if `element` is a JAX array (not but a NumPy array).
+
+```python
+equinox.is_array_like(element)
+```
+Returns `True` if `element` is a JAX array, NumPy array, or a Python float/int/bool/complex.
+
+```python
 equinox.is_inexact_array(element)
 ```
 Returns `True` if `element` is a floating point JAX array (but not a NumPy array).
 
 ```python
-equinox.is_array_like(element)
+equinox.is_inexact_array_like(element)
 ```
-Returns `True` if `element` can be interpreted as a JAX array. (i.e. does `jax.numpy.array` throw an exception or not.)
+Returns `True` if `element` is a floating point JAX array, floating point NumPy array, or a Python float or complex.
 
 ### Splitting/merging
 

--- a/equinox/__init__.py
+++ b/equinox/__init__.py
@@ -1,5 +1,12 @@
 from . import nn
-from .filters import is_array_like, is_inexact_array, merge, split
+from .filters import (
+    is_array,
+    is_array_like,
+    is_inexact_array,
+    is_inexact_array_like,
+    merge,
+    split,
+)
 from .gradf import gradf, value_and_grad_f
 from .jitf import jitf
 from .module import Module
@@ -7,4 +14,4 @@ from .tree import tree_at, tree_equal
 from .update import apply_updates
 
 
-__version__ = "0.0.2"
+__version__ = "0.0.3"

--- a/equinox/filters.py
+++ b/equinox/filters.py
@@ -4,24 +4,34 @@ from typing_extensions import get_args
 import jax
 import jax.numpy as jnp
 
-from .custom_types import Array, PyTree, TreeDef
+from .custom_types import Array, MoreArrays, PyTree, TreeDef
+
+
+_array_types = get_args(Array)
+_morearray_types = get_args(MoreArrays)
+_arraylike_types = _morearray_types + (int, float, complex, bool)
 
 
 # TODO: not sure if this is the best way to do this? In light of:
 # https://github.com/google/jax/commit/258ae44303b1539eff6253263694ec768b8803f0#diff-de759f969102e9d64b54a299d11d5f0e75cfe3052dc17ffbcd2d43b250719fb0
-def is_inexact_array(element: Any) -> bool:
-    return isinstance(element, get_args(Array)) and jnp.issubdtype(
-        element.dtype, jnp.inexact
-    )
+def is_array(element: Any) -> bool:
+    return isinstance(element, _array_types)
 
 
+# Does _not_ do a try/except on jnp.asarray(element) because that's very slow.
 def is_array_like(element: Any) -> bool:
-    try:
-        jnp.asarray(element)
-    except Exception:
-        return False
-    else:
-        return True
+    return isinstance(element, _arraylike_types)
+
+
+def is_inexact_array(element: Any) -> bool:
+    return is_array(element) and jnp.issubdtype(element.dtype, jnp.inexact)
+
+
+def is_inexact_array_like(element: Any) -> bool:
+    return (
+        isinstance(element, _morearray_types)
+        and jnp.issubdtype(element.dtype, jnp.inexact)
+    ) or isinstance(element, (float, complex))
 
 
 def split(

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,11 +1,12 @@
 import jax
 import jax.numpy as jnp
+import numpy as np
 import pytest
 
 import equinox as eqx
 
 
-def test_is_inexact_array(getkey):
+def test_is_array(getkey):
     objs = [
         1,
         2.0,
@@ -14,11 +15,13 @@ def test_is_inexact_array(getkey):
         object(),
         jnp.array([1]),
         jnp.array(1.0),
+        np.array(1.0),
+        np.array(1),
         eqx.nn.Linear(1, 1, key=getkey()),
     ]
-    results = [False, False, False, False, False, False, True, False]
+    results = [False, False, False, False, False, True, True, False, False, False]
     for o, r in zip(objs, results):
-        assert eqx.is_inexact_array(o) == r
+        assert eqx.is_array(o) == r
 
 
 def test_is_array_like(getkey):
@@ -30,11 +33,49 @@ def test_is_array_like(getkey):
         object(),
         jnp.array([1]),
         jnp.array(1.0),
+        np.array(1.0),
+        np.array(1),
         eqx.nn.Linear(1, 1, key=getkey()),
     ]
-    results = [True, True, True, True, False, True, True, False]
+    results = [True, True, False, True, False, True, True, True, True, False]
     for o, r in zip(objs, results):
         assert eqx.is_array_like(o) == r
+
+
+def test_is_inexact_array(getkey):
+    objs = [
+        1,
+        2.0,
+        [2.0],
+        True,
+        object(),
+        jnp.array([1]),
+        jnp.array(1.0),
+        np.array(1.0),
+        np.array(1),
+        eqx.nn.Linear(1, 1, key=getkey()),
+    ]
+    results = [False, False, False, False, False, False, True, False, False, False]
+    for o, r in zip(objs, results):
+        assert eqx.is_inexact_array(o) == r
+
+
+def test_is_inexact_array_like(getkey):
+    objs = [
+        1,
+        2.0,
+        [2.0],
+        True,
+        object(),
+        jnp.array([1]),
+        jnp.array(1.0),
+        np.array(1.0),
+        np.array(1),
+        eqx.nn.Linear(1, 1, key=getkey()),
+    ]
+    results = [False, True, False, False, False, False, True, True, False, False]
+    for o, r in zip(objs, results):
+        assert eqx.is_inexact_array_like(o) == r
 
 
 def test_splitfn_and_merge(getkey):


### PR DESCRIPTION
- Added `is_array` and `is_inexact_array_like`.
- Tweaked the behaviour of `is_array_like` to use an instance check rather than doing a try/except on `jnp.asarray`. This is much (much) faster. Technically this is a slight change in behaviour (wrt arguments like `[1.0]`), but as its primary use is filtering, and always called on leaves, this (hopefully) shouldn't be an issue.