### PR TITLE
Remove default bias in `MultiheadAttention`

### DIFF
--- a/equinox/nn/attention.py
+++ b/equinox/nn/attention.py
@@ -103,7 +103,7 @@ class MultiheadAttention(Module):
         use_query_bias: bool = False,
         use_key_bias: bool = False,
         use_value_bias: bool = False,
-        use_output_bias: bool = True,
+        use_output_bias: bool = False,
         dropout_p: float = 0.0,
         *,
         key: "jax.random.PRNGKey",

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -463,11 +463,9 @@ def test_multihead_attention(getkey):
             x.key_proj.weight,
             x.value_proj.weight,
             x.output_proj.weight,
-            x.output_proj.bias,
         ),
         attn,
-        [jnp.arange(16).reshape(4, 4) for _ in range(4)]
-        + [jnp.zeros_like(attn.output_proj.bias)],
+        [jnp.arange(16).reshape(4, 4) for _ in range(4)],
     )
     x = jnp.array([[1, 2, 3, 4]])
     assert jnp.allclose(attn(x, x, x), jnp.array([[680.0, 1960.0, 3240.0, 4520.0]]))


### PR DESCRIPTION
Following up on the conversation in https://github.com/patrick-kidger/equinox/pull/38#discussion_r842082571, this is probably a better default for modelling. Moreover it's a more consistent default.

This should be merged in the next breaking release.