### PR TITLE
Improved pretty-printing

### DIFF
--- a/equinox/__init__.py
+++ b/equinox/__init__.py
@@ -11,7 +11,8 @@ from .filters import (
 from .grad import filter_custom_vjp, filter_grad, filter_value_and_grad
 from .jit import filter_jit
 from .module import Module, static_field
-from .tree import tree_at, tree_equal, tree_pformat
+from .pretty_print import tree_pformat
+from .tree import tree_at, tree_equal
 from .update import apply_updates
 
 

--- a/equinox/module.py
+++ b/equinox/module.py
@@ -5,7 +5,8 @@ from dataclasses import dataclass, field, fields
 
 import jax
 
-from .tree import tree_equal, tree_pformat
+from .pretty_print import tree_pformat
+from .tree import tree_equal
 
 
 def static_field(**kwargs):
@@ -101,7 +102,7 @@ class _ModuleMeta(abc.ABCMeta):
         _init = cls._has_dataclass_init = _has_dataclass_init(cls)
         if _init:
             init_doc = cls.__init__.__doc__
-        cls = dataclass(eq=False, frozen=True, init=_init)(cls)
+        cls = dataclass(eq=False, repr=False, frozen=True, init=_init)(cls)
         if _init:
             cls.__init__.__doc__ = init_doc
         jax.tree_util.register_pytree_node_class(cls)
@@ -218,7 +219,7 @@ class Module(metaclass=_ModuleMeta):
     def __eq__(self, other):
         return tree_equal(self, other)
 
-    def __str__(self):
+    def __repr__(self):
         return tree_pformat(self)
 
     def tree_flatten(self):

--- a/equinox/pretty_print.py
+++ b/equinox/pretty_print.py
@@ -1,0 +1,203 @@
+import dataclasses
+import functools as ft
+import types
+from typing import Any, Dict, List, NamedTuple, Tuple
+
+import jax
+import jax._src.pretty_printer as pp
+import jax.numpy as jnp
+import numpy as np
+
+from .custom_types import Array
+
+
+Dataclass = Any
+PrettyPrintAble = Any
+
+
+_comma_sep = pp.concat([pp.text(","), pp.brk()])
+
+
+def _nest(n: int, doc: pp.Doc) -> pp.Doc:
+    return pp.nest(n, pp.concat([pp.brk(""), doc]))
+
+
+def _pformat_list(obj: List, **kwargs) -> pp.Doc:
+    indent = kwargs["indent"]
+    return pp.group(
+        pp.concat(
+            [
+                pp.text("["),
+                _nest(
+                    indent, pp.join(_comma_sep, [_pformat(x, **kwargs) for x in obj])
+                ),
+                pp.brk(""),
+                pp.text("]"),
+            ]
+        )
+    )
+
+
+def _pformat_tuple(obj: Tuple, **kwargs) -> pp.Doc:
+    indent = kwargs["indent"]
+    if len(obj) == 1:
+        entries = pp.concat([_pformat(obj[0], **kwargs), pp.text(",")])
+    else:
+        entries = pp.join(_comma_sep, [_pformat(x, **kwargs) for x in obj])
+    return pp.group(
+        pp.concat([pp.text("("), _nest(indent, entries), pp.brk(""), pp.text(")")])
+    )
+
+
+def _dict_entry(key: PrettyPrintAble, value: PrettyPrintAble, **kwargs) -> pp.Doc:
+    return pp.concat(
+        [_pformat(key, **kwargs), pp.text(":"), pp.brk(), _pformat(value, **kwargs)]
+    )
+
+
+def _pformat_dict(obj: Dict, **kwargs) -> pp.Doc:
+    indent = kwargs["indent"]
+    entries = [_dict_entry(key, value, **kwargs) for key, value in obj.items()]
+    return pp.group(
+        pp.concat(
+            [
+                pp.text("{"),
+                _nest(indent, pp.join(_comma_sep, entries)),
+                pp.brk(""),
+                pp.text("}"),
+            ]
+        )
+    )
+
+
+def _named_entry(name: str, value: Any, **kwargs) -> pp.Doc:
+    return pp.concat([pp.text(name), pp.text("="), _pformat(value, **kwargs)])
+
+
+def _pformat_namedtuple(obj: NamedTuple, **kwargs) -> pp.Doc:
+    indent = kwargs["indent"]
+    entries = [_named_entry(name, getattr(obj, name), **kwargs) for name in obj._fields]
+    return pp.group(
+        pp.concat(
+            [
+                pp.text(obj.__class__.__name__),
+                pp.text("("),
+                _nest(indent, pp.join(_comma_sep, entries)),
+                pp.brk(""),
+                pp.text(")"),
+            ]
+        )
+    )
+
+
+def _pformat_dataclass(obj: Dataclass, **kwargs) -> pp.Doc:
+    indent = kwargs["indent"]
+    entries = [
+        _named_entry(f.name, getattr(obj, f.name), **kwargs)
+        for f in dataclasses.fields(obj)
+        if f.repr
+    ]
+    return pp.group(
+        pp.concat(
+            [
+                pp.text(obj.__class__.__name__),
+                pp.text("("),
+                _nest(indent, pp.join(_comma_sep, entries)),
+                pp.brk(""),
+                pp.text(")"),
+            ]
+        )
+    )
+
+
+def _pformat_array(obj: Array, **kwargs) -> pp.Doc:
+    short = kwargs["short_arrays"]
+    if short:
+        dtype_str = (
+            obj.dtype.name.replace("float", "f")
+            .replace("uint", "u")
+            .replace("int", "i")
+            .replace("complex", "c")
+        )
+        shape_str = ",".join(map(str, obj.shape))
+        backend = "(numpy)" if isinstance(obj, np.ndarray) else ""
+        return pp.text(f"{dtype_str}[{shape_str}]{backend}")
+    else:
+        return repr(obj)
+
+
+def _pformat_function(obj: types.FunctionType, **kwargs) -> pp.Doc:
+    if kwargs.get("wrapped", False):
+        fn = "wrapped function"
+    else:
+        fn = "function"
+    return pp.text(f"<{fn} {obj.__name__}>")
+
+
+# TODO: offer user-customisable override mechanism if they wish.
+# Ideally this would be something tied to being a PyTree.
+def _pformat(obj: PrettyPrintAble, **kwargs) -> pp.Doc:
+    follow_wrapped = kwargs["follow_wrapped"]
+    if dataclasses.is_dataclass(obj):
+        return _pformat_dataclass(obj, **kwargs)
+    elif isinstance(obj, list):
+        return _pformat_list(obj, **kwargs)
+    elif isinstance(obj, dict):
+        return _pformat_dict(obj, **kwargs)
+    elif isinstance(obj, tuple):
+        if hasattr(obj, "_fields"):
+            return _pformat_namedtuple(obj, **kwargs)
+        else:
+            return _pformat_tuple(obj, **kwargs)
+    elif isinstance(obj, (np.ndarray, jnp.ndarray)):
+        return _pformat_array(obj, **kwargs)
+    elif isinstance(obj, (jax.custom_jvp, jax.custom_vjp)):
+        return _pformat(obj.__wrapped__, **kwargs)
+    elif hasattr(obj, "__wrapped__") and follow_wrapped:
+        kwargs["wrapped"] = True
+        return _pformat(obj.__wrapped__, **kwargs)
+    elif isinstance(obj, ft.partial) and follow_wrapped:
+        kwargs["wrapped"] = True
+        return _pformat(obj.func, **kwargs)
+    elif isinstance(obj, types.FunctionType):
+        return _pformat_function(obj, **kwargs)
+    else:  # int, str, float, complex, bool, etc.
+        return pp.text(repr(obj))
+
+
+def tree_pformat(
+    pytree: PrettyPrintAble,
+    width: int = 80,
+    indent: int = 2,
+    short_arrays: bool = True,
+    follow_wrapped: bool = True,
+) -> str:
+    """Pretty-formats a PyTree as a string, whilst abbreviating JAX arrays.
+
+    All JAX arrays in the PyTree are condensed down to a short string representation
+    of their dtype and shape.
+
+    (This is the function used in `__repr__` of [`equinox.Module`][].)
+
+    !!! example
+
+       A 32-bit floating-point JAX array of shape `(3, 4)` is printed as `f32[3,4]`.
+
+    **Arguments:**
+
+    - `pytree`: The PyTree to pretty-format.
+    - `width`: The desired maximum number of characters per line of output. If a
+        structure cannot be formatted within this constraint then a best effort will
+        be made.
+    - `indent`: The amount of indentation each nesting level.
+    - `short_arrays`: Toggles the abbreviation of JAX arrays.
+    - `follow_wrapped`: Whether to unwrap `functools.partial` and `functools.wraps`.
+
+    **Returns:**
+
+    A string.
+    """
+
+    return _pformat(
+        pytree, indent=indent, short_arrays=short_arrays, follow_wrapped=follow_wrapped
+    ).format(width=width)

--- a/equinox/pretty_print.py
+++ b/equinox/pretty_print.py
@@ -1,7 +1,7 @@
 import dataclasses
 import functools as ft
 import types
-from typing import Any, Dict, List, NamedTuple, Tuple
+from typing import Any, Callable, Dict, List, NamedTuple, Tuple
 
 import jax
 import jax._src.pretty_printer as pp
@@ -138,7 +138,10 @@ def _pformat_function(obj: types.FunctionType, **kwargs) -> pp.Doc:
 # Ideally this would be something tied to being a PyTree.
 def _pformat(obj: PrettyPrintAble, **kwargs) -> pp.Doc:
     follow_wrapped = kwargs["follow_wrapped"]
-    if dataclasses.is_dataclass(obj):
+    truncate_leaf = kwargs["truncate_leaf"]
+    if truncate_leaf(obj):
+        return pp.text(f"{type(obj).__name__}(...)")
+    elif dataclasses.is_dataclass(obj):
         return _pformat_dataclass(obj, **kwargs)
     elif isinstance(obj, list):
         return _pformat_list(obj, **kwargs)
@@ -165,12 +168,17 @@ def _pformat(obj: PrettyPrintAble, **kwargs) -> pp.Doc:
         return pp.text(repr(obj))
 
 
+def _false(_):
+    return False
+
+
 def tree_pformat(
     pytree: PrettyPrintAble,
     width: int = 80,
     indent: int = 2,
     short_arrays: bool = True,
     follow_wrapped: bool = True,
+    truncate_leaf: Callable[[PrettyPrintAble], bool] = _false,
 ) -> str:
     """Pretty-formats a PyTree as a string, whilst abbreviating JAX arrays.
 
@@ -192,6 +200,8 @@ def tree_pformat(
     - `indent`: The amount of indentation each nesting level.
     - `short_arrays`: Toggles the abbreviation of JAX arrays.
     - `follow_wrapped`: Whether to unwrap `functools.partial` and `functools.wraps`.
+    - `truncate_leaf`: A function `Any -> bool`. Applied to all nodes in the PyTree;
+        all truthy nodes will be truncated to just `f"{type(node).__name__}(...)"`.
 
     **Returns:**
 
@@ -199,5 +209,9 @@ def tree_pformat(
     """
 
     return _pformat(
-        pytree, indent=indent, short_arrays=short_arrays, follow_wrapped=follow_wrapped
+        pytree,
+        indent=indent,
+        short_arrays=short_arrays,
+        follow_wrapped=follow_wrapped,
+        truncate_leaf=truncate_leaf,
     ).format(width=width)

--- a/tests/test_pformat.py
+++ b/tests/test_pformat.py
@@ -1,0 +1,83 @@
+import functools as ft
+import typing
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+import equinox as eqx
+
+
+def test_tuple():
+    assert eqx.tree_pformat((1, 2)) == "(1, 2)"
+    assert eqx.tree_pformat((1,)) == "(1,)"
+    assert eqx.tree_pformat(()) == "()"
+
+
+def test_list():
+    assert eqx.tree_pformat([1, 2]) == ("[1, 2]")
+    assert eqx.tree_pformat([1]) == "[1]"
+    assert eqx.tree_pformat([]) == "[]"
+
+
+def test_dict():
+    assert eqx.tree_pformat({"a": 1, "b": 2}) == "{'a': 1, 'b': 2}"
+    assert eqx.tree_pformat({"a": 1}) == "{'a': 1}"
+    assert eqx.tree_pformat(dict()) == "{}"
+
+
+def test_module(getkey):
+    lin = eqx.nn.Linear(2, 2, key=getkey())
+    mlp = eqx.nn.MLP(2, 2, 2, 2, key=getkey())
+    eqx.tree_pformat(lin)
+    eqx.tree_pformat(mlp)
+
+
+def test_named_tuple():
+    class M(typing.NamedTuple):
+        a: int
+
+    assert eqx.tree_pformat(M(1)) == "M(a=1)"
+
+
+def test_jax_array():
+    assert eqx.tree_pformat(jnp.array(1)) == "i32[]"
+    assert eqx.tree_pformat(jnp.arange(12).reshape(3, 4)) == "i32[3,4]"
+    assert (
+        eqx.tree_pformat(jnp.array(1), short_arrays=False)
+        == "DeviceArray(1, dtype=int32, weak_type=True)"
+    )
+
+
+def test_numpy_array():
+    assert eqx.tree_pformat(np.array(1)) == "i64[](numpy)"
+    assert eqx.tree_pformat(np.arange(12).reshape(3, 4)) == "i64[3,4](numpy)"
+    assert eqx.tree_pformat(np.array(1), short_arrays=False) == "array(1)"
+
+
+def test_builtins():
+    assert eqx.tree_pformat(1) == "1"
+    assert eqx.tree_pformat(0.1) == "0.1"
+    assert eqx.tree_pformat(True) == "True"
+    assert eqx.tree_pformat(1 + 1j) == "(1+1j)"
+    assert eqx.tree_pformat("hi") == "'hi'"
+
+
+def test_function():
+    def f():
+        pass
+
+    @ft.wraps(f)
+    def g():
+        pass
+
+    h = ft.partial(f)
+
+    i = jax.custom_vjp(f)
+    j = jax.custom_jvp(f)
+
+    assert eqx.tree_pformat(f, "<function f>")
+    assert eqx.tree_pformat(g, "<function f>")
+    assert eqx.tree_pformat(h, "<function f>")
+    assert eqx.tree_pformat(i, "<function f>")
+    assert eqx.tree_pformat(j, "<function f>")


### PR DESCRIPTION
Switched from using the builtin `pprint` library to using `jax._src.pretting_printing`, which is a much better pretty-printer. In particular the `__str__` representation of an `equinox.Module` should generally be narrower now.