### PR TITLE
V010

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,32 +2,14 @@
 <h2 align='center'>Callable PyTrees and filtered JIT/grad transformations<br>=> neural networks in JAX</h2>
 
 Equinox brings more power to your model building in [JAX](https://github.com/google/jax).<br>
-Represent *parameterised functions as data*, and use *filtered transformations* for powerful fine-grained control of the model-building process.
+Represent *parameterised functions as data* and use *filtered transformations* for powerful fine-grained control of the model-building process. Equinox demonstrates how to use a PyTorch-like class-based API without compromising on JAX-like functional programming.
 
-Equinox is half tech-demo, half neural network library.
+Equinox is half tech-demo, half neural network library, and comes with no behind-the-scenes magic, guaranteed.
 
-## Equinox in brief
+The elegance of Equinox is its selling point in a world that already has [Haiku](https://github.com/deepmind/dm-haiku), [Flax](https://github.com/google/flax) and so on.
 
-### Building neural networks
 
-Build models using a PyTorch-like class based API *without* sacrificing JAX-like functional programming.
-
-In particular, *without* extra complexity like class-to-functional transformations, or custom notions of parameter groups.
-
-Equinox is a tiny library -- no behind-the-scenes magic, guaranteed.
-The elegance of Equinox is its selling point in a world that already has [Haiku](https://github.com/deepmind/dm-haiku), [Flax](https://github.com/google/flax) etc.
-
-### Technical contributions
-
-1. Equinox represents *parameterised functions as [PyTrees](https://jax.readthedocs.io/en/latest/pytrees.html)*. This is done by subclassing `equinox.Module`. (For example a neural network is a function parameterised by its weights, biases, etc.) They key point is that you can now JIT/grad a higher-order function (like a loss function) with respect to a parameterised function as its input (like a model).
-2. Equinox provides *filtered transformations*. These allow you to JIT/grad just some of the leaves of a PyTree -- not just a whole argument. This is provided by `equinox.jitf` and `equinox.gradf`.
-
-Point 1 allows you to represent models as PyTrees. (No separate passing around of parameters and forward passes.)<br>
-Point 2 is a more fine-grained way to JIT/grad PyTrees.<br>
-They are completely independent of each other -- but synergise very nicely.
-- If your model-as-a-PyTree only consists of things you want to JIT/differentiate, then just use `jax.jit` or `jax.grad` as normal. Equinox is JAX-friendly.
-- If you parameterise your model by something that isn't JIT/grad-able, then use `equinox.jitf` or `equinox.gradf`. For example you might want to store an arbitrary Python function as an activation function.
-
+## Quick start
 ### Installation
 
 ```
@@ -35,63 +17,125 @@ pip install equinox
 ```
 Requires Python 3.7+ and JAX 0.2.18+.
 
-### Quick example
+### Parameterised functions as data
+
+Equinox represents *parameterised functions as [PyTrees](https://jax.readthedocs.io/en/latest/pytrees.html)*. (For example a neural network is a function parameterised by its weights, biases, etc.) Now you can JIT/grad/etc. a higher-order function (like a loss function) with respect to a parameterised function as its input (like a model).
+
+Previous libraries have introduced a lot of extra complexity to make this work. e.g. custom notions of parameter groups, class-to-functional transformations, or specially-wrapped `library.jit` or `library.grad` to be compatible with JAX's JIT/grad/etc.
+
+In contrast, Equinox makes it elegant:
 
 ```python
 import equinox as eqx
-import functools as ft, jax, jax.numpy as jnp, jax.random as jrandom
+import jax
+import jax.nn as jnn
+import jax.numpy as jnp
+import jax.random as jrandom
 
-# Define our model. `Module` subclasses are both functions and data, so we can pass them into higher
-# order functions like vmap/jit/grad or a loss function.
-# There's no magic here. `Module` just registers your class as a PyTree node.
-class LinearOrIdentity(eqx.Module):
-    weight: jnp.ndarray
-    flag: bool
+class MyModule(eqx.Module):
+    # Specify the module's attributes;
+    layers: list
+    bias: jnp.ndarray
+    
+    # And how to initialise them;
+    def __init__(self, key):
+        key1, key2 = jrandom.split(key)
+        self.layers = [eqx.nn.Linear(2, 8, key=key1),
+                       eqx.nn.Linear(8, 2, key=key2)]
+        self.bias = jnp.ones(2)
 
-    def __init__(self, in_features, out_features, flag, key):
-        self.weight = jrandom.normal(key, (out_features, in_features))
-        self.flag = flag
-
+    # And the forward pass of the model.
     def __call__(self, x):
-        if self.flag:
-            return x
-        return self.weight @ x
+        for layer in self.layers[:-1]:
+            x = jnn.relu(layer(x))
+        return self.layers[-1](x) + self.bias
 
-# We use the fact that our model is data, by passing it in as an argument to the loss.
-# There's no magic here. `model` is a PyTree like any other; nothing about it being a `Module` is
-# special-cased.
-#
-# We use filtered transformations to unpack its data and select just the leaves we want to 
-# JIT+differentiate. (In this case, all JAX arrays -- so `weight` but not `flag`.)
-@ft.partial(eqx.jitf, filter_fn=eqx.is_array)
-@ft.partial(eqx.gradf, filter_fn=eqx.is_array)
+@jax.jit
+@jax.grad
 def loss(model, x, y):
     pred_y = jax.vmap(model)(x)
     return jnp.mean((y - pred_y) ** 2)
 
-modelkey, xkey, ykey = jrandom.split(jrandom.PRNGKey(0), 3)
-model = LinearOrIdentity(2, 3, flag=False, key=modelkey)
-x, y = jrandom.normal(xkey, (100, 2)), jrandom.normal(ykey, (100, 3))
+x_key, y_key, model_key = jrandom.split(jrandom.PRNGKey(0), 3)
+x, y = jrandom.normal(x_key, (100, 2)), jrandom.normal(y_key, (100, 2))
+model = MyModule(model_key)
 grads = loss(model, x, y)
 ```
 
+And there's no magic there! All `eqx.Module` really does is register your class with JAX as a PyTree node.<br>
+(In fact the source code for `eqx.Module` is only about 100 lines long.)
+
+### Filtering
+
+In the previous example, all of the model attributes were Modules and JAX arrays.
+
+Arbitrary Python objects are fine too! We just need to handle them appropriately around `jax.jit` and `jax.grad`.
+
+```python
+import equinox as eqx
+import functools as ft
+import jax
+import jax.nn as jnn
+import jax.numpy as jnp
+import jax.random as jrandom
+
+class AnotherModule(eqx.Module):
+    layers: list
+
+    def __init__(self, key):
+        key1, key2 = jrandom.split(key)
+        # Model now has `jnn.relu` -- a Python function -- as part of its PyTree.
+        self.layers = [eqx.nn.Linear(2, 8, key=key1),
+                       jnn.relu,
+                       eqx.nn.Linear(8, 2, key=key2)]
+
+    def __call__(self, x):
+        for layer in self.layers:
+            x = layer(x)
+        return x
+
+x_key, y_key, model_key = jrandom.split(jrandom.PRNGKey(0), 3)
+x, y = jrandom.normal(x_key, (100, 2)), jrandom.normal(y_key, (100, 2))
+model = AnotherModule(model_key)
+
+# Option 1: explicitly filter out anything that isn't JIT/grad-able.
+
+@ft.partial(jax.jit, static_argnums=1)
+@jax.grad
+def loss(params, static, x, y):
+    model = eqx.combine(params, static)
+    pred_y = jax.vmap(model)(x)
+    return jnp.mean((y - pred_y) ** 2)
+
+params, static = eqx.partition(model, eqx.is_array)
+loss(params, static, x, y)
+
+# Option 2: use filtered transformations, which automates the above process for you.
+# (Can be handy if you want to JIT/grad with respect to different things!)
+
+@ft.partial(eqx.filter_jit, filter_spec=eqx.is_array)
+@ft.partial(eqx.filter_grad, filter_spec=eqx.is_array)
+def loss(model, x, y):
+    pred_y = jax.vmap(model)(x)
+    return jnp.mean((y - pred_y) ** 2)
+
+loss(model, x, y)
+```
+
+Here, `params` and `static` are actually both instances of `AnotherModule`. `params` keeps just the attributes that are JAX arrays, and `static` keeps everything else. Then `combine` just merges the two PyTrees back together afterwards.
+
 ### Integrates smoothly with JAX
 
-There's nothing special about Equinox modules. They're just PyTrees.
-
-There's nothing special about filtered transformations. They just operate on PyTrees.
-
-Equinox is all just regular JAX -- PyTrees and transformations! Together, these two pieces allow us to specify complex models in JAX-friendly ways.
-
-In particular note that `equinox.jitf` and `equinox.gradf` are *not* "a way to make JIT/grad work with Modules" like many libraries have. They are general operations on PyTrees, and nothing about `Module` is special-cased. (And indeed `Module` itself is just a PyTree like any other.)
+And that's it! That's pretty much all of Equinox.<br>
+Equinox is all just regular JAX -- PyTrees and transformations. Together, these two pieces allow us to specify complex models in JAX-friendly ways.
 
 ## Examples
 
-- [`train_mlp.py`](./examples/train_mlp.py) gives a short example that introduces `equinox.jitf` and `equinox.gradf`. These will be used to select the parameters of an MLP and train them.
+- [`build_model.py`](./examples/build_model.py) builds an MLP from scratch, demonstrating the easy parameterised-functions-as-data approach that Equinox introduces. We'll then pass it into higher-order functions like JIT and grad. Overall we produce models using a familiar class-based syntax, that are also functional and integrate directly with JAX's JIT/autograd.
+
+- [`filtered_transformations.py`](./examples/filtered_transformations.py) introduces `equinox.filter_jit` and `equinox.filter_grad`. These will be used to select the parameters of an MLP and train them.
  
 - [`frozen_layer.py`](./examples/frozen_layer.py) demonstrates how this approach really shines: some of the parameters will be trained, some of them will be frozen, but *all* of them will be efficiently JIT-traced.
-
-- [`build_model.py`](./examples/build_model.py) demonstrates how to build parameterised-functions-as-data using `equinox.Module`. In particular we'll construct an MLP from scratch, and then pass it into higher-order functions like JIT and grad in order to train it. This allows us to produce models using a familiar class-based syntax, that are also functional and integrate directly with JAX's JIT/autograd.
 
 - [`train_rnn.py`](./examples/train_rnn.py) trains an RNN on a toy clockwise/anticlockwise spiral classification problem.
 
@@ -100,25 +144,26 @@ In particular note that `equinox.jitf` and `equinox.gradf` are *not* "a way to m
 ## API
 
 ### Full API list
-```python
-# Module                         # Utilities        
-equinox.Module                   equinox.apply_updates
-                                 equinox.tree_at      
-# Filtered transformations       equinox.tree_equal   
-equinox.jitf                     
-equinox.gradf                    # Neural networks
-equinox.value_and_grad_f         equinox.nn.Linear
-                                 equinox.nn.Identity
-# Filters                        equinox.nn.Dropout
-equinox.is_array                 equinox.nn.GRUCell
-equinox.is_array_like            equinox.nn.LSTMCell
-equinox.is_inexact_array         equinox.nn.Sequential
-equinox.is_inexact_array_like    equinox.nn.MLP
 
-# Splitting/merging
-equinox.split                    
-equinox.merge                    
-                                 
+```python
+# Module                         # Neural networks
+equinox.Module                   equinox.nn.Linear
+                                 equinox.nn.Identity
+# Filtering/combining            equinox.nn.Dropout
+equinox.filter                   equinox.nn.GRUCell
+equinox.partition                equinox.nn.LSTMCell
+equinox.combine                  equinox.nn.Sequential
+                                 equinox.nn.MLP
+# Filtered transformations       
+equinox.filter_jit               # Utilities
+equinox.filter_grad              equinox.apply_updates
+equinox.filter_value_and_grad    equinox.tree_at
+                                 equinox.tree_equal
+# Filters                        
+equinox.is_array                 
+equinox.is_array_like            
+equinox.is_inexact_array         
+equinox.is_inexact_array_like    
 ```
 
 ### Module
@@ -147,7 +192,7 @@ class AnotherModule(equinox.Module):
         self.weight = jax.random.normal(key, (output_size, input_size))
 ```
 
-After initialisation then attributes cannot be modified: models are immutable as per functional programming. (Parameter updates are made by creating a new model, not by mutating parameters in-place; see for example [`train_mlp.py`](./examples/train_mlp.py).)
+After initialisation then attributes cannot be modified: models are immutable as per functional programming. (Parameter updates are made by creating a new model, not by mutating parameters in-place; see for example [`train_rnn.py`](./examples/train_rnn.py).)
 
 It is typical to also create some methods on the class. As `self` will be an input parameter -- treated as a PyTree -- then these methods will get access to the attributes of the instance. Defining `__call__` gives an easy way to define a forward pass for a model (although any method can be used, and no methods are special-cased):
 
@@ -159,7 +204,7 @@ class LinearWithoutBias(equinox.Module):
         return self.weight @ x
 ```
 
-If defining a method `meth`, then take care not to write `instance = MyModule(...); jax.jit(instance.meth)(...)`. (Or similarly with `jax.grad`, `equinox.jitf` etc.) This is because `instance.meth` is not a pure function as it already has the `self` parameter passed implicitly. Instead do
+If defining a method `meth`, then take care not to write `instance = MyModule(...); jax.jit(instance.meth)(...)`. (Or similarly with `jax.grad`, `equinox.filter_jit` etc.) This is because `instance.meth` is not a pure function as it already has the `self` parameter passed implicitly. Instead do
 ```python
 @jax.jit
 def func(instance, args):
@@ -167,44 +212,77 @@ def func(instance, args):
     # Also use this pattern with instance(args) if you defined `__call__` instead of `meth`.
 ```
 
-### Filtered transformations
+### Filtering/combining
+
+Filtering can be used to organise the contents of PyTrees.
 
 ```python
-equinox.jitf(fun, *, filter_fn=None, filter_tree=None, **kwargs)
+equinox.filter(pytree, filter_spec, inverse=False, replace=None)
+```
+Filters out the leaves of a PyTree not satisfying a condition. Those not satisfying the condition are replaced with `replace`.
+
+- `pytree` is any PyTree
+- `filter_spec` is a PyTree whose structure should be a prefix of the structure of `pytree`. Each of its leaves should either be:
+  - `True`, in which case the leaf or subtree is kept;
+  - `False`, in which case the leaf or subtree is replaced with `replace`;
+  - a callable `Leaf -> bool`, in which case this is evaluted on the leaf or mapped over the subtree, and the leaf kept or replaced as appropriate.
+- `inverse` switches the truthy/falsey behaviour: falsey results are kept and truthy results are replaced.
+- `replace` is what to replace any falsey leaves with. Defaults to `None`.
+
+Returns a PyTree of the same structure as `pytree`.
+
+An important special case is something like `equinox.filter(pytree, equinox.is_array)`. Then `equinox.is_array` is evaluted on all of `pytree`'s leaves, and each leaf then kept or replaced.
+
+See also `equinox.combine` to reconstitute the PyTree again.
+
+```python
+equinox.partition(pytree, filter_spec, replace=None)
+```
+Equivalent to `filter(...), filter(..., inverse=True)`, but slightly more efficient.
+
+```python
+equinox.combine(*pytrees)
+```
+
+Every element of `pytrees` must be a PyTree of the same structure. The return value is also a PyTree of the same structure. Each leaf will be the first non-`None` leaf found in the corresponding leaves of `pytrees`, as they are iterated over. The intention is that this be used to undo a call to `equinox.filter` or `equinox.partition`.
+
+### Filtered transformations
+
+It's very common to need to filter just to handle JAX transformations. Equinox provides the following convenience wrappers.<br>
+They're not designed to handle every edge case -- they're just a way to streamline the common cases. Use separate `equinox.filter`+`jax.jit` etc. if you need finer control.
+
+```python
+equinox.filter_jit(fun, *, filter_spec, **kwargs)
 ```
 Wraps `jax.jit`.
 
 - `fun` is a pure function to JIT compile.
-- `filter_fn` is a callable `Any -> bool`. It will be called on every leaf of every PyTree that is inputted to `fun`. If it returns `True`, the leaf will be traced. It returns `False`, the leaf with be treated as static. Mutually exclusive with `filter_tree`.
-- `filter_tree` is a tree, or tuple of trees, of the same length as the number of inputs. (Or if `static_argnums` is passed, the number of inputs not already marked static via `static_argnums`.) It must have the exact same tree structure as the inputs. Every leaf must be either `True` or `False`. Each leaf of `filter_tree` is matched up against the corresponding input: if it is `True` the leaf will be traced; it it is `False` the leaf will be treated as static. Mutually exclusive with `filter_tree`.
-- `**kwargs` are the usual other arguments to `jax.jit`, like `static_argnums`. In particular, a leaf will be marked static if either (a) it is filtered as being so, *or* (b) it is part of a PyTree that is marked through `static_argnums`.
+- `filter_spec` is a PyTree whose structure should be a prefix of the structure of the inputs to `fun`. Each of its leaves should either be `True`, `False`, or a callable `Leaf -> bool`. It behaves exactly as the `filter_spec` argument to `equinox.filter`. Truthy values will be traced; falsey values will be held static. Specifically, if calling `fun(*args, **kwargs)`, then `filter_spec` must have a structure which is a prefix for `(args, kwargs)`.
+- `**kwargs` are any other arguments to `jax.jit`.
 
-Precisely one of `filter_fn` or `filter_tree` must be passed.<br>
-See also `equinox.is_array`, which is usually a good choice of `filter_fn`. This will trace every JAX array, and make the rest static.<br>
-See also `equinox.tree_at` for an easy way to create the `filter_tree` argument.
+An important special case is to pass a function as `filter_spec`, which will be applied to every leaf of every input. For example, `equinox.filter_jit(fun, equinox.is_array)`.
+
+See also `equinox.is_array`, which is usually a good choice of `filter_spec`. This will trace every JAX array, and make every other argument static.
 
 ```python
-equinox.gradf(fun, *, filter_fn=None, filter_tree=None, **kwargs)
+equinox.filter_grad(fun, *, filter_spec, **kwargs)
 ```
 Wraps `jax.grad`.
 
-- `fun` is a pure function to JIT compile.
-- `filter_fn` is a callable `Any -> bool`. It will be called on every leaf of every PyTree that is marked as potentially requiring gradient via `argnums`. If it returns `True`, the leaf will be differentiated. If it returns `False`, the leaf will not be differentiated. Mutually exclusive with `filter_tree`.
-- `filter_tree` is a tree, or tuple of trees, of the same length as the number of inputs marked as potentially requiring gradient via `argnums`. It must have the exact same tree structure as the inputs. Every leaf must be either `True` or `False`. Each leaf of `filter_tree` is matched up against the corresponding input: if it is `True` the leaf will be differentiated; if it is `False` the leaf will not be differentiated. Mutually exclusive with `filter_fn`.
-- `**kwargs` are the usual other argments to `jax.grad`, like `argnums`. In particular, a leaf will only be differentiated if (a) it is filtered as being so, *and* (b) it is part of a PyTree that is marked through `argnums`.
+- `fun` is a pure function to differentiate.
+- `filter_spec` is a PyTree whose structure should be a prefix of the structure of the **first** input to `fun`. Each of its leaves should either be `True`, `False`, or a callable `Leaf -> bool`. It behaves exactly as the `filter_spec` argument to `equinox.filter`. Truthy values will be differentiated; falsey values will not. Specifically, if calling `fun(x, *args, **kwargs)`, then `filter_spec` must have a structure which is a prefix for the structure of `x`.
+- `**kwargs` are any other arguments to `jax.grad`.
 
-Precisely one of `filter_fn` or `filter_tree` must be passed.<br>
-See also `equinox.is_inexact_array`, which is usually a good choice of `filter_fn`. This will differentiate all floating-point JAX arrays.<br>
-See also `equinox.tree_at` for an easy way to create the `filter_tree` argument.
+An important special case is to pass a function as `filter_spec`, which will be applied to every leaf of the first input. For example, `equinox.filter_grad(fun, equinox.is_inexact_array)`.<br>
 
-Note that as the returned gradients must have the same structure as the inputs, then all nondifferentiable components of the input PyTrees will have gradient `None`. 
-Doing a simple `jax.tree_map(lambda m, g: m - lr * g, model, grad)` will fail. 
-As such Equinox provides `equinox.apply_updates` as a simple convenience: it will only apply the update if the gradient is not `None`. See below.
+See also `equinox.is_inexact_array`, which is usually a good choice of `filter_spec`. This will differentiate all floating-point JAX arrays.
+
+Note that as the returned gradients must have the same structure as the inputs, then all nondifferentiable components of the input PyTree will have gradient `None`. See `equinox.apply_updates` for a convenience to only apply non-`None` updates.
 
 ```python
-equinox.value_and_grad_f(fun, *, filter_fn=None, filter_tree=None, **kwargs)
+equinox.filter_value_and_grad(fun, *, filter_spec, **kwargs)
 ```
-Wraps `jax.value_and_grad`. Arguments are as `equinox.gradf`.
+Wraps `jax.value_and_grad`. Arguments are as `equinox.filter_grad`.
 
 ### Filters
 
@@ -230,37 +308,6 @@ equinox.is_inexact_array_like(element)
 ```
 Returns `True` if `element` is a floating point JAX array, floating point NumPy array, or a Python float or complex.
 
-### Splitting/merging
-
-Filters can also be used to organise the contents of PyTrees, if needed.
-
-```python
-equinox.split(pytree, filter_fn=None, filter_tree=None)
-```
-Partitions the leaves of a PyTree into two groups.
-
-- `pytree` is any PyTree
-- `filter_fn` is any function `Leaf -> bool` to call on each of its leaves.
-- `filter_tree` is a PyTree with the same structure as `pytree`, with every leaf either `True` or `False`.
-
-Precisely one of `filter_fn` or `filter_tree` may be passed.
-
-Returns a 4-tuple of `(flat_true, flat_false, which, treedef)`.
-
-- `flat_true` will be a list of leaves for which `filter_fn`/`filter_tree` was `True`.
-- `flat_false` will be a list of leaves for which `filter_fn`/`filter_tree` was `False`.
-- `which` and `treedef` specify the input PyTree. `treedef` is a `PyTreeDef` (like `jax.tree_flatten` returns). `which` is a list of `True`/`False` specifying which leaves were truthy or falsey.
-
-See also `equinox.merge` to reconstitute the PyTree again.
-
-This function is useful when working with JAX libraries that only support PyTrees of trainable parameters, and not more general PyTrees: the model can be split into its trainable and nontrainable components and passed into the library that way. See the example [`modules_to_initapply.py`](./examples/modules_to_initapply.py).
-
-```python
-equinox.merge(flat_true, flat_false, which, treedef)
-```
-
-The inverse of `equinox.split`.
-
 ### Utilities
 
 ```python
@@ -270,9 +317,9 @@ Performs a training update to a model.
 - `model` must be a PyTree;
 - `updates` must be a PyTree with the same structure.
 
-It essentially performs `jax.tree_map(lambda m, u: m + u, model, updates)`. However anywhere `updates` is `None` then no update is made at all, so as to handle nondifferentiable parts of `model`.
+It essentially performs `jax.tree_map(lambda m, u: m + u, model, updates)` (or `optax.apply_upates(model, updates)`). However anywhere `updates` is `None` then no update is made at all, so as to handle nondifferentiable parts of `model`.
 
-The returned value is the updated model. (`model` is *not* mutated in place, as is usual in JAX and functional programming.)
+The returned value is the updated model. (`model` is not mutated in place, as is usual in JAX and functional programming.)
 
 To produce `updates`, it is typical to take the gradients from the loss function, and then adjust them according to any standard optimiser; for example [Optax](https://github.com/deepmind/optax) provides `optax.sgd` or `optax.adam`.
 
@@ -286,11 +333,11 @@ Modifies an existing tree, and returns the modified tree. (Like `.at` for "in pl
 - `replace` should either be a single element, or a tuple of the same length as returned by `where`. This specifies the replacements to make at the locations specified by `where`. Mutually exclusive with `replace_fn`.
 - `replace_fn` should be a function `Leaf -> Any`. It will be called on every leaf replaced using `where`. The return value from `replace_fn` will be used in its place. Mutually exclusive with `replace`.
 
-For example this can be used to specify the weights of a model to train or not train:
+For example this can be used to help specify the weights of a model to train or not train:
 ```python
 trainable = jax.tree_map(lambda _: False, model)
 trainable = equinox.tree_at(lambda mlp: mlp.layers[-1].linear.weight, model, replace=True)
-equinox.gradf(..., filter_tree=trainable)
+equinox.filter_grad(..., filter_spec=trainable)
 ```
 
 ```python
@@ -300,7 +347,7 @@ Returns `True` if all PyTrees in the list are equal. All arrays must have the sa
 
 ### Neural network library
 
-Equinox includes a small neural network library, mostly as a tech demo for how the rest of the library can be used. Its API is modelled after PyTorch.
+Equinox includes a small neural network library, mostly as a tech demo for how the rest of the library can be used. Its API is broadly modelled after PyTorch.
 
 ```python
 equinox.nn.Linear(in_features, out_features, use_bias=True, *, key)(input)

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ model = MyModule(model_key)
 grads = loss(model, x, y)
 ```
 
-And there's no magic there! All `eqx.Module` really does is register your class with JAX as a PyTree node.<br>
+    And there's no magic there! All `eqx.Module` really does is register your class with JAX as a PyTree node.<br>
 (In fact the source code for `eqx.Module` is only about 100 lines long.)
 
 ### Filtering
@@ -126,7 +126,10 @@ Here, `params` and `static` are actually both instances of `AnotherModule`. `par
 
 ### Integrates smoothly with JAX
 
-And that's it! That's pretty much all of Equinox.<br>
+And that's it! That's pretty much all of Equinox.
+
+Equinox introduces a powerful yet straightforward way to build neural networks, without introducing lots of new notions or tieing you into a framework.
+
 Equinox is all just regular JAX -- PyTrees and transformations. Together, these two pieces allow us to specify complex models in JAX-friendly ways.
 
 ## Examples

--- a/equinox/__init__.py
+++ b/equinox/__init__.py
@@ -1,17 +1,20 @@
 from . import nn
 from .filters import (
+    combine,
+    filter,
     is_array,
     is_array_like,
     is_inexact_array,
     is_inexact_array_like,
     merge,
+    partition,
     split,
 )
-from .gradf import gradf, value_and_grad_f
-from .jitf import jitf
+from .gradf import filter_grad, filter_value_and_grad, gradf, value_and_grad_f
+from .jitf import filter_jit, jitf
 from .module import Module
 from .tree import tree_at, tree_equal
 from .update import apply_updates
 
 
-__version__ = "0.0.3"
+__version__ = "0.1.0"

--- a/equinox/deprecated.py
+++ b/equinox/deprecated.py
@@ -1,0 +1,16 @@
+import functools as ft
+import warnings
+
+
+def deprecated(*, in_favour_of):
+    def decorator(fn):
+        msg = f"{fn.__name__} is deprecated in favour of {in_favour_of.__name__}"
+
+        @ft.wraps(fn)
+        def wrapper(*args, **kwargs):
+            warnings.warn(msg)
+            return fn(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/equinox/filters.py
+++ b/equinox/filters.py
@@ -72,21 +72,19 @@ def partition(pytree: PyTree, filter_spec: PyTree, replace: Any = None) -> PyTre
     return left, right
 
 
-_sentinel = object()
-
-
 def _combine(*args):
     for arg in args:
-        if arg is not _sentinel:
+        if arg is not None:
             return arg
     return None
 
 
+def _is_none(x):
+    return x is None
+
+
 def combine(*pytrees: PyTree):
-    pytrees = [
-        jax._src.tree_util._replace_nones(_sentinel, pytree) for pytree in pytrees
-    ]
-    return jax.tree_map(_combine, *pytrees)
+    return jax.tree_map(_combine, *pytrees, is_leaf=_is_none)
 
 
 #

--- a/equinox/module.py
+++ b/equinox/module.py
@@ -1,4 +1,5 @@
 import abc
+import functools as ft
 from dataclasses import dataclass, fields
 
 import jax
@@ -12,14 +13,24 @@ def _dataclass_astuple(cls):
     return tuple(getattr(cls, field.name) for field in fields(cls) if field.init)
 
 
-def _allow_setattr(fields):
+@ft.lru_cache(maxsize=128)
+def _make_initable(cls):
+    field_names = {field.name for field in fields(cls)}
+
+    class _InitableModule(cls):
+        pass
+
+    # Done like this to avoid dataclasses complaining about overriding setattr on a
+    # frozen class.
     def __setattr__(self, name, value):
-        if name in fields:
+        if name in field_names:
             object.__setattr__(self, name, value)
         else:
             raise AttributeError(f"Cannot set attribute {name}")
 
-    return __setattr__
+    _InitableModule.__setattr__ = __setattr__
+
+    return _InitableModule, field_names
 
 
 # Inherits from abc.ABCMeta as a convenience for a common use-case.
@@ -38,9 +49,7 @@ class _ModuleMeta(abc.ABCMeta):
         cls = dataclass(eq=False, frozen=True)(cls)
 
         assert "__dataclass_init__" not in cls.__dict__
-        assert "__dataclass_setattr__" not in cls.__dict__
         cls.__dataclass_init__ = cls.__init__
-        cls.__dataclass_setattr__ = cls.__setattr__
         if not reinstate_init:
             # Override the default dataclass init if our parent has an init
             for kls in cls.__mro__[1:-1]:
@@ -54,24 +63,18 @@ class _ModuleMeta(abc.ABCMeta):
         if reinstate_init:
             cls.__init__ = user_provided_init
 
-        def flatten(self):
-            return _dataclass_astuple(self), None
-
-        def unflatten(_, fields):
-            self = cls.__new__(cls, *fields)
-            cls.__dataclass_init__(self, *fields)
-            return self
-
-        jax.tree_util.register_pytree_node(cls, flatten, unflatten)
+        jax.tree_util.register_pytree_node_class(cls)
         return cls
 
     def __call__(cls, *args, **kwargs):
         self = cls.__new__(cls, *args, **kwargs)
-        # Defreeze it during __init__. TODO: this isn't thread/recursion-safe.
-        field_names = {field.name for field in fields(cls)}
-        cls.__setattr__ = _allow_setattr(field_names)
+
+        # Defreeze it during __init__
+        initable_cls, field_names = _make_initable(cls)
+        object.__setattr__(self, "__class__", initable_cls)
         cls.__init__(self, *args, **kwargs)
-        cls.__setattr__ = cls.__dataclass_setattr__
+        object.__setattr__(self, "__class__", cls)
+
         missing_names = {name for name in field_names if name not in dir(self)}
         if len(missing_names):
             raise ValueError(
@@ -81,5 +84,17 @@ class _ModuleMeta(abc.ABCMeta):
 
 
 class Module(metaclass=_ModuleMeta):
+    def __hash__(self):
+        return hash(tuple(jax.tree_leaves(self)))
+
     def __eq__(self, other):
         return tree_equal(self, other)
+
+    def tree_flatten(self):
+        return _dataclass_astuple(self), None
+
+    @classmethod
+    def tree_unflatten(cls, _, fields):
+        self = cls.__new__(cls, *fields)
+        cls.__dataclass_init__(self, *fields)
+        return self

--- a/equinox/update.py
+++ b/equinox/update.py
@@ -3,17 +3,17 @@ import jax
 from .custom_types import PyTree
 
 
-_sentinel = object()
-
-
 def _apply_update(u, p):
-    if u is _sentinel:
+    if u is None:
         return p
     else:
         return p + u
 
 
+def _is_none(x):
+    return x is None
+
+
 def apply_updates(model: PyTree, updates: PyTree) -> PyTree:
     # Assumes that updates is a prefix of model
-    updates = jax._src.tree_util._replace_nones(_sentinel, updates)
-    return jax.tree_map(_apply_update, updates, model)
+    return jax.tree_map(_apply_update, updates, model, is_leaf=_is_none)

--- a/equinox/update.py
+++ b/equinox/update.py
@@ -3,12 +3,17 @@ import jax
 from .custom_types import PyTree
 
 
-def _apply_update(p, u):
-    if u is None:
+_sentinel = object()
+
+
+def _apply_update(u, p):
+    if u is _sentinel:
         return p
     else:
         return p + u
 
 
 def apply_updates(model: PyTree, updates: PyTree) -> PyTree:
-    return jax.tree_map(_apply_update, model, updates)
+    # Assumes that updates is a prefix of model
+    updates = jax._src.tree_util._replace_nones(_sentinel, updates)
+    return jax.tree_map(_apply_update, updates, model)

--- a/examples/train_rnn.py
+++ b/examples/train_rnn.py
@@ -1,10 +1,6 @@
 ##############
 #
-# This example has a similar structure to `train_mlp.py`, except that we now train
-# an RNN.
-#
-# In particular this demonstrates the use of Modules alongside jax.lax.scan. (They just
-# work, no tricks required.)
+# This example trains an RNN to classify clockwise versus anticlockwise spirals.
 #
 #############
 
@@ -18,7 +14,7 @@ import jax.random as jrandom
 import optax
 
 # Borrow dataloader from other example
-from train_mlp import dataloader
+from filtered_transformations import dataloader
 
 import equinox as eqx
 
@@ -65,7 +61,7 @@ def main(
     dataset_size=10000,
     batch_size=32,
     learning_rate=3e-3,
-    steps=500,
+    steps=200,
     hidden_size=16,
     depth=1,
     seed=5678,
@@ -76,8 +72,8 @@ def main(
 
     model = RNN(in_size=2, out_size=1, hidden_size=hidden_size, key=model_key)
 
-    @ft.partial(eqx.jitf, filter_fn=eqx.is_inexact_array)
-    @ft.partial(eqx.value_and_grad_f, filter_fn=eqx.is_inexact_array)
+    @ft.partial(eqx.filter_jit, filter_spec=eqx.is_array)
+    @ft.partial(eqx.filter_value_and_grad, filter_spec=eqx.is_inexact_array)
     def loss(model, x, y):
         pred_y = jax.vmap(model)(x)
         # Trains with respect to binary cross-entropy

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -8,8 +8,10 @@ _here = pathlib.Path(__file__).resolve().parent
 sys.path.append(str(_here / ".." / "examples"))
 
 import build_model
+import filtered_transformations
 import frozen_layer
-import train_mlp
+import modules_to_initapply
+import train_rnn
 
 
 def test_build_model():
@@ -24,6 +26,37 @@ def test_frozen_layer():
     assert jnp.any(original_model.layers[-1].weight != model.layers[-1].weight)
 
 
-def test_train_mlp():
-    loss = train_mlp.main()
-    assert loss < 5
+def test_filtered_transformations():
+    loss = filtered_transformations.main()
+    assert loss < 0.1
+
+
+def test_train_rnn():
+    loss = train_rnn.main()
+    assert loss < 0.01
+
+
+def test_modules_to_initapply():
+    modules_to_initapply.main()
+
+
+def test_readme():
+    with open(_here / ".." / "README.md") as f:
+        program = []
+        maybe_program = False
+        start_program = False
+        for line in f.readlines():
+            if "```python" in line:
+                maybe_program = True
+            elif maybe_program:
+                maybe_program = False
+                if "import equinox as eqx" in line:
+                    program.append(line)
+                    start_program = True
+            elif start_program:
+                if "```" in line:
+                    exec("\n".join(program), dict())
+                    program = []
+                    start_program = False
+                else:
+                    program.append(line)

--- a/tests/test_filter_grad.py
+++ b/tests/test_filter_grad.py
@@ -1,0 +1,121 @@
+import functools as ft
+
+import jax
+import jax.numpy as jnp
+import jax.random as jrandom
+import numpy as np
+import pytest
+
+import equinox as eqx
+
+
+def test_filter_grad1(getkey):
+    a = jrandom.normal(getkey(), (2, 3))
+
+    @ft.partial(eqx.filter_grad, filter_spec=lambda _: True)
+    def f(x):
+        return jnp.sum(x)
+
+    grad_f = f(a)
+    assert jnp.all(grad_f == 1)
+
+
+def test_filter_grad2(getkey):
+    a = jrandom.normal(getkey(), (2, 3))
+    b = jrandom.normal(getkey(), (2, 3))
+
+    @ft.partial(eqx.filter_grad, filter_spec=eqx.is_inexact_array)
+    def f(x):
+        sum = 0.0
+        for arg in jax.tree_leaves(x):
+            if eqx.is_array_like(arg):
+                sum = sum + jnp.sum(arg)
+        return sum
+
+    ga, gb = f([a, b])
+    assert jnp.all(ga == 1)
+    assert jnp.all(gb == 1)
+
+    gtrue, ghi, gobject, ga = f([True, "hi", object(), a])
+    assert gtrue is None
+    assert ghi is None
+    assert gobject is None
+    assert jnp.all(ga == 1)
+
+    gtrue, gdict, (g5, g1), gnp = f(
+        [
+            True,
+            {"hi": eqx.nn.Linear(1, 1, key=getkey())},
+            (5, 1.0),
+            np.array([2.0, 3.0]),
+        ]
+    )
+    assert gtrue is None
+    assert list(gdict.keys()) == ["hi"]
+    assert isinstance(gdict["hi"], eqx.nn.Linear)
+    assert jnp.all(gdict["hi"].weight == 1)
+    assert jnp.all(gdict["hi"].bias == 1)
+    assert g5 is None
+    assert g1 is None
+    assert gnp is None
+
+
+def test_filter_grad3(getkey):
+    a = jrandom.normal(getkey(), (2, 3))
+    b = jrandom.normal(getkey(), (1, 2))
+    c = jrandom.normal(getkey(), ())
+
+    @ft.partial(eqx.filter_grad, filter_spec=[True, False])
+    def f(x):
+        return jnp.sum(x[0]) + jnp.sum(x[1])
+
+    ga, gb = f([a, b])
+    assert jnp.all(ga == 1)
+    assert gb is None
+
+    @ft.partial(eqx.filter_grad, filter_spec={"a": True, "b": False})
+    def h(x, y):
+        return jnp.sum(x["a"]) * jnp.sum(x["b"]) * y
+
+    grad = h({"a": a, "b": b}, c)
+    assert jnp.allclose(grad["a"], jnp.sum(b) * c)
+    assert grad["b"] is None
+
+    with pytest.raises(ValueError):
+        grad = h(c, {"a": a, "b": b})
+
+
+# TODO: more comprehensive tests on this.
+def test_filter_value_and_grad_(getkey):
+    a = jrandom.normal(getkey(), (2, 3))
+
+    @ft.partial(eqx.filter_value_and_grad, filter_spec=eqx.is_inexact_array)
+    def f(x):
+        return jnp.sum(x)
+
+    val, grad = f(a)
+    assert val == jnp.sum(a)
+    assert jnp.all(grad == 1)
+
+
+def test_aux(getkey):
+    a = jrandom.normal(getkey(), (2, 3))
+
+    @ft.partial(eqx.filter_grad, has_aux=True, filter_spec=eqx.is_inexact_array)
+    def f(x):
+        return jnp.sum(x), "hi"
+
+    aux, grad = f(a)
+    assert aux == "hi"
+    assert jnp.all(grad == 1)
+
+    @ft.partial(
+        eqx.filter_value_and_grad, has_aux=True, filter_spec=eqx.is_inexact_array
+    )
+    def f(x):
+        return jnp.sum(x), "hi"
+
+    (value, aux), grad = f(a)
+    assert value == jnp.sum(a)
+    assert aux == "hi"
+    assert jnp.all(grad == 1)

--- a/tests/test_filter_jit.py
+++ b/tests/test_filter_jit.py
@@ -1,0 +1,175 @@
+import functools as ft
+
+import jax
+import jax.numpy as jnp
+import jax.random as jrandom
+import pytest
+
+import equinox as eqx
+
+
+def _eq(a, b):
+    return (type(a) is type(b)) and (a == b)
+
+
+def test_filter_jit1(getkey):
+    a = jrandom.normal(getkey(), (2, 3))
+    b = jrandom.normal(getkey(), (3,))
+    c = jrandom.normal(getkey(), (1, 4))
+    general_tree = [
+        1,
+        True,
+        object(),
+        {"a": a, "tuple": (2.0, b)},
+        c,
+        eqx.nn.MLP(2, 2, 2, 2, key=getkey()),
+    ]
+    array_tree = [{"a": a, "b": b}, (c,)]
+    _mlp = jax.tree_map(lambda u: u if eqx.is_array_like(u) else None, general_tree[-1])
+
+    @ft.partial(eqx.filter_jit, filter_spec=lambda _: True)
+    def f(x):
+        return x
+
+    assert jnp.all(a == f(a))
+    f1 = f(array_tree)
+    assert jnp.all(f1[0]["a"] == a)
+    assert jnp.all(f1[0]["b"] == b)
+    assert jnp.all(f1[1][0] == c)
+
+    with pytest.raises(TypeError):
+        f(general_tree)
+
+    @ft.partial(eqx.filter_jit, filter_spec=eqx.is_inexact_array)
+    def g(x):
+        return jax.tree_map(lambda u: u if eqx.is_array_like(u) else None, x)
+
+    assert jnp.all(a == g(a))
+    g1 = g(array_tree)
+    assert jnp.all(g1[0]["a"] == a)
+    assert jnp.all(g1[0]["b"] == b)
+    assert jnp.all(g1[1][0] == c)
+    g2 = g(general_tree)
+    assert _eq(g2[0], jnp.array(1))
+    assert _eq(g2[1], jnp.array(True))
+    assert _eq(g2[2], None)
+    assert jnp.all(g2[3]["a"] == a)
+    assert _eq(g2[3]["tuple"][0], jnp.array(2.0))
+    assert jnp.all(g2[3]["tuple"][1] == b)
+    assert jnp.all(g2[4] == c)
+    assert _eq(g2[5], _mlp)
+
+    @ft.partial(eqx.filter_jit, filter_spec=eqx.is_array_like)
+    def h(x):
+        return jax.tree_map(lambda u: u if eqx.is_array_like(u) else None, x)
+
+    assert jnp.all(a == h(a))
+    h1 = h(array_tree)
+    assert jnp.all(h1[0]["a"] == a)
+    assert jnp.all(h1[0]["b"] == b)
+    assert jnp.all(h1[1][0] == c)
+    h2 = h(general_tree)
+    assert _eq(h2[0], jnp.array(1))
+    assert _eq(h2[1], jnp.array(True))
+    assert _eq(h2[2], None)
+    assert jnp.all(h2[3]["a"] == a)
+    assert _eq(g2[3]["tuple"][0], jnp.array(2.0))
+    assert jnp.all(g2[3]["tuple"][1] == b)
+    assert jnp.all(g2[4] == c)
+    assert _eq(g2[5], _mlp)
+
+
+def test_filter_jit2(getkey):
+    a = jrandom.normal(getkey(), (2, 3))
+    b = jrandom.normal(getkey(), (3,))
+    c = jrandom.normal(getkey(), (1, 4))
+    general_tree = [
+        1,
+        True,
+        object(),
+        {"a": a, "tuple": (2.0, b)},
+        c,
+        eqx.nn.MLP(2, 2, 2, 2, key=getkey()),
+    ]
+    _mlp = jax.tree_map(lambda u: u if eqx.is_array_like(u) else None, general_tree[-1])
+    _filter_mlp = jax.tree_map(eqx.is_inexact_array, general_tree[-1])
+
+    @ft.partial(
+        eqx.filter_jit,
+        filter_spec=(
+            (
+                [
+                    True,
+                    True,
+                    False,
+                    {"a": True, "tuple": (False, True)},
+                    True,
+                    _filter_mlp,
+                ],
+            ),
+            {},
+        ),
+    )
+    def f(x):
+        return jax.tree_map(lambda u: u if eqx.is_array_like(u) else None, x)
+
+    f1 = f(general_tree)
+    assert _eq(f1[0], jnp.array(1))
+    assert _eq(f1[1], jnp.array(True))
+    assert _eq(f1[2], None)
+    assert jnp.all(f1[3]["a"] == a)
+    assert _eq(f1[3]["tuple"][0], jnp.array(2.0))
+    assert jnp.all(f1[3]["tuple"][1] == b)
+    assert jnp.all(f1[4] == c)
+    assert _eq(f1[5], _mlp)
+
+
+def test_num_traces():
+    num_traces = 0
+
+    @ft.partial(eqx.filter_jit, filter_spec=lambda _: True)
+    def f(x):
+        nonlocal num_traces
+        num_traces += 1
+
+    f(jnp.zeros(2))
+    f(jnp.zeros(2))
+    assert num_traces == 1
+
+    f(jnp.zeros(3))
+    f(jnp.zeros(3))
+    assert num_traces == 2
+
+    f([jnp.zeros(2)])
+    f([jnp.zeros(2), jnp.zeros(3)])
+    f([jnp.zeros(2), True])
+    assert num_traces == 5
+
+    num_traces = 0
+
+    @ft.partial(eqx.filter_jit, filter_spec=([eqx.is_array_like, False], {}))
+    def g(x, y):
+        nonlocal num_traces
+        num_traces += 1
+
+    g(jnp.zeros(2), True)
+    g(jnp.zeros(2), False)
+    assert num_traces == 2
+
+    num_traces = 0
+
+    @ft.partial(
+        eqx.filter_jit, filter_spec=([False, {"a": True, "b": False}, False, False], {})
+    )
+    def h(x, y, z, w):
+        nonlocal num_traces
+        num_traces += 1
+
+    h(True, {"a": 1, "b": 1}, True, True)
+    h(False, {"a": 1, "b": 1}, True, True)
+    h(True, {"a": 1, "b": 0}, True, True)
+    h(True, {"a": 1, "b": 1}, True, 2)
+    h(True, {"a": 1, "b": 1}, 5, True)
+    assert num_traces == 5
+    h(True, {"a": 2, "b": 1}, True, True)
+    assert num_traces == 5

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -113,7 +113,8 @@ def test_inheritance():
         m = MyModule5(value4=1, weight5=2)
 
     class MyModule6(MyModule4):
-        pass
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
 
     m = MyModule6(value4=1)
     assert m.weight4 == 1


### PR DESCRIPTION
- Added `filter`, `partition`, and `combine` as easier-to-use replacements for `split` and `merge`.
  - Correspondingly these can also be used alongside `jax.jit` and `jax.grad`, largely obviating the need for `equinox.jitf` and `equinox.gradf`.
- Added `filtered_jit`, `filtered_grad`, `filtered_value_and_grad` as much-simpler replacements for `jitf`, `gradf`.
- Improved internals of `Module`:
  - Now handles recursions/multithreading properly;
  - Modules are hashable if all their leaves are;
  - Flatten/unflatten can be overridden in subclasses if desired.
  - Handles edge cases wrt properties shadowing fields, and init=False fields
- Updated README substantially -- hopefully much improved.
- Now explicitly testing the examples in the README.