### PR TITLE
fix minor variable mix up in examples

### DIFF
--- a/examples/frozen_layer.py
+++ b/examples/frozen_layer.py
@@ -25,7 +25,7 @@ def main(
     data = dataloader(data, batch_size=batch_size, key=loader_key)
 
     model = eqx.nn.MLP(
-        in_size=1, out_size=1, width_size=depth, depth=depth, key=model_key
+        in_size=1, out_size=1, width_size=width_size, depth=depth, key=model_key
     )
     # Let's train just the final layer of the MLP, and leave the others frozen.
     filter_tree = jax.tree_map(lambda _: False, model)

--- a/examples/train_mlp.py
+++ b/examples/train_mlp.py
@@ -59,7 +59,7 @@ def main(
     # `equinox.jitf` and `equinox.gradf` will work just fine on any PyTree you like.
     # (Here, `model` is actually a PyTree -- have a look at the `build_model.py` example for more on that.)
     model = eqx.nn.MLP(
-        in_size=1, out_size=1, width_size=depth, depth=depth, key=model_key
+        in_size=1, out_size=1, width_size=width_size, depth=depth, key=model_key
     )
 
     # `jitf` and `value_and_grad_f` are thin wrappers around the usual `jax` functions; they just flatten the


### PR DESCRIPTION
Replaced `depth` with `width_size` in `train_mlp.py` and `frozen_layer.py` examples