### PR TITLE
v0.1.5

### DIFF
--- a/equinox/__init__.py
+++ b/equinox/__init__.py
@@ -23,4 +23,4 @@ from .tree import tree_at, tree_equal
 from .update import apply_updates
 
 
-__version__ = "0.1.4"
+__version__ = "0.1.5"

--- a/equinox/grad.py
+++ b/equinox/grad.py
@@ -1,4 +1,5 @@
 import functools as ft
+import types
 import typing
 
 import jax
@@ -228,8 +229,11 @@ class filter_custom_vjp:
 if getattr(typing, "GENERATING_DOCUMENTATION", False):
     _filter_custom_vjp_doc = filter_custom_vjp.__doc__
 
-    def filter_custom_vjp(fn):
+    def defvjp(fn_fwd, fn_bwd):
         pass
+
+    def filter_custom_vjp(fn):
+        return types.SimpleNamespace(defvjp=defvjp)
 
     filter_custom_vjp.__doc__ = _filter_custom_vjp_doc
 

--- a/equinox/module.py
+++ b/equinox/module.py
@@ -99,7 +99,11 @@ class _ModuleMeta(abc.ABCMeta):
         # e.g. if `B` has a custom init then `class A(B): pass` would otherwise set a
         # dataclass init that overrides the custom __init__.
         _init = cls._has_dataclass_init = _has_dataclass_init(cls)
+        if _init:
+            init_doc = cls.__init__.__doc__
         cls = dataclass(eq=False, frozen=True, init=_init)(cls)
+        if _init:
+            cls.__init__.__doc__ = init_doc
         jax.tree_util.register_pytree_node_class(cls)
         return cls
 


### PR DESCRIPTION
- If a `Module` has a dataclass `__init__` that has been monkey-patched with `__doc__`, then its subclasses with a dataclass `__init__` will inherit the `__doc__`.
- The `GENERATING_DOCUMENTATION` version of `filter_custom_vjp` now has a dummy `defvjp` method.