### PR TITLE
Version 0.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,15 +328,15 @@ To produce `updates`, it is typical to take the gradients from the loss function
 ```python
 equinox.static_field(**kwargs)
 ```
-This is a relatively advanced feature. Use it to mark one of the fields of a `Module` as being "static": that is, never differentiated, and always a `static_argnum` to JIT. Best used only if you control whatever will be assigned to that field. For example `equinox.nn.MLP` does *not* use this for its activation function, as in principle a learnt activation functino could be passed.
+This is a relatively advanced feature. Use it to mark one of the fields of a `Module` as being "static": that is, never differentiated, and always a `static_argnum` to JIT. Best used only if you control whatever will be assigned to that field. For example `equinox.nn.MLP` does *not* use this for its activation function, as in principle a learnt activation function could be passed.
 
 Example:
 ```python
 class MyModule(equinox.Module):
-    value: equinox.static_field()
+    value: list = equinox.static_field()
 ```
 
-If any `**kwargs` are passed, then they will be forwarded on to `dataclasses.field`.
+If any `**kwargs` are passed, then they will be forwarded on to `dataclasses.field`. (Recall that Equinox uses dataclasses as its modules, so general `dataclasses` behaviour should work as normal.)
 
 ```python
 equinox.tree_at(where, pytree, replace=_sentinel, replace_fn=_sentinel)

--- a/README.md
+++ b/README.md
@@ -112,8 +112,8 @@ loss(params, static, x, y)
 # Option 2: use filtered transformations, which automates the above process for you.
 # (Can be handy if you want to JIT/grad with respect to different things!)
 
-@ft.partial(eqx.filter_jit, filter_spec=eqx.is_array)
-@ft.partial(eqx.filter_grad, filter_spec=eqx.is_array)
+@eqx.filter_jit
+@eqx.filter_grad
 def loss(model, x, y):
     pred_y = jax.vmap(model)(x)
     return jnp.mean((y - pred_y) ** 2)
@@ -159,9 +159,9 @@ equinox.combine                  equinox.nn.Sequential
 # Filtered transformations       
 equinox.filter_jit               # Utilities
 equinox.filter_grad              equinox.apply_updates
-equinox.filter_value_and_grad    equinox.tree_at
-                                 equinox.tree_equal
-# Filters                        
+equinox.filter_value_and_grad    equinox.static_field
+                                 equinox.tree_at
+# Filters                        equinox.tree_equal
 equinox.is_array                 
 equinox.is_array_like            
 equinox.is_inexact_array         
@@ -254,7 +254,7 @@ It's very common to need to filter just to handle JAX transformations. Equinox p
 They're not designed to handle every edge case -- they're just a way to streamline the common cases. Use separate `equinox.filter`+`jax.jit` etc. if you need finer control.
 
 ```python
-equinox.filter_jit(fun, *, filter_spec, **kwargs)
+equinox.filter_jit(fun, *, filter_spec=is_array, **kwargs)
 ```
 Wraps `jax.jit`.
 
@@ -264,10 +264,10 @@ Wraps `jax.jit`.
 
 An important special case is to pass a function as `filter_spec`, which will be applied to every leaf of every input. For example, `equinox.filter_jit(fun, equinox.is_array)`.
 
-See also `equinox.is_array`, which is usually a good choice of `filter_spec`. This will trace every JAX array, and make every other argument static.
+See also `equinox.is_array`, which is the default choice of `filter_spec`. This will trace every JAX array, and make every other argument static.
 
 ```python
-equinox.filter_grad(fun, *, filter_spec, **kwargs)
+equinox.filter_grad(fun, *, filter_spec=is_inexact_array, **kwargs)
 ```
 Wraps `jax.grad`.
 
@@ -277,12 +277,12 @@ Wraps `jax.grad`.
 
 An important special case is to pass a function as `filter_spec`, which will be applied to every leaf of the first input. For example, `equinox.filter_grad(fun, equinox.is_inexact_array)`.<br>
 
-See also `equinox.is_inexact_array`, which is usually a good choice of `filter_spec`. This will differentiate all floating-point JAX arrays.
+See also `equinox.is_inexact_array`, which is the default choice of `filter_spec`. This will differentiate all floating-point JAX arrays.
 
 Note that as the returned gradients must have the same structure as the inputs, then all nondifferentiable components of the input PyTree will have gradient `None`. See `equinox.apply_updates` for a convenience to only apply non-`None` updates.
 
 ```python
-equinox.filter_value_and_grad(fun, *, filter_spec, **kwargs)
+equinox.filter_value_and_grad(fun, *, filter_spec=is_inexact_array, **kwargs)
 ```
 Wraps `jax.value_and_grad`. Arguments are as `equinox.filter_grad`.
 
@@ -326,6 +326,19 @@ The returned value is the updated model. (`model` is not mutated in place, as is
 To produce `updates`, it is typical to take the gradients from the loss function, and then adjust them according to any standard optimiser; for example [Optax](https://github.com/deepmind/optax) provides `optax.sgd` or `optax.adam`.
 
 ```python
+equinox.static_field(**kwargs)
+```
+This is a relatively advanced feature. Use it to mark one of the fields of a `Module` as being "static": that is, never differentiated, and always a `static_argnum` to JIT. Best used only if you control whatever will be assigned to that field. For example `equinox.nn.MLP` does *not* use this for its activation function, as in principle a learnt activation functino could be passed.
+
+Example:
+```python
+class MyModule(equinox.Module):
+    value: equinox.static_field()
+```
+
+If any `**kwargs` are passed, then they will be forwarded on to `dataclasses.field`.
+
+```python
 equinox.tree_at(where, pytree, replace=_sentinel, replace_fn=_sentinel)
 ```
 Modifies an existing tree, and returns the modified tree. (Like `.at` for "in place modifications" of JAX arrays.)
@@ -355,8 +368,8 @@ Equinox includes a small neural network library, mostly as a tech demo for how t
 equinox.nn.Linear(in_features, out_features, use_bias=True, *, key)(input)
 equinox.nn.Identity(*args, **kwargs)(input)  # args and kwargs are ignored
 equinox.nn.Dropout(p=0.5, deterministic=False)(input, *, key=None, deterministic=None)
-equinox.nn.GRUCell(input_size, hidden_size, bias=True, *, key)(input, hidden)
-equinox.nn.LSTMCell(input_size, hidden_size, bias=True, *, key)(input, hidden)
+equinox.nn.GRUCell(input_size, hidden_size, use_bias=True, *, key)(input, hidden)
+equinox.nn.LSTMCell(input_size, hidden_size, use_bias=True, *, key)(input, hidden)
 equinox.nn.Sequential(layers)(input, *, key=None)
 equinox.nn.MLP(in_size, out_size, width_size, depth,
                activation=jax.nn.relu, final_activation=lambda x: x, *, key)(input)

--- a/equinox/__init__.py
+++ b/equinox/__init__.py
@@ -12,9 +12,9 @@ from .filters import (
 )
 from .gradf import filter_grad, filter_value_and_grad, gradf, value_and_grad_f
 from .jitf import filter_jit, jitf
-from .module import Module
+from .module import Module, static_field
 from .tree import tree_at, tree_equal
 from .update import apply_updates
 
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/equinox/gradf.py
+++ b/equinox/gradf.py
@@ -3,14 +3,25 @@ import functools as ft
 import jax
 
 from .deprecated import deprecated
-from .filters import combine, merge, partition, split, validate_filters, is_inexact_array
+from .filters import (
+    combine,
+    is_inexact_array,
+    merge,
+    partition,
+    split,
+    validate_filters,
+)
 
 
-def filter_value_and_grad(fun, *, filter_spec=is_inexact_array, argnums=None, **gradkwargs):
+def filter_value_and_grad(
+    fun, *, filter_spec=is_inexact_array, argnums=None, **gradkwargs
+):
     if argnums is not None:
-        raise ValueError("`argnums` should not be passed. If you need to differentiate "
-                         "multiple objects then collect them into a tuple and pass that "
-                         "as the first argument.")
+        raise ValueError(
+            "`argnums` should not be passed. If you need to differentiate "
+            "multiple objects then collect them into a tuple and pass that "
+            "as the first argument."
+        )
 
     @ft.partial(jax.value_and_grad, argnums=0, **gradkwargs)
     def fun_value_and_grad(diff_x, nondiff_x, *args, **kwargs):

--- a/equinox/gradf.py
+++ b/equinox/gradf.py
@@ -3,12 +3,14 @@ import functools as ft
 import jax
 
 from .deprecated import deprecated
-from .filters import combine, merge, partition, split, validate_filters
+from .filters import combine, merge, partition, split, validate_filters, is_inexact_array
 
 
-def filter_value_and_grad(fun, *, filter_spec, argnums=None, **gradkwargs):
+def filter_value_and_grad(fun, *, filter_spec=is_inexact_array, argnums=None, **gradkwargs):
     if argnums is not None:
-        raise ValueError("`argnums` should not be passed; use a filter instead.")
+        raise ValueError("`argnums` should not be passed. If you need to differentiate "
+                         "multiple objects then collect them into a tuple and pass that "
+                         "as the first argument.")
 
     @ft.partial(jax.value_and_grad, argnums=0, **gradkwargs)
     def fun_value_and_grad(diff_x, nondiff_x, *args, **kwargs):
@@ -22,7 +24,7 @@ def filter_value_and_grad(fun, *, filter_spec, argnums=None, **gradkwargs):
     return fun_value_and_grad_wrapper
 
 
-def filter_grad(fun, *, filter_spec, has_aux=False, **gradkwargs):
+def filter_grad(fun, *, filter_spec=is_inexact_array, has_aux=False, **gradkwargs):
     fun_value_and_grad = filter_value_and_grad(
         fun, filter_spec=filter_spec, has_aux=has_aux, **gradkwargs
     )

--- a/equinox/jitf.py
+++ b/equinox/jitf.py
@@ -5,7 +5,7 @@ from typing import Any
 import jax
 
 from .deprecated import deprecated
-from .filters import combine, partition, validate_filters, is_array
+from .filters import combine, is_array, partition, validate_filters
 from .module import Module, static_field
 
 
@@ -16,13 +16,16 @@ class _Static(Module):
 @ft.lru_cache(maxsize=4096)
 def _filter_jit_cache(f, **jitkwargs):
     @ft.partial(jax.jit, static_argnums=(0, 1, 4), **jitkwargs)
-    def f_wrapped(static_leaves, static_treedef, dynamic_args, dynamic_kwargs, filter_spec_return):
+    def f_wrapped(
+        static_leaves, static_treedef, dynamic_args, dynamic_kwargs, filter_spec_return
+    ):
         static_args, static_kwargs = jax.tree_unflatten(static_treedef, static_leaves)
         args = combine(dynamic_args, static_args)
         kwargs = combine(dynamic_kwargs, static_kwargs)
         out = f(*args, **kwargs)
         dynamic_out, static_out = partition(out, filter_spec_return)
         return dynamic_out, _Static(static_out)
+
     return f_wrapped
 
 
@@ -65,9 +68,14 @@ def filter_jit(
         static_leaves, static_treedef = jax.tree_flatten((static_args, static_kwargs))
         static_leaves = tuple(static_leaves)
         dynamic_out, static_out = _filter_jit_cache(fun, **jitkwargs)(
-            static_leaves, static_treedef, dynamic_args, dynamic_kwargs, filter_spec_return
+            static_leaves,
+            static_treedef,
+            dynamic_args,
+            dynamic_kwargs,
+            filter_spec_return,
         )
         return combine(dynamic_out, static_out.value)
+
     return fun_wrapper
 
 

--- a/equinox/module.py
+++ b/equinox/module.py
@@ -1,10 +1,21 @@
 import abc
 import functools as ft
-from dataclasses import dataclass, fields
+from dataclasses import dataclass, field, fields
 
 import jax
 
 from .tree import tree_equal
+
+
+def static_field(**kwargs):
+    try:
+        metadata = dict(kwargs["metadata"])
+    except KeyError:
+        metadata = kwargs["metadata"] = {}
+    if "static" in metadata:
+        raise ValueError("Cannot use metadata with `static` already set.")
+    metadata["static"] = True
+    return field(**kwargs)
 
 
 @ft.lru_cache(maxsize=128)
@@ -27,12 +38,24 @@ def _make_initable(cls):
     return _InitableModule
 
 
+def _has_dataclass_init(cls):
+    if "__init__" in cls.__dict__:
+        return False
+    return cls._has_dataclass_init
+
+
 # Inherits from abc.ABCMeta as a convenience for a common use-case.
 # It's not a feature we use ourselve.
 class _ModuleMeta(abc.ABCMeta):
     def __new__(mcs, name, bases, dict_):
         cls = super().__new__(mcs, name, bases, dict_)
-        cls = dataclass(eq=False, frozen=True)(cls)
+        # Do override subclasses' dataclass-__init__-s. (None of which call super, so
+        # they must be overriden.)
+        # Don't override custom __init__'s, which leads to poor ergonomics:
+        # e.g. if `B` has a custom init then `class A(B): pass` would otherwise set a
+        # dataclass init that overrides the custom __init__.
+        _init = cls._has_dataclass_init = _has_dataclass_init(cls)
+        cls = dataclass(eq=False, frozen=True, init=_init)(cls)
         jax.tree_util.register_pytree_node_class(cls)
         return cls
 
@@ -58,6 +81,8 @@ class _ModuleMeta(abc.ABCMeta):
 
 
 class Module(metaclass=_ModuleMeta):
+    _has_dataclass_init = True
+
     def __hash__(self):
         return hash(tuple(jax.tree_leaves(self)))
 
@@ -65,21 +90,34 @@ class Module(metaclass=_ModuleMeta):
         return tree_equal(self, other)
 
     def tree_flatten(self):
-        field_names = []
-        field_values = []
-        for field in fields(self):
-            name = field.name
+        dynamic_field_names = []
+        dynamic_field_values = []
+        static_field_names = []
+        static_field_values = []
+        for field_ in fields(self):
+            name = field_.name
             try:
                 value = self.__dict__[name]
             except KeyError:
                 continue
-            field_names.append(name)
-            field_values.append(value)
-        return tuple(field_values), tuple(field_names)
+            if field_.metadata.get("static", False):
+                static_field_names.append(name)
+                static_field_values.append(value)
+            else:
+                dynamic_field_names.append(name)
+                dynamic_field_values.append(value)
+        return tuple(dynamic_field_values), (
+            tuple(dynamic_field_names),
+            tuple(static_field_names),
+            tuple(static_field_values),
+        )
 
     @classmethod
-    def tree_unflatten(cls, field_names, field_values):
+    def tree_unflatten(cls, aux, dynamic_field_values):
         self = cls.__new__(cls)
-        for name, value in zip(field_names, field_values):
+        dynamic_field_names, static_field_names, static_field_values = aux
+        for name, value in zip(dynamic_field_names, dynamic_field_values):
+            object.__setattr__(self, name, value)
+        for name, value in zip(static_field_names, static_field_values):
             object.__setattr__(self, name, value)
         return self

--- a/equinox/module.py
+++ b/equinox/module.py
@@ -1,7 +1,7 @@
 import abc
-from dataclasses import dataclass, field, fields
 import functools as ft
 import inspect
+from dataclasses import dataclass, field, fields
 
 import jax
 
@@ -59,7 +59,9 @@ def _has_dataclass_init(cls):
 # It's not a feature we use ourselve.
 class _ModuleMeta(abc.ABCMeta):
     def __new__(mcs, name, bases, dict_):
-        dict_ = {k: _wrap_method(v) if inspect.isfunction(v) else v for k, v in dict_.items()}
+        dict_ = {
+            k: _wrap_method(v) if inspect.isfunction(v) else v for k, v in dict_.items()
+        }
         cls = super().__new__(mcs, name, bases, dict_)
         # Do override subclasses' dataclass-__init__-s. (None of which call super, so
         # they must be overriden.)

--- a/equinox/nn/composed.py
+++ b/equinox/nn/composed.py
@@ -3,7 +3,7 @@ from typing import List
 import jax.nn as jnn
 import jax.random as jrandom
 
-from ..module import Module
+from ..module import Module, static_field
 from .linear import Linear
 
 
@@ -11,6 +11,10 @@ class MLP(Module):
     layers: List[Linear]
     activation: callable
     final_activation: callable
+    in_size: int = static_field()
+    out_size: int = static_field()
+    width_size: int = static_field()
+    depth: int = static_field()
 
     def __init__(
         self,
@@ -35,6 +39,10 @@ class MLP(Module):
                 layers.append(Linear(width_size, width_size, key=keys[i + 1]))
             layers.append(Linear(width_size, out_size, key=keys[-1]))
         self.layers = layers
+        self.in_size = in_size
+        self.out_size = out_size
+        self.width_size = width_size
+        self.depth = depth
         self.activation = activation
         self.final_activation = final_activation
 

--- a/equinox/nn/dropout.py
+++ b/equinox/nn/dropout.py
@@ -5,6 +5,7 @@ from ..module import Module
 
 
 class Dropout(Module):
+    # Not static_fields as it makes sense to want to modify them via equinox.tree_at.
     p: float = 0.5
     deterministic: bool = False
 

--- a/equinox/nn/linear.py
+++ b/equinox/nn/linear.py
@@ -4,12 +4,15 @@ from typing import Optional
 import jax.random as jrandom
 
 from ..custom_types import Array
-from ..module import Module
+from ..module import Module, static_field
 
 
 class Linear(Module):
     weight: Array
     bias: Optional[Array]
+    in_features: int = static_field()
+    out_features: int = static_field()
+    use_bias: bool = static_field()
 
     def __init__(self, in_features, out_features, use_bias=True, *, key):
         super().__init__()
@@ -22,6 +25,10 @@ class Linear(Module):
             self.bias = jrandom.uniform(bkey, (out_features,), minval=-lim, maxval=lim)
         else:
             self.bias = None
+
+        self.in_features = in_features
+        self.out_features = out_features
+        self.use_bias = use_bias
 
     def __call__(self, x, *, key=None):
         x = self.weight @ x

--- a/equinox/nn/rnn.py
+++ b/equinox/nn/rnn.py
@@ -1,4 +1,5 @@
 import math
+import warnings
 from typing import Optional
 
 import jax.nn as jnn
@@ -18,7 +19,9 @@ class GRUCell(Module):
     hidden_size: int = static_field()
     use_bias: bool = static_field()
 
-    def __init__(self, input_size, hidden_size, use_bias=True, bias=None, *, key, **kwargs):
+    def __init__(
+        self, input_size, hidden_size, use_bias=True, bias=None, *, key, **kwargs
+    ):
         super().__init__(**kwargs)
         if bias is not None:
             warnings.warn("`bias` is deprecated in favour of `use_bias`.")
@@ -71,7 +74,9 @@ class LSTMCell(Module):
     hidden_size: int = static_field()
     use_bias: bool = static_field()
 
-    def __init__(self, input_size, hidden_size, use_bias=True, bias=None, *, key, **kwargs):
+    def __init__(
+        self, input_size, hidden_size, use_bias=True, bias=None, *, key, **kwargs
+    ):
         super().__init__(**kwargs)
         if bias is not None:
             warnings.warn("`bias` is deprecated in favour of `use_bias`.")

--- a/equinox/nn/rnn.py
+++ b/equinox/nn/rnn.py
@@ -6,7 +6,7 @@ import jax.numpy as jnp
 import jax.random as jrandom
 
 from ..custom_types import Array
-from ..module import Module
+from ..module import Module, static_field
 
 
 class GRUCell(Module):
@@ -14,9 +14,15 @@ class GRUCell(Module):
     weight_hh: Array
     bias: Optional[Array]
     bias_n: Optional[Array]
+    input_size: int = static_field()
+    hidden_size: int = static_field()
+    use_bias: bool = static_field()
 
-    def __init__(self, input_size, hidden_size, bias=True, *, key, **kwargs):
+    def __init__(self, input_size, hidden_size, use_bias=True, bias=None, *, key, **kwargs):
         super().__init__(**kwargs)
+        if bias is not None:
+            warnings.warn("`bias` is deprecated in favour of `use_bias`.")
+            use_bias = bias
 
         ihkey, hhkey, bkey, bkey2 = jrandom.split(key, 4)
         lim = math.sqrt(1 / hidden_size)
@@ -27,7 +33,7 @@ class GRUCell(Module):
         self.weight_hh = jrandom.uniform(
             hhkey, (3 * hidden_size, hidden_size), minval=-lim, maxval=lim
         )
-        if bias:
+        if use_bias:
             self.bias = jrandom.uniform(
                 bkey, (3 * hidden_size,), minval=-lim, maxval=lim
             )
@@ -37,6 +43,10 @@ class GRUCell(Module):
         else:
             self.bias = None
             self.bias_n = None
+
+        self.input_size = input_size
+        self.hidden_size = hidden_size
+        self.use_bias = use_bias
 
     def __call__(self, input, hidden, *, key=None):
         if self.bias is None:
@@ -57,9 +67,15 @@ class LSTMCell(Module):
     weight_ih: Array
     weight_hh: Array
     bias: Optional[Array]
+    input_size: int = static_field()
+    hidden_size: int = static_field()
+    use_bias: bool = static_field()
 
-    def __init__(self, input_size, hidden_size, bias=True, *, key, **kwargs):
+    def __init__(self, input_size, hidden_size, use_bias=True, bias=None, *, key, **kwargs):
         super().__init__(**kwargs)
+        if bias is not None:
+            warnings.warn("`bias` is deprecated in favour of `use_bias`.")
+            use_bias = bias
 
         ihkey, hhkey, bkey = jrandom.split(key, 3)
         lim = math.sqrt(1 / hidden_size)
@@ -76,6 +92,10 @@ class LSTMCell(Module):
             )
         else:
             self.bias = None
+
+        self.input_size = input_size
+        self.hidden_size = hidden_size
+        self.use_bias = use_bias
 
     def __call__(self, input, hidden, *, key=None):
         h, c = hidden

--- a/examples/filtered_transformations.py
+++ b/examples/filtered_transformations.py
@@ -8,8 +8,6 @@
 #
 #############
 
-import functools as ft
-
 import jax
 import jax.numpy as jnp
 import jax.random as jrandom

--- a/examples/filtered_transformations.py
+++ b/examples/filtered_transformations.py
@@ -62,11 +62,11 @@ def main(
         in_size=1, out_size=1, width_size=width_size, depth=depth, key=model_key
     )
 
-    # `filter_jit` and `filter_value_and_grad_` are thin wrappers around the usual `jax` functions.
-    # In this case we're asking to JIT with respect to all JAX arrays, and differentiate with respect to all floating
-    # point JAX arrays, i.e. the parameters of our model.
-    @ft.partial(eqx.filter_jit, filter_spec=eqx.is_array)
-    @ft.partial(eqx.filter_value_and_grad, filter_spec=eqx.is_inexact_array)
+    # `filter_jit` and `filter_value_and_grad` are thin wrappers around the usual `jax` functions, that automatically
+    # inspect the arguments of the function, JIT with respect to all JAX arrays, and differentiate with respect to all
+    # floating point JAX arrays (i.e. the parameters of the model).
+    @eqx.filter_jit
+    @eqx.filter_value_and_grad
     def loss(model, x, y):
         pred_y = jax.vmap(model)(x)
         return jnp.mean((y - pred_y) ** 2)

--- a/examples/frozen_layer.py
+++ b/examples/frozen_layer.py
@@ -39,7 +39,7 @@ def main(
     )
 
     # We'll still JIT with respect to every array.
-    @ft.partial(eqx.filter_jit, filter_spec=eqx.is_array)
+    @eqx.filter_jit
     @ft.partial(eqx.filter_value_and_grad, filter_spec=filter_spec)
     def loss(model, x, y):
         pred_y = jax.vmap(model)(x)

--- a/examples/train_rnn.py
+++ b/examples/train_rnn.py
@@ -4,7 +4,6 @@
 #
 #############
 
-import functools as ft
 import math
 
 import jax

--- a/examples/train_rnn.py
+++ b/examples/train_rnn.py
@@ -72,8 +72,8 @@ def main(
 
     model = RNN(in_size=2, out_size=1, hidden_size=hidden_size, key=model_key)
 
-    @ft.partial(eqx.filter_jit, filter_spec=eqx.is_array)
-    @ft.partial(eqx.filter_value_and_grad, filter_spec=eqx.is_inexact_array)
+    @eqx.filter_jit
+    @eqx.filter_value_and_grad
     def loss(model, x, y):
         pred_y = jax.vmap(model)(x)
         # Trains with respect to binary cross-entropy

--- a/tests/test_filter_jit.py
+++ b/tests/test_filter_jit.py
@@ -50,11 +50,11 @@ def test_filter_jit1(getkey):
     assert jnp.all(g1[0]["b"] == b)
     assert jnp.all(g1[1][0] == c)
     g2 = g(general_tree)
-    assert _eq(g2[0], jnp.array(1))
-    assert _eq(g2[1], jnp.array(True))
+    assert _eq(g2[0], 1)
+    assert _eq(g2[1], True)
     assert _eq(g2[2], None)
     assert jnp.all(g2[3]["a"] == a)
-    assert _eq(g2[3]["tuple"][0], jnp.array(2.0))
+    assert _eq(g2[3]["tuple"][0], 2.0)
     assert jnp.all(g2[3]["tuple"][1] == b)
     assert jnp.all(g2[4] == c)
     assert _eq(g2[5], _mlp)
@@ -73,10 +73,10 @@ def test_filter_jit1(getkey):
     assert _eq(h2[1], jnp.array(True))
     assert _eq(h2[2], None)
     assert jnp.all(h2[3]["a"] == a)
-    assert _eq(g2[3]["tuple"][0], jnp.array(2.0))
-    assert jnp.all(g2[3]["tuple"][1] == b)
-    assert jnp.all(g2[4] == c)
-    assert _eq(g2[5], _mlp)
+    assert _eq(h2[3]["tuple"][0], jnp.array(2.0))
+    assert jnp.all(h2[3]["tuple"][1] == b)
+    assert jnp.all(h2[4] == c)
+    assert _eq(h2[5], _mlp)
 
 
 def test_filter_jit2(getkey):
@@ -92,7 +92,6 @@ def test_filter_jit2(getkey):
         eqx.nn.MLP(2, 2, 2, 2, key=getkey()),
     ]
     _mlp = jax.tree_map(lambda u: u if eqx.is_array_like(u) else None, general_tree[-1])
-    _filter_mlp = jax.tree_map(eqx.is_inexact_array, general_tree[-1])
 
     @ft.partial(
         eqx.filter_jit,
@@ -104,7 +103,7 @@ def test_filter_jit2(getkey):
                     False,
                     {"a": True, "tuple": (False, True)},
                     True,
-                    _filter_mlp,
+                    eqx.is_inexact_array
                 ],
             ),
             {},
@@ -118,7 +117,7 @@ def test_filter_jit2(getkey):
     assert _eq(f1[1], jnp.array(True))
     assert _eq(f1[2], None)
     assert jnp.all(f1[3]["a"] == a)
-    assert _eq(f1[3]["tuple"][0], jnp.array(2.0))
+    assert _eq(f1[3]["tuple"][0], 2.0)
     assert jnp.all(f1[3]["tuple"][1] == b)
     assert jnp.all(f1[4] == c)
     assert _eq(f1[5], _mlp)

--- a/tests/test_filter_jit.py
+++ b/tests/test_filter_jit.py
@@ -103,7 +103,7 @@ def test_filter_jit2(getkey):
                     False,
                     {"a": True, "tuple": (False, True)},
                     True,
-                    eqx.is_inexact_array
+                    eqx.is_inexact_array,
                 ],
             ),
             {},

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+import jax
 import pytest
 
 import equinox as eqx
@@ -113,8 +114,7 @@ def test_inheritance():
         m = MyModule5(value4=1, weight5=2)
 
     class MyModule6(MyModule4):
-        def __init__(self, **kwargs):
-            super().__init__(**kwargs)
+        pass
 
     m = MyModule6(value4=1)
     assert m.weight4 == 1
@@ -131,3 +131,19 @@ def test_inheritance():
     m = MyModule7(value4=1, value7=2)
     assert m.weight4 == 1
     assert m.weight7 == 2
+
+
+def test_static_field():
+    class MyModule(eqx.Module):
+        field1: int
+        field2: int = eqx.static_field()
+        field3: int = eqx.static_field(default=3)
+
+    m = MyModule(1, 2)
+    flat, treedef = jax.tree_flatten(m)
+    assert len(flat) == 1
+    assert flat[0] == 1
+    rm = jax.tree_unflatten(treedef, flat)
+    assert rm.field1 == 1
+    assert rm.field2 == 2
+    assert rm.field3 == 3


### PR DESCRIPTION
**More important points**
- `filter_jit` and `filter_grad` and `filter_value_and_grad` now have a sensible default for `filter_spec`. This means it is now typical to simply write
    ```python
    @eqx.filter_jit
    @eqx.filter_grad
    def loss(model, data):
        ...
    ```
    - Moreover, as 99% of all uses cases are to JIT wrt all JAX arrays and differentiate all floating point JAX arrays, then this makes `filter_jit` and `filter_grad` pretty much just upgraded versions of `jax.jit` and `jax.grad`, suitable for all use-cases.

  - `filter_jit` is now smart enough to filter its return types (as well as its arguments). This means that PyTrees with mixed dynamic/static pieces can be returned without issue.
  - Previously `filter_jit` behaved like `jax.jit`: (a) implicitly casting int/float/bool/complex to a JAX array, or (b) throwing an error on arbitrary Python types. `*`

`*` This is also a meaningful philosophical difference to something like PyTorch -- all `torch.nn.Module` instances are typically created up-front at the "topl level", and creating/returning them on the forward pass is generally a mistake. In contrast I frequently find myself creating/returning `eqx.Module`s in the forward pass, as they're a really convenient way to encapsulate functionality.

- Added `equinox.static_field`. This marks an instance attribute as being `aux_data` when flattening.
    - Used as
    ```python
    class MyModule(eqx.Module):
        field: Any = eqx.static_field()
    ```
    - Use cases for this should actually be pretty rare.
        - It's tempting to think that an MLP's activation function should be static, but this would then break the use of learnt activation functions. (Whose parameters we want to be PyTree leaves.)
    - Mostly this represents a trade-off between `jax.jit/vmap` and `eqx.tree_at`.
        - If the field is not static then it can easily be modified via tree manipulation routines, like `eqx.tree_at`.
        - If the field is static then `jax.jit/vmap` is able to _return_ instances of `MyModule`. 
    - As such, this is mostly just here so that `jax.jit/vmap` does the expected thing for new users. More advanced use-cases will pretty much ubiquitously use `eqx.filter_jit`, which is smart enough to handle things appropriately in the return type. (And does raise the question of whether we want an `eqx.filter_vmap` that is also smart about its return type.)
    - Looking forward, it also establishes the way Equinox handles any field-specific metadata -- namely the standardised `dataclasses` metadata approach.

- Evaluating `value = MyModule().method` now binds `self` to `method` in a PyTree-transparent way. This means one can safely pass around methods as functions.

**Minor points:**
- `GRUCell(bias=)` and `LSTMCell(bias=)` have been deprecated in favour of `use_bias=`, for consistency with `eqx.nn.Linear`.
- Reverted a change to inheritance and `__init__`. In version 0.1.0 then the following code would see `AnotherModule`  have a default `__init__` created. In versions 0.3.0, and now also version 0.1.1, it keeps the `__init__` from `MyModule`. This is a reversion of an intended change that ended up having poorer ergonomics than expected.
```python
class MyModule(eqx.Module):
    def __init__(self, ...):
        ...

class AnotherModule(MyModule):
    pass
```