### PR TITLE
Added pretty-printing for Modules

### DIFF
--- a/docs/api/utilities.md
+++ b/docs/api/utilities.md
@@ -1,14 +1,18 @@
 # Utilities
 
+::: equinox.apply_updates
+
+---
+
 ::: equinox.tree_at
 
 ---
 
-::: equinox.tree_equal
+::: equinox.tree_pformat
 
 ---
 
-::: equinox.apply_updates
+::: equinox.tree_equal
 
 ---
 

--- a/equinox/__init__.py
+++ b/equinox/__init__.py
@@ -23,4 +23,4 @@ from .tree import tree_at, tree_equal, tree_pformat
 from .update import apply_updates
 
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/equinox/__init__.py
+++ b/equinox/__init__.py
@@ -19,7 +19,7 @@ from .grad import (
 )
 from .jit import filter_jit, jitf
 from .module import Module, static_field
-from .tree import tree_at, tree_equal
+from .tree import tree_at, tree_equal, tree_pformat
 from .update import apply_updates
 
 

--- a/equinox/module.py
+++ b/equinox/module.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass, field, fields
 
 import jax
 
-from .tree import tree_equal
+from .tree import tree_equal, tree_pformat
 
 
 def static_field(**kwargs):
@@ -217,6 +217,9 @@ class Module(metaclass=_ModuleMeta):
 
     def __eq__(self, other):
         return tree_equal(self, other)
+
+    def __str__(self):
+        return tree_pformat(self)
 
     def tree_flatten(self):
         dynamic_field_names = []

--- a/equinox/tree.py
+++ b/equinox/tree.py
@@ -1,3 +1,6 @@
+import functools as ft
+import inspect
+import pprint
 from typing import Any, Callable, Sequence, Union
 
 import jax
@@ -5,6 +8,7 @@ import jax.numpy as jnp
 import numpy as np
 
 from .custom_types import PyTree
+from .filters import is_array
 
 
 _sentinel = object()
@@ -148,3 +152,71 @@ def tree_equal(*pytrees: PyTree) -> bool:
                     if elem != elem_:
                         return False
     return True
+
+
+# From:
+# https://github.com/google/jax/blob/ee6749608a1588f1f458e0e8ad8c9ecc8942aa83/jax/core.py#L1080  # noqa: E501
+def _short_dtype_name(dtype):
+    return (
+        dtype.name.replace("float", "f")
+        .replace("uint", "u")
+        .replace("int", "i")
+        .replace("complex", "c")
+    )
+
+
+class _WithRepr:
+    def __init__(self, val):
+        self.val = val
+
+    def __repr__(self):
+        return self.val
+
+
+def _convert(leaf):
+    wrapped = False
+    wrapper_types = (jax.custom_vjp, jax.custom_jvp, ft.partial)
+    while isinstance(leaf, wrapper_types):
+        if isinstance(leaf, (jax.custom_jvp, jax.custom_vjp)):
+            leaf = leaf.__wrapped__
+            # Not always thought of as a wrapper so we don't set wrapped=True
+        if isinstance(leaf, ft.partial):
+            leaf = leaf.func
+            wrapped = True
+
+    if is_array(leaf):
+        dt_str = _short_dtype_name(leaf.dtype)
+        shape_str = ",".join(map(str, leaf.shape))
+        return _WithRepr(f"{dt_str}[{shape_str}]")
+    elif inspect.isfunction(leaf):
+        if wrapped:
+            fn_str = "wrapped function"
+        else:
+            fn_str = "function"
+        return _WithRepr(f"<{fn_str} {leaf.__name__}>")
+    else:
+        return leaf
+
+
+def tree_pformat(pytree: PyTree, **kwargs) -> str:
+    """Pretty-formats a PyTree as a string, whilst abbreviating JAX arrays.
+
+    All JAX arrays in the PyTree are condensed down to a short string representation
+    of their dtype and shape.
+
+    (This is the function used in `__str__` of [`equinox.Module`][].)
+
+    !!! example
+
+        A 32-bit floating-point JAX array of shape `(3, 4)` is printed as `f32[3,4]`.
+
+    **Arguments:**
+
+    - `pytree`: The PyTree to pretty-format.
+    - `**kwargs`: Any keyword arguments for `pprint.pformat`.
+
+    **Returns:**
+
+    A string.
+    """
+    return pprint.pformat(jax.tree_map(_convert, pytree), **kwargs)

--- a/equinox/tree.py
+++ b/equinox/tree.py
@@ -218,5 +218,11 @@ def tree_pformat(pytree: PyTree, **kwargs) -> str:
     **Returns:**
 
     A string.
+
+    !!! info
+
+        This is best used with Python 3.10 or above, for which the standard library
+        `pprint` supports dataclasses and will add line breaks appropriately.
+        (`tree_pformat` uses `pprint`; [`equinox.Module`][] uses dataclasses.)
     """
     return pprint.pformat(jax.tree_map(_convert, pytree), **kwargs)


### PR DESCRIPTION
More generally, this adds pretty-printing for all PyTrees containing JAX arrays, via the `equinox.tree_pformat` function. This is used in `equinox.Module.__str__`.

- Note that this will produce best results for Python >3.10, for which the standard library `pprint` supports dataclasses. On lower versions of Python it won't add line breaks.
- Note that we deliberately only set `equinox.Module.__str__` and not `equinox.Module.__repr__`, so as to avoid an infinite recursion: `pprint` uses an object's `__repr__`.