### PR TITLE
Improved filtered transformations

### DIFF
--- a/docs/api/filtering/filtered-transformations.md
+++ b/docs/api/filtering/filtered-transformations.md
@@ -22,8 +22,8 @@ Practically speaking these are usually the only kind of filtering you ever have 
 
 ---
 
-::: equinox.experimental.filter_vmap
+::: equinox.filter_vmap
 
 ---
 
-::: equinox.experimental.filter_pmap
+::: equinox.filter_pmap

--- a/docs/api/filtering/filtered-transformations.md
+++ b/docs/api/filtering/filtered-transformations.md
@@ -1,6 +1,6 @@
 # Filtered transformations
 
-These typically combine [`equinox.partition`][], a filter function, and a JAX transformation, all together.
+These typically combine [`equinox.partition`][], a [filter function](./filter-functions.md), and a JAX transformation, all together.
 
 Practically speaking these are usually the only kind of filtering you ever have to use. (But it's good to understand what e.g. [`equinox.partition`][] and [`equinox.is_array`][] are doing under the hood, just so that these don't seem too magical.)
 
@@ -19,3 +19,11 @@ Practically speaking these are usually the only kind of filtering you ever have 
 ::: equinox.filter_custom_vjp
     selection:
         members: false
+
+---
+
+::: equinox.experimental.filter_vmap
+
+---
+
+::: equinox.experimental.filter_pmap

--- a/docs/api/helpers.md
+++ b/docs/api/helpers.md
@@ -8,6 +8,10 @@
 
 ---
 
+::: equinox.tree_inference
+
+---
+
 ::: equinox.tree_pformat
 
 ---

--- a/docs/api/stateful.md
+++ b/docs/api/stateful.md
@@ -17,27 +17,28 @@ Use cases:
 - Something like [`equinox.experimental.BatchNorm`][], for which we would like to save the running statistics as a side-effect.
 - Implicitly passing information between loop iterations -- i.e. rather than explicitly via the `carry` argument to `lax.scan`. Perhaps you're using a third-party library that handles the `lax.scan`, that doesn't allow you pass your own information between iterations.
 
-Example:
-```python
-import equinox as eqx
-import jax
-import jax.lax as lax
-import jax.numpy as jnp
+!!! example
 
-index = eqx.experimental.StateIndex()
-init = jnp.array(0)
-eqx.experimental.set_state(index, init)
+    ```python
+    import equinox as eqx
+    import jax
+    import jax.lax as lax
+    import jax.numpy as jnp
 
-@jax.jit
-def scan_fun(_, __):
-    val = eqx.experimental.get_state(index, like=init)
-    val = val + 1
-    eqx.experimental.set_state(index, val)
-    return None, val
+    index = eqx.experimental.StateIndex()
+    init = jnp.array(0)
+    eqx.experimental.set_state(index, init)
 
-_, out = lax.scan(scan_fun, None, xs=None, length=5)
-print(out)  # [1 2 3 4 5]
-```
+    @jax.jit
+    def scan_fun(_, __):
+        val = eqx.experimental.get_state(index, like=init)
+        val = val + 1
+        eqx.experimental.set_state(index, val)
+        return None, val
+
+    _, out = lax.scan(scan_fun, None, xs=None, length=5)
+    print(out)  # [1 2 3 4 5]
+    ```
 
 ---
 

--- a/docs/api/stateful.md
+++ b/docs/api/stateful.md
@@ -6,6 +6,8 @@ These operations can be used to introduce save/load JAX arrays as a side-effect 
 
     This is considered experimental.
 
+    Stateful operations will not produce correct results under `jax.checkpoint` or `jax.pmap`.
+
 !!! danger
 
     Really, **this is experimental**. Side effects can easily make your code do something unexpected. Whatever you're doing, you almost certainly do not need this.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -37,11 +37,11 @@ Recall that in Equinox, models are PyTrees. Meanwhile, JAX treats all PyTrees as
 
 The resolution is simple: just don't store the same object in multiple places in the PyTree.
 
-## I cannot feed higher-order tensors (e.g. with batch dimensions) into my model.
+## How do I input higher-order tensors (e.g. with batch dimensions) into my model?
 
-Use [`jax.vmap`](https://jax.readthedocs.io/en/latest/_autosummary/jax.vmap.html#jax.vmap). This maps arbitrary JAX operations -- including any Equinox module -- over additional dimensions.
+Use [`jax.vmap`](https://jax.readthedocs.io/en/latest/_autosummary/jax.vmap.html#jax.vmap). This maps arbitrary JAX operations -- including any Equinox module -- over additional dimensions (such as batch dimensions).
 
-For example if `x` is an array/tensor of shape `(batch_size, input_size)`, the following code in PyTorch:
+For example if `x` is an array/tensor of shape `(batch_size, input_size)`, then the following PyTorch code:
 
 ```python
 import torch
@@ -50,8 +50,7 @@ linear = torch.nn.Linear(input_size, output_size)
 y = linear(x)
 ```
 
-is equivalent to the following code in Equinox:
-
+is equivalent to the following Equinox code:
 ```python
 import jax
 import equinox as eqx

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,7 +4,7 @@ mkdocs-material==7.3.6   # Theme
 pymdown-extensions==9.1  # Markdown extensions e.g. to handle LaTeX.
 mkdocstrings==0.17.0     # Autogenerate documentation from docstrings.
 mknotebooks==0.7.1       # Turn Jupyter Lab notebooks into webpages.
-pytkdocs_tweaks==0.0.4   # Tweaks mkdocstrings to improve various aspects
+pytkdocs_tweaks==0.0.5   # Tweaks mkdocstrings to improve various aspects
 mkdocs_include_exclude_files==0.0.1  # Tweak which files are included/excluded
 jinja2==3.0.3            # Older version. After 3.1.0 seems to be incompatible with current versions of mkdocstrings.
 

--- a/equinox/__init__.py
+++ b/equinox/__init__.py
@@ -14,6 +14,7 @@ from .module import Module, static_field
 from .pretty_print import tree_pformat
 from .tree import tree_at, tree_equal, tree_inference
 from .update import apply_updates
+from .vmap_pmap import filter_pmap, filter_vmap
 
 
 __version__ = "0.4.0"

--- a/equinox/__init__.py
+++ b/equinox/__init__.py
@@ -12,7 +12,7 @@ from .grad import filter_custom_vjp, filter_grad, filter_value_and_grad
 from .jit import filter_jit
 from .module import Module, static_field
 from .pretty_print import tree_pformat
-from .tree import tree_at, tree_equal
+from .tree import tree_at, tree_equal, tree_inference
 from .update import apply_updates
 
 

--- a/equinox/compile_utils.py
+++ b/equinox/compile_utils.py
@@ -29,3 +29,18 @@ def strip_wrapped_partial(fun):
     if isinstance(fun, ft.partial):
         return strip_wrapped_partial(fun.func)
     return fun
+
+
+def compile_cache(fun):
+    @ft.lru_cache(maxsize=None)
+    def _cache(leaves, treedef):
+        args, kwargs = jax.tree_unflatten(treedef, leaves)
+        return fun(*args, **kwargs)
+
+    @ft.wraps(fun)
+    def _fun(*args, **kwargs):
+        leaves, treedef = jax.tree_flatten((args, kwargs))
+        leaves = tuple(leaves)
+        return _cache(leaves, treedef)
+
+    return _fun

--- a/equinox/compile_utils.py
+++ b/equinox/compile_utils.py
@@ -1,0 +1,31 @@
+import functools as ft
+from typing import Any
+
+import jax
+
+from .filters import combine, partition
+from .module import Module, static_field
+
+
+def hashable_partition(pytree, filter_spec):
+    dynamic, static = partition(pytree, filter_spec)
+    static_leaves, static_treedef = jax.tree_flatten(static)
+    static_leaves = tuple(static_leaves)
+    return dynamic, static_leaves, static_treedef
+
+
+def hashable_combine(dynamic, static_leaves, static_treedef):
+    static = jax.tree_unflatten(static_treedef, static_leaves)
+    return combine(dynamic, static)
+
+
+class Static(Module):
+    value: Any = static_field()
+
+
+def strip_wrapped_partial(fun):
+    if hasattr(fun, "__wrapped__"):  # ft.wraps
+        return strip_wrapped_partial(fun.__wrapped__)
+    if isinstance(fun, ft.partial):
+        return strip_wrapped_partial(fun.func)
+    return fun

--- a/equinox/custom_types.py
+++ b/equinox/custom_types.py
@@ -1,8 +1,10 @@
 import inspect
 import typing
-from typing import Generic, Tuple, TypeVar, Union
+from typing import Any, Callable, Generic, Tuple, TypeVar, Union
 
 import jax
+
+from .doc_utils import WithRepr
 
 
 # Custom flag we set when generating documentation.
@@ -94,6 +96,8 @@ if getattr(typing, "GENERATING_DOCUMENTATION", False):
     Array.__module__ = "builtins"
     PyTree.__module__ = "builtins"
 
+    sentinel = WithRepr("sentinel")
+
 else:
 
     class Array:
@@ -104,5 +108,10 @@ else:
         def __class_getitem__(cls, item):
             return PyTree
 
+    sentinel = object()
+
 
 TreeDef = type(jax.tree_structure(0))
+
+ResolvedBoolAxisSpec = bool
+BoolAxisSpec = Union[ResolvedBoolAxisSpec, Callable[[Any], ResolvedBoolAxisSpec]]

--- a/equinox/doc_utils.py
+++ b/equinox/doc_utils.py
@@ -10,20 +10,6 @@ class WithRepr:
         return self.string
 
 
-if getattr(typing, "GENERATING_DOCUMENTATION", False):
-
-    def doc_fn(fn: FunctionType) -> WithRepr:
-        name = fn.__name__
-        if name.startswith("_"):
-            name = name[1:]
-        return WithRepr(f"<function {name}>")
-
-else:
-
-    def doc_fn(fn: FunctionType) -> FunctionType:
-        return fn
-
-
 def doc_strip_annotations(fn: FunctionType) -> FunctionType:
     if getattr(typing, "GENERATING_DOCUMENTATION", False):
         fn.__annotations__ = None

--- a/equinox/doc_utils.py
+++ b/equinox/doc_utils.py
@@ -1,0 +1,30 @@
+import typing
+from types import FunctionType
+
+
+class WithRepr:
+    def __init__(self, string):
+        self.string = string
+
+    def __repr__(self):
+        return self.string
+
+
+if getattr(typing, "GENERATING_DOCUMENTATION", False):
+
+    def doc_fn(fn: FunctionType) -> WithRepr:
+        name = fn.__name__
+        if name.startswith("_"):
+            name = name[1:]
+        return WithRepr(f"<function {name}>")
+
+else:
+
+    def doc_fn(fn: FunctionType) -> FunctionType:
+        return fn
+
+
+def doc_strip_annotations(fn: FunctionType) -> FunctionType:
+    if getattr(typing, "GENERATING_DOCUMENTATION", False):
+        fn.__annotations__ = None
+    return fn

--- a/equinox/experimental/__init__.py
+++ b/equinox/experimental/__init__.py
@@ -1,3 +1,4 @@
 from .batch_norm import BatchNorm
 from .spectral_norm import SpectralNorm
 from .stateful import get_state, set_state, StateIndex
+from .vmap_pmap import filter_pmap, filter_vmap

--- a/equinox/experimental/__init__.py
+++ b/equinox/experimental/__init__.py
@@ -1,4 +1,3 @@
 from .batch_norm import BatchNorm
 from .spectral_norm import SpectralNorm
 from .stateful import get_state, set_state, StateIndex
-from .vmap_pmap import filter_pmap, filter_vmap

--- a/equinox/experimental/batch_norm.py
+++ b/equinox/experimental/batch_norm.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, Sequence, Union
 
 import jax
 import jax.lax as lax
@@ -60,7 +60,7 @@ class BatchNorm(Module):
     bias: Optional[Array["input_size"]]
     first_time_index: StateIndex
     state_index: StateIndex
-    axis_name: str
+    axis_name: Union[str, Sequence[str]]
     inference: bool
     input_size: int = static_field()
     eps: float = static_field()
@@ -81,7 +81,8 @@ class BatchNorm(Module):
 
         - `input_size`: The number of channels in the input array.
         - `axis_name`: The name of the batch axis to compute statistics over, as passed
-            to `axis_name` in `jax.vmap` or `jax.pmap`.
+            to `axis_name` in `jax.vmap` or `jax.pmap`. Can also be a sequence (tuple,
+            list) of strings to compute statistics over multiple named axes.
         - `eps`: Value added to the denominator for numerical stability.
         - `channelwise_affine`: Whether the module has learnable channel-wise affine
             parameters.

--- a/equinox/experimental/stateful.py
+++ b/equinox/experimental/stateful.py
@@ -77,7 +77,7 @@ class StateIndex(Module):
     !!! warning
 
         You should not modify the `inference` flag whilst inside a JIT region. For
-        example, the following will produced undesired behaviour:
+        example, the following will produced undefined behaviour:
 
         ```python
         @jax.jit

--- a/equinox/experimental/vmap_pmap.py
+++ b/equinox/experimental/vmap_pmap.py
@@ -1,0 +1,390 @@
+import functools as ft
+import inspect
+from typing import Any, Callable, Union
+
+import jax
+import jax.interpreters.batching as batching
+
+from ..compile_utils import (
+    hashable_combine,
+    hashable_partition,
+    Static,
+    strip_wrapped_partial,
+)
+from ..custom_types import BoolAxisSpec, PyTree, ResolvedBoolAxisSpec, sentinel
+from ..doc_utils import doc_fn, doc_strip_annotations
+from ..filters import combine, is_array, partition
+
+
+ResolvedMapAxisSpec = Union[None, int]
+MapAxisSpec = Union[ResolvedMapAxisSpec, Callable[[Any], ResolvedMapAxisSpec]]
+#
+ResolvedAxisSpec = Union[ResolvedBoolAxisSpec, ResolvedMapAxisSpec]
+AxisSpec = Union[ResolvedAxisSpec, Callable[[Any], ResolvedAxisSpec]]
+
+
+def _is_none(x: Any) -> bool:
+    return x is None
+
+
+def _resolve_axis(axis_spec: AxisSpec, elem: Any) -> PyTree[ResolvedAxisSpec]:
+    if axis_spec is None or isinstance(axis_spec, (bool, int)):
+        return axis_spec
+    if callable(axis_spec):
+        return jax.tree_map(axis_spec, elem)
+    else:
+        raise ValueError(
+            "`in_axes` and `out_axes` must consist of None, bools, ints, and callables only."
+        )
+
+
+def _resolve_axes(
+    pytree: PyTree[Any], axes_spec: PyTree[AxisSpec]
+) -> PyTree[ResolvedAxisSpec]:
+    return jax.tree_map(_resolve_axis, axes_spec, pytree, is_leaf=_is_none)
+
+
+def _jit_axis(axis: ResolvedAxisSpec) -> BoolAxisSpec:  # not necessarily resolved
+    if isinstance(axis, bool):
+        return axis
+    elif isinstance(axis, int):
+        return True
+    elif axis is None:
+        return is_array
+    else:
+        assert False
+
+
+def _map_axis(axis: ResolvedAxisSpec) -> ResolvedMapAxisSpec:
+    if isinstance(axis, bool):
+        return None
+    elif isinstance(axis, int):
+        return axis
+    elif axis is None:
+        return None
+    else:
+        assert False
+
+
+def _jit_axes(axes: PyTree[ResolvedAxisSpec]) -> PyTree[BoolAxisSpec]:
+    return jax.tree_map(_jit_axis, axes, is_leaf=_is_none)
+
+
+def _map_axes(axes: PyTree[ResolvedAxisSpec]) -> PyTree[ResolvedMapAxisSpec]:
+    return jax.tree_map(_map_axis, axes, is_leaf=_is_none)
+
+
+class _VmapFilter:
+    def __init__(self, axis: AxisSpec):
+        self.axis = axis
+
+
+_have_monkey_patched = False
+
+
+def _monkey_patch():
+    global _have_monkey_patched
+    if not _have_monkey_patched:
+        _have_monkey_patched = True
+
+        _old_from_elt = batching.from_elt
+
+        def from_elt(trace, axis_size, x, spec):
+            if isinstance(spec, _VmapFilter):
+                spec = _resolve_axis(spec.axis, x)
+                spec = _map_axis(spec)
+            return _old_from_elt(trace, axis_size, x, spec)
+
+        batching.from_elt = from_elt
+        batching.spec_types.add(_VmapFilter)
+
+
+def _zero_if_array_else_none(x: Any) -> ResolvedMapAxisSpec:
+    return 0 if is_array(x) else None
+
+
+# Note the use of AxisSpec rather than MapAxisSpec.
+# This is to support seamlessly switching out filter_pmap for filter_vmap.
+@doc_strip_annotations
+def filter_vmap(
+    fun: Callable = sentinel,
+    *,
+    default: AxisSpec = doc_fn(_zero_if_array_else_none),
+    fn: PyTree[AxisSpec] = None,
+    args: PyTree[AxisSpec] = (),
+    kwargs: PyTree[AxisSpec] = None,
+    out: PyTree[AxisSpec] = doc_fn(_zero_if_array_else_none),
+    **vmapkwargs
+) -> Callable:
+    """Wraps together [`equinox.partition`][] and `jax.vmap`.
+
+    **Arguments:**
+
+    For all of `args`, `kwargs`, `out`, `fn`, then each leaf should either be a value of
+    type `Union[None, int]` or a function `Leaf -> Union[None, int]`.
+
+    For all of `default`, `args,` `kwargs`, `out`, `fn`, then integers specify which
+    array axis to vectorise over. `None` specifies not to vectorise over any axis.
+    (These follow the same behaviour as `jax.vmap(in_axes=..., out_axes=...)`.)
+
+    - `fun` is a pure function to vectorise.
+    - `default` should be a value of type `Union[None, int]` or a function
+        `Leaf -> Union[None, int]` that will be called on every leaf of every input to
+        the function.
+    - `args` and `kwargs` are optional per-argument and per-keyword-argument overrides
+        for `default`. These should be PyTrees whose structures are a prefix of the
+        inputs to `fun`.
+    - `out` is a PyTree whose structure should be a prefix of the structure of the
+        outputs of `fun`.
+    - `fn` is a PyTree whose structure should be a prefix of the function `fun` itself.
+        (So that `fun` may be any callable -- such as a bound method, or a class
+        implementing `__call__` -- and not necessarily just a normal Python function.)
+    - `**vmapkwargs` are any other keyword arguments to `jax.vmap`.
+
+    Where `args`, `kwargs`, `out`, `fn` are prefixes of the corresponding input, their
+    value will be mapped over the input PyTree.
+
+    **Returns:**
+
+    The vectorised version of `fun`.
+
+    !!! info
+
+        By default, all JAX arrays are vectorised down their leading axis (i.e. axis
+        index 0), and all other types are not vectorised.
+
+        (Indeed only JAX arrays may be either vectorised or non-vectorised; all other
+        types must always by non-vectorised.)
+
+    !!! info
+
+        In fact, besides `None`, `int` and `Leaf -> Union[None, int]`, then boolean
+        types are also supported, and treated identical to `None`. This is to support
+        seamlessly switching out [`equinox.experimental.filter_pmap`][] for
+        [`equinox.experimental.filter_vmap`][] if desired.
+
+    !!! example
+
+        ```python
+        import equinox.experimental as eqxe
+        import jax.numpy as jnp
+
+        @eqxe.filter_vmap
+        def f(x, y):
+            return x + y
+
+        @eqxe.filter_vmap(kwargs=dict(x=1))
+        def g(x, y):
+            return x + y
+
+        @eqxe.filter_vmap(args=(None,))
+        def h(x, y):
+            return x + y
+
+        f(jnp.array([1, 2]), jnp.array([3, 4]))  # both args vectorised down axis 0
+        f(jnp.array([1, 2]), 3)  # first arg vectorised down axis 0
+                                 # second arg broadcasted
+        g(jnp.array([[1, 2]]), jnp.array([3, 4]))  # first arg vectorised down axis 1
+                                                   # second arg vectorised down axis 0
+        h(jnp.array(1), jnp.array([2, 3]))  # first arg broadcasted
+                                            # second arg vectorised down axis 0
+        ```
+
+    !!! example
+
+        `filter_vmap` can be used to easily create ensembles of models. For example, here's an
+        ensemble of eight MLPs:
+
+        ```python
+        import equinox as eqx
+        import equinox.experimental as eqxe
+        import jax.random as jr
+
+        key = jr.PRNGKey(0)
+        keys = jr.split(key, 8)
+
+        # Create an ensemble of models
+
+        @eqxe.filter_vmap
+        def make_ensemble(key):
+            return eqx.nn.MLP(2, 2, 2, 2, key=key)
+
+        mlp_ensemble = make_ensemble(keys)
+
+        # Evaluate each member of the ensemble on the same data
+
+        @eqxe.filter_vmap(kwargs=dict(x=None))
+        def evaluate_ensemble(model, x):
+            return model(x)
+
+        evaluate_ensemble(mlp_ensemble, jr.normal(key, (2,)))
+
+        # Evaluate each member of the ensemble on different data
+
+        @eqxe.filter_vmap
+        def evaluate_per_ensemble(model, x):
+            return model(x)
+
+        evaluate_per_ensemble(mlp_ensemble, jr.normal(key, (8, 2)))
+        ```
+
+        Here, `make_ensemble` works because [`equinox.nn.MLP`][] is a PyTree, and so it
+        is a valid output from a `filter_vmap`. This PyTree includes some JAX arrays
+        (the weights and biases) and some non-JAX-arrays (e.g. activation functions).
+        `filter_vmap` will vectorise the JAX arrays (with separate weights for each
+        member of the ensemble) whilst leaving the non-JAX-arrays alone.
+
+        Note that as the weights in `mlp_ensemble` now have a leading batch dimension
+        -- that the weights of `eqx.nn.MLP` instances do not typically have -- then it
+        cannot be called directly. It must instead be passed back into a vectorised
+        region to be called.
+    """
+
+    _monkey_patch()
+
+    if fun is sentinel:
+        return ft.partial(
+            filter_vmap,
+            default=default,
+            fn=fn,
+            args=args,
+            kwargs=kwargs,
+            out=out,
+            **vmapkwargs
+        )
+
+    if kwargs is None:
+        kwargs = {}
+
+    signature = inspect.signature(fun)
+
+    signature_default = signature.replace(
+        parameters=[p.replace(default=default) for p in signature.parameters.values()]
+    )
+    bound = signature_default.bind_partial(*args, **kwargs)
+    bound.apply_defaults()
+
+    def _fun_wrapper(_fun, _args, _kwargs):
+        result = _fun(*_args, **_kwargs)
+        out_axes = _resolve_axes(result, out)
+        out_axes = _map_axes(out_axes)
+        out_axes_is_none = jax.tree_map(_is_none, out_axes, is_leaf=_is_none)
+        nonvmapd, vmapd = partition(result, out_axes_is_none)
+        return vmapd, Static(nonvmapd)
+
+    @ft.wraps(fun)
+    def fun_wrapper(*_args, **_kwargs):
+        _bound = signature.bind(*_args, **_kwargs)
+        in_axes = _resolve_axes(
+            (fun, _bound.args, _bound.kwargs), (fn, bound.args, bound.kwargs)
+        )
+        in_axes = _map_axes(in_axes)
+        out_axes = (jax.tree_map(_VmapFilter, out), None)
+        vmapd, nonvmapd = jax.vmap(
+            _fun_wrapper, in_axes=in_axes, out_axes=out_axes, **vmapkwargs
+        )(fun, _bound.args, _bound.kwargs)
+        return combine(vmapd, nonvmapd.value)
+
+    return fun_wrapper
+
+
+@ft.lru_cache(maxsize=None)
+def _filter_pmap_cache(unwrapped_fun_treedef, unwrapped_fun_leaves, **pmapkwargs):
+    unwrapped_fun = jax.tree_unflatten(unwrapped_fun_treedef, unwrapped_fun_leaves)
+
+    @ft.partial(jax.pmap, **pmapkwargs)
+    @ft.wraps(unwrapped_fun)
+    def fun_wrapped(dynamic, static_leaves, static_treedef, jit_out_axes):
+        _fun, _args, _kwargs = hashable_combine(dynamic, static_leaves, static_treedef)
+        _out = _fun(*_args, **_kwargs)
+        _dynamic, _static = partition(_out, jit_out_axes)
+        return _dynamic, Static(_static)
+
+    return fun_wrapped
+
+
+@doc_strip_annotations
+def filter_pmap(
+    fun: Callable = sentinel,
+    axis_name=None,
+    *,
+    default: AxisSpec = doc_fn(_zero_if_array_else_none),
+    fn: PyTree[AxisSpec] = None,
+    args: PyTree[AxisSpec] = (),
+    kwargs: PyTree[AxisSpec] = None,
+    out: PyTree[AxisSpec] = 0,
+    **pmapkwargs
+) -> Callable:
+
+    if fun is sentinel:
+        return ft.partial(
+            filter_vmap,
+            axis_name=axis_name,
+            default=default,
+            fn=fn,
+            args=args,
+            kwargs=kwargs,
+            out=out,
+            **pmapkwargs
+        )
+
+    if kwargs is None:
+        kwargs = {}
+
+    signature = inspect.signature(fun)
+
+    signature_default = signature.replace(
+        parameters=[p.replace(default=default) for p in signature.parameters.values()]
+    )
+    bound = signature_default.bind_partial(*args, **kwargs)
+    bound.apply_defaults()
+
+    _, unwrapped_fun_leaves, unwrapped_fun_treedef = hashable_partition(
+        strip_wrapped_partial(fun), fn
+    )
+
+    def _fun_wrapper(is_lower, _args, _kwargs):
+        _bound = signature.bind(*_args, **_kwargs)
+        in_axes = _resolve_axes(
+            (fun, _bound.args, _bound.kwargs), (fn, bound.args, bound.kwargs)
+        )
+        jit_in_axes = _jit_axes(in_axes)
+        map_in_axes = _map_axes(in_axes)
+        if any(callable(o) for o in jax.tree_leaves(out)):
+            # In practice we demand `out` be of type `PyTree[ResolvedAxisSpec]`.
+            raise NotImplementedError(
+                "`filter_pmap(out_axes=...)` does not support filter functions (only None, bool, int)"
+            )
+        jit_out_axes = _jit_axes(out)
+        map_out_axes = _map_axes(out)
+
+        cached = _filter_pmap_cache(
+            unwrapped_fun_treedef,
+            unwrapped_fun_leaves,
+            in_axes=(map_in_axes, None, None),
+            out_axes=(map_out_axes, None),
+            static_broadcasted_argnums=(1, 2, 3),
+            **pmapkwargs
+        )
+
+        dynamic, static_leaves, static_treedef = hashable_partition(
+            (fun, _bound.args, _bound.kwargs), jit_in_axes
+        )
+        if is_lower:
+            return cached.lower(dynamic, static_leaves, static_treedef, jit_out_axes)
+        else:
+            dynamic_out, static_out = cached(
+                dynamic, static_leaves, static_treedef, jit_out_axes
+            )
+            return combine(dynamic_out, static_out.value)
+
+    @ft.wraps(fun)
+    def fun_wrapper(*_args, **_kwargs):
+        return _fun_wrapper(False, _args, _kwargs)
+
+    def lower(*_args, **_kwargs):
+        return _fun_wrapper(True, _args, _kwargs)
+
+    fun_wrapper.lower = lower
+
+    return fun_wrapper

--- a/equinox/filters.py
+++ b/equinox/filters.py
@@ -52,7 +52,7 @@ def is_inexact_array_like(element: Any) -> bool:
 
 def _make_filter_tree(mask: BoolAxisSpec, arg: Any) -> ResolvedBoolAxisSpec:
     if isinstance(mask, bool):
-        return mask
+        return jax.tree_map(lambda _: mask, arg)
     elif callable(mask):
         return jax.tree_map(mask, arg)
     else:

--- a/equinox/grad.py
+++ b/equinox/grad.py
@@ -7,7 +7,7 @@ from typing import Callable
 import jax
 
 from .custom_types import BoolAxisSpec, PyTree, sentinel
-from .doc_utils import doc_fn, doc_strip_annotations
+from .doc_utils import doc_strip_annotations
 from .filters import combine, is_array, is_inexact_array, partition
 
 
@@ -15,7 +15,7 @@ from .filters import combine, is_array, is_inexact_array, partition
 def filter_value_and_grad(
     fun: Callable = sentinel,
     *,
-    arg: PyTree[BoolAxisSpec] = doc_fn(is_inexact_array),
+    arg: PyTree[BoolAxisSpec] = is_inexact_array,
     **gradkwargs,
 ) -> Callable:
     """As [`equinox.filter_grad`][], except that it is `jax.value_and_grad` that is
@@ -55,7 +55,7 @@ def filter_value_and_grad(
 def filter_grad(
     fun: Callable = sentinel,
     *,
-    arg: PyTree[BoolAxisSpec] = doc_fn(is_inexact_array),
+    arg: PyTree[BoolAxisSpec] = is_inexact_array,
     **gradkwargs,
 ):
     """Wraps together [`equinox.partition`][] and `jax.grad`.

--- a/equinox/grad.py
+++ b/equinox/grad.py
@@ -28,6 +28,11 @@ class _ValueAndGradWrapper(Module):
         diff_x, nondiff_x = partition(__x, __self._arg)
         return fun_value_and_grad(diff_x, nondiff_x, *args, **kwargs)
 
+    def __get__(self, instance, owner):
+        if instance is None:
+            return self
+        return jax.tree_util.Partial(self, instance)
+
 
 class _GradWrapper(Module):
     _fun_value_and_grad: _ValueAndGradWrapper
@@ -40,6 +45,11 @@ class _GradWrapper(Module):
             return grad, aux
         else:
             return grad
+
+    def __get__(self, instance, owner):
+        if instance is None:
+            return self
+        return jax.tree_util.Partial(self, instance)
 
 
 @doc_strip_annotations

--- a/equinox/grad.py
+++ b/equinox/grad.py
@@ -81,7 +81,7 @@ def filter_grad(
         An important special case is to trace all inexact (i.e. floating point)
         JAX arrays and treat all other objects as nondifferentiable.
 
-        This is accomplished with `arg=equinox.is_inexact_array`, which is the
+        This is accomplished with [`equinox.is_inexact_array`][], which is the
         default.
 
     !!! tip

--- a/equinox/jit.py
+++ b/equinox/jit.py
@@ -95,6 +95,11 @@ class _JitWrapper(Module):
     def lower(__self, *args, **kwargs):
         return __self._fun_wrapper(True, args, kwargs)
 
+    def __get__(self, instance, owner):
+        if instance is None:
+            return self
+        return jax.tree_util.Partial(self, instance)
+
 
 @doc_strip_annotations
 def filter_jit(

--- a/equinox/jit.py
+++ b/equinox/jit.py
@@ -1,4 +1,6 @@
 import functools as ft
+import inspect
+import warnings
 from typing import Any
 
 import jax
@@ -7,26 +9,49 @@ from .filters import combine, is_array, partition
 from .module import Module, static_field
 
 
+def _hashable_partition(pytree, filter_spec):
+    dynamic, static = partition(pytree, filter_spec)
+    static_leaves, static_treedef = jax.tree_flatten(static)
+    static_leaves = tuple(static_leaves)
+    return dynamic, static_leaves, static_treedef
+
+
+def _hashable_combine(dynamic, static_leaves, static_treedef):
+    static = jax.tree_unflatten(static_treedef, static_leaves)
+    return combine(dynamic, static)
+
+
 class _Static(Module):
     value: Any = static_field()
 
 
 @ft.lru_cache(maxsize=None)
-def _f_wrapped_cache(fun, **jitkwargs):
-    @ft.partial(jax.jit, static_argnums=(1, 2, 3), **jitkwargs)
-    @ft.wraps(fun)
-    def f_wrapped(dynamic, static_treedef, static_leaves, filter_spec_return):
-        static = jax.tree_unflatten(static_treedef, static_leaves)
-        f, args, kwargs = combine(dynamic, static)
-        out = f(*args, **kwargs)
-        dynamic_out, static_out = partition(out, filter_spec_return)
+def _filter_jit_cache(unwrapped_fun_treedef, unwrapped_fun_leaves, **jitkwargs):
+    unwrapped_fun = jax.tree_unflatten(unwrapped_fun_treedef, unwrapped_fun_leaves)
+
+    @ft.partial(jax.jit, static_argnums=1, **jitkwargs)
+    @ft.wraps(unwrapped_fun)
+    def fun_wrapped(dynamic, static):
+        dynamic_fun, dynamic_spec = dynamic
+        (
+            static_fun_treedef,
+            static_fun_leaves,
+            static_spec_treedef,
+            static_spec_leaves,
+            filter_out,
+        ) = static
+        fun = _hashable_combine(dynamic_fun, static_fun_leaves, static_fun_treedef)
+        args, kwargs = _hashable_combine(
+            dynamic_spec, static_spec_leaves, static_spec_treedef
+        )
+        out = fun(*args, **kwargs)
+        dynamic_out, static_out = partition(out, filter_out)
         return dynamic_out, _Static(static_out)
 
-    return f_wrapped
+    return fun_wrapped
 
 
 def _strip_wrapped_partial(fun):
-    """Preserve the outermost wraps call's docstring or traverse to the inner function"""
     if hasattr(fun, "__wrapped__"):  # ft.wraps
         return _strip_wrapped_partial(fun.__wrapped__)
     if isinstance(fun, ft.partial):
@@ -34,22 +59,22 @@ def _strip_wrapped_partial(fun):
     return fun
 
 
-def _process_args(args, kwargs, dynamic_fun, static_fun, filter_spec):
-    dynamic_args_kwargs, static_args_kwargs = partition((args, kwargs), filter_spec)
-    dynamic = (dynamic_fun,) + dynamic_args_kwargs
-    static = (static_fun,) + static_args_kwargs
-    static_leaves, static_treedef = jax.tree_flatten(static)
-    static_leaves = tuple(static_leaves)
-    inner_fun = _strip_wrapped_partial(static_fun)
-    return inner_fun, dynamic, static_treedef, static_leaves
+_sentinel = object()
 
 
 def filter_jit(
-    fun,
+    fun=_sentinel,
     *,
+    default=is_array,
+    fn=is_array,
+    args=(),
+    kwargs=None,
+    out=is_array,
+    # Backward compatibility
     filter_spec=is_array,
     filter_spec_return=is_array,
     filter_spec_fun=is_array,
+    # ~Backward compatibility
     **jitkwargs
 ):
     """Wraps together [`equinox.partition`][] and `jax.jit`.
@@ -57,25 +82,24 @@ def filter_jit(
     **Arguments:**
 
     - `fun` is a pure function to JIT compile.
-    - `filter_spec` is a PyTree whose structure should be a prefix of the structure of
-        the inputs to `fun`. It behaves as the `filter_spec` argument to
-        [`equinox.filter`][]. Truthy values will be traced; falsey values will be held
+    - `default` should be function `Leaf -> bool` that will be called on every leaf of
+        every input to the function. Truthy values will be traced; falsey values will
+        be held static.
+    - `args` and `kwargs` are optional per-argument and per-keyword-argument overrides
+        for `default`. These should be PyTrees whose structures are a prefix of the
+        inputs to `fun`. It behaves as the `filter_spec` argument to
+        [`equinox.filter`][]; truthy values will be traced; falsey values will be held
         static.
-    - `filter_spec_return` is a PyTree whose structure should be a prefix of the
+    - `out` is a PyTree whose structure should be a prefix of the
         structure of the outputs of `fun`. It behaves as the `filter_spec` argument to
         [`equinox.filter`][]. Truthy values should be tracers; falsey values are any
         (non-tracer) auxiliary information to return.
-    - `filter_spec_fun` is a PyTree whose structure should be a prefix of `fun` itself.
-        (Note that `fun` may be any callable -- e.g. a bound method, or a class
-        implementing `__call__` -- and not necessarily only a function.) It behaves as
-        the `filter_spec` argument to [`equinox.filter`][]. Truthy values will be
-        traced; falsey values will be held static.
+    - `fn` is a PyTree whose structure should be a prefix of the function `fun` itself.
+        It behaves as the `filter_spec` argument to [`equinox.filter`][]. Truthy values
+        will be traced; falsey values will be held static. (So that `fun` may be any
+        callable -- such as a bound method, or a class implementing `__call__` -- and
+        not necessarily just a normal Python function.)
     - `**jitkwargs` are any other keyword arguments to `jax.jit`.
-
-        !!! info
-
-            Specifically, if calling `fun(*args, **kwargs)`, then `filter_spec` must
-            have a structure which is a prefix for `(args, kwrgs)`.
 
     **Returns:**
 
@@ -83,12 +107,53 @@ def filter_jit(
 
     !!! info
 
-        A very important special case is to trace all JAX arrays and treat all other
-        objects as static.
-
-        This is accomplished with `filter_spec=equinox.is_array`, which is the default.
+        The most common case is to trace all JAX arrays and treat all other objects as
+        static. This is accomplished with `equinox.is_array`, which is the default.
         (It is relatively unusual to need different behaviour to this.)
+
+    !!! example
+
+        ```python
+        @eqx.filter_jit
+        def f(x, y):  # both args traced if arrays, static if non-arrays
+            return x + y
+
+        @eqx.filter_jit(kwargs=dict(x=False))
+        def g(x, y):  # x held static; y is traced if array, static if non-array
+            return x + y
+
+        @eqx.filter_jit(args=(True,))
+        def h(x):
+            return x
+
+        f(jnp.array(1), jnp.array(2))  # both args traced
+        f(jnp.array(1), 2)  # first arg traced, second arg static
+        f(1, 2)  # both args static
+
+        g(1, jnp.array(2))  # first arg static, second arg traced
+        g(1, 2)  # both args static
+
+        h(1)  # traced
+        h(jnp.array(1))  # traced
+        h("hi")  # not a trace-able JAX type, so error
+        ```
     """
+
+    if fun is _sentinel:
+        return ft.partial(
+            filter_jit,
+            default=default,
+            fn=fn,
+            args=args,
+            kwargs=kwargs,
+            out=out,
+            # Backward compatibility
+            filter_spec=filter_spec,
+            filter_spec_fun=filter_spec_fun,
+            filter_spec_return=filter_spec_return,
+            # ~Backward compatibility
+            **jitkwargs
+        )
 
     if any(
         x in jitkwargs for x in ("static_argnums", "static_argnames", "donate_argnums")
@@ -98,33 +163,98 @@ def filter_jit(
             "'donate_argnums'."
         )
 
-    # We choose not to make a distinction between ([arg, ..., arg], kwargs) and ((arg, ..., arg), kwargs)
-    if (
-        isinstance(filter_spec, tuple)
-        and len(filter_spec) == 2
-        and isinstance(filter_spec[0], list)
-    ):
-        filter_spec = (tuple(filter_spec[0]), filter_spec[1])
+    if kwargs is None:
+        kwargs = {}
 
-    dynamic_fun, static_fun = partition(fun, filter_spec_fun)
+    # Original names are to provide a nice API, but they're too ambiguous for the code.
+    filter_default = default
+    filter_fn = fn
+    filter_args = args
+    filter_kwargs = kwargs
+    filter_out = out
+    del default, fn, args, kwargs, out
+
+    signature = inspect.signature(fun)
+
+    # Backward compatibility
+    if any(
+        x is not is_array for x in (filter_spec, filter_spec_return, filter_spec_fun)
+    ):
+        # Old API
+
+        warnings.warn(
+            "`filter_spec` is deprecated in favour of the new `args`, `kwargs` interface."
+        )
+        if (
+            any(x is not is_array for x in (filter_default, filter_fn, filter_out))
+            or filter_args != ()
+            or filter_kwargs != {}
+        ):
+            raise ValueError(
+                "Cannot use deprecated `filter_spec` at the same time as the new `args`, `kwargs` interface."
+            )
+
+        # We choose not to make a distinction between ([arg, ..., arg], kwargs) and ((arg, ..., arg), kwargs)
+        if (
+            isinstance(filter_spec, tuple)
+            and len(filter_spec) == 2
+            and isinstance(filter_spec[0], list)
+        ):
+            filter_spec = (tuple(filter_spec[0]), filter_spec[1])
+
+        filter_fn = filter_spec_fun
+        filter_out = filter_spec_return
+        new_style = False
+    else:
+        # New API
+
+        signature_default = signature.replace(
+            parameters=[
+                p.replace(default=filter_default) for p in signature.parameters.values()
+            ]
+        )
+        filter_bound = signature_default.bind_partial(*filter_args, **filter_kwargs)
+        filter_bound.apply_defaults()
+        filter_spec = (filter_bound.args, filter_bound.kwargs)
+        new_style = True
+    # ~Backward compatibility
+
+    _, unwrapped_fun_leaves, unwrapped_fun_treedef = _hashable_partition(
+        _strip_wrapped_partial(fun), filter_fn
+    )
+    dynamic_fun, static_fun_leaves, static_fun_treedef = _hashable_partition(
+        fun, filter_fn
+    )
+    cached = _filter_jit_cache(unwrapped_fun_treedef, unwrapped_fun_leaves, **jitkwargs)
+
+    def _fun_wrapper(is_lower, args, kwargs):
+        if new_style:
+            bound = signature.bind(*args, **kwargs)
+            args = bound.args
+            kwargs = bound.kwargs
+        dynamic_spec, static_spec_leaves, static_spec_treedef = _hashable_partition(
+            (args, kwargs), filter_spec
+        )
+        dynamic = (dynamic_fun, dynamic_spec)
+        static = (
+            static_fun_treedef,
+            static_fun_leaves,
+            static_spec_treedef,
+            static_spec_leaves,
+            filter_out,
+        )
+        if is_lower:
+            return cached.lower(dynamic, static)
+        else:
+            dynamic_out, static_out = cached(dynamic, static)
+            return combine(dynamic_out, static_out.value)
 
     @ft.wraps(fun)
     def fun_wrapper(*args, **kwargs):
-        inner_fun, dynamic, static_treedef, static_leaves = _process_args(
-            args, kwargs, dynamic_fun, static_fun, filter_spec
-        )
-        dynamic_out, static_out = _f_wrapped_cache(inner_fun, **jitkwargs)(
-            dynamic, static_treedef, static_leaves, filter_spec_return
-        )
-        return combine(dynamic_out, static_out.value)
+        return _fun_wrapper(False, args, kwargs)
 
     def lower(*args, **kwargs):
-        inner_fun, dynamic, static_treedef, static_leaves = _process_args(
-            args, kwargs, dynamic_fun, static_fun, filter_spec
-        )
-        return _f_wrapped_cache(inner_fun, **jitkwargs).lower(
-            dynamic, static_treedef, static_leaves, filter_spec_return
-        )
+        return _fun_wrapper(True, args, kwargs)
 
     fun_wrapper.lower = lower
 

--- a/equinox/jit.py
+++ b/equinox/jit.py
@@ -56,39 +56,37 @@ class _JitWrapper(Module):
     _cached: FunctionType
 
     def _fun_wrapper(self, is_lower, args, kwargs):
-        if self.new_style:
-            bound = self.signature.bind(*args, **kwargs)
+        if self._new_style:
+            bound = self._signature.bind(*args, **kwargs)
             bound.apply_defaults()
             args = bound.args
             kwargs = bound.kwargs
-        if isinstance(self.filter_spec, tuple) and len(self.filter_spec) == 2:
-            filter_args, filter_kwargs = self.filter_spec
-            if isinstance(filter_args, tuple):
-                filter_args = filter_args + (self._filter_default,) * (
-                    len(args) - len(filter_args)
-                )
-            if isinstance(filter_kwargs, dict):
-                filter_kwargs = {
-                    key: filter_kwargs.get(key, self._filter_default) for key in kwargs
-                }
+
+            filter_args, filter_kwargs = self._filter_spec
+            filter_args = filter_args + (self._filter_default,) * (
+                len(args) - len(filter_args)
+            )
+            filter_kwargs = {
+                key: filter_kwargs.get(key, self._filter_default) for key in kwargs
+            }
             filter_spec = (filter_args, filter_kwargs)
         else:
-            filter_spec = self.filter_spec
+            filter_spec = self._filter_spec
         dynamic_spec, static_spec_leaves, static_spec_treedef = hashable_partition(
             (args, kwargs), filter_spec
         )
-        dynamic = (self.dynamic_fun, dynamic_spec)
+        dynamic = (self._dynamic_fun, dynamic_spec)
         static = (
-            self.static_fun_treedef,
-            self.static_fun_leaves,
+            self._static_fun_treedef,
+            self._static_fun_leaves,
             static_spec_treedef,
             static_spec_leaves,
-            self.filter_out,
+            self._filter_out,
         )
         if is_lower:
-            return self.cached.lower(dynamic, static)
+            return self._cached.lower(dynamic, static)
         else:
-            dynamic_out, static_out = self.cached(dynamic, static)
+            dynamic_out, static_out = self._cached(dynamic, static)
             return combine(dynamic_out, static_out.value)
 
     def __call__(__self, *args, **kwargs):

--- a/equinox/module.py
+++ b/equinox/module.py
@@ -277,7 +277,11 @@ def module_update_wrapper(wrapper: Module, wrapped) -> Module:
     initable_cls = _make_initable(cls, wraps=True)
     object.__setattr__(wrapper, "__class__", initable_cls)
     try:
-        ft.update_wrapper(wrapper, wrapped)
+        # updated = ("__dict__",) is the default, but that's a bit much.
+        # It's common/possible for wrapper and wrapped to both be classes
+        # implementing __call__, in which case copying __dict__ over basically
+        # just breaks the wrapper class.
+        ft.update_wrapper(wrapper, wrapped, updated=())
     finally:
         object.__setattr__(wrapper, "__class__", cls)
     return wrapper

--- a/equinox/module.py
+++ b/equinox/module.py
@@ -10,8 +10,9 @@ from .tree import tree_equal
 
 
 def static_field(**kwargs):
-    """Used for marking that a field should _not_ be treated as part of the PyTree
-    of a [`equinox.Module`][]. (And is instead just treated as extra metadata.)
+    """Used for marking that a field should _not_ be treated as a leaf of the PyTree
+    of a [`equinox.Module`][]. (And is instead treated as part of the structure, i.e.
+    as extra metadata.)
 
     !!! example
 
@@ -20,9 +21,10 @@ def static_field(**kwargs):
             normal_field: int
             static_field: int = equinox.static_field()
 
-        mymodule = MyModule()
+        mymodule = MyModule("normal", "static")
         leaves, treedef = jax.tree_flatten(mymodule)
-        assert len(leaves) == 1
+        assert leaves == ["normal"]
+        assert "static" in str(treedef)
         ```
 
     In practice this should rarely be used; it is usually preferential to just filter

--- a/equinox/nn/attention.py
+++ b/equinox/nn/attention.py
@@ -179,6 +179,7 @@ class MultiheadAttention(Module):
         ] = None,
         *,
         key: Optional["jax.random.PRNGKey"] = None,
+        inference: Optional[bool] = None,
         deterministic: Optional[bool] = None,
     ) -> Array["query_seq_length", "output_size"]:  # noqa: F821
         """**Arguments:**
@@ -193,8 +194,9 @@ class MultiheadAttention(Module):
             JAX array of shape `(num_heads, query_seq_length, kv_seq_length)`.
         - `key`: A `jax.random.PRNGKey` used for dropout. Unused if `dropout = 0`.
             (Keyword only argument.)
-        - `deterministic`: As [`equinox.nn.Dropout.__call__`][]. (Keyword only
+        - `inference`: As [`equinox.nn.Dropout.__call__`][]. (Keyword only
             argument.)
+        - `deterministic`: (Deprecated in favour of `inference`.)
 
         **Returns:**
 
@@ -224,7 +226,9 @@ class MultiheadAttention(Module):
             logits = jnp.where(mask, logits, -jnp.inf)
 
         weights = jax.nn.softmax(logits, axis=-1)
-        weights = self.dropout(weights, key=key, deterministic=deterministic)
+        weights = self.dropout(
+            weights, key=key, inference=inference, deterministic=deterministic
+        )
         attn = jnp.einsum("hsS,Shd->shd", weights, value_heads)
         attn = attn.reshape(query_seq_length, -1)
 

--- a/equinox/pretty_print.py
+++ b/equinox/pretty_print.py
@@ -189,7 +189,7 @@ def tree_pformat(
 
     !!! example
 
-       A 32-bit floating-point JAX array of shape `(3, 4)` is printed as `f32[3,4]`.
+        A 32-bit floating-point JAX array of shape `(3, 4)` is printed as `f32[3,4]`.
 
     **Arguments:**
 

--- a/equinox/tree.py
+++ b/equinox/tree.py
@@ -4,10 +4,8 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
-from .custom_types import PyTree
+from .custom_types import PyTree, sentinel
 
-
-_sentinel = object()
 
 _Leaf = Any
 
@@ -15,8 +13,8 @@ _Leaf = Any
 def tree_at(
     where: Callable[[PyTree], Union[_Leaf, Sequence[_Leaf]]],
     pytree: PyTree,
-    replace: Union[_Leaf, Sequence[_Leaf]] = _sentinel,
-    replace_fn: Callable[[_Leaf], _Leaf] = _sentinel,
+    replace: Union[_Leaf, Sequence[_Leaf]] = sentinel,
+    replace_fn: Callable[[_Leaf], _Leaf] = sentinel,
     is_leaf: Callable[[_Leaf], bool] = None,
 ) -> PyTree:
     """Updates a PyTree out-of-place; a bit like using `.at[].set()` on a JAX array.
@@ -63,13 +61,13 @@ def tree_at(
         ```
     """
 
-    if (replace is _sentinel and replace_fn is _sentinel) or (
-        replace is not _sentinel and replace_fn is not _sentinel
+    if (replace is sentinel and replace_fn is sentinel) or (
+        replace is not sentinel and replace_fn is not sentinel
     ):
         raise ValueError(
             "Precisely one of `replace` and `replace_fn` must be specified."
         )
-    elif replace is _sentinel:
+    elif replace is sentinel:
         replace_passed = False
         replacer = lambda j, i: replace_fn(flat[i])
     else:
@@ -177,14 +175,18 @@ def tree_inference(pytree: PyTree, value: bool) -> PyTree:
     equinox.tree_at(where, pytree, replace_fn=lambda _: value)
     ```
 
+    `inference` flags are used to toggle the behaviour of a number of the pre-built
+    neural network layers, such as [`equinox.nn.Dropout`][] or
+    [`equinox.experimental.BatchNorm`][].
+
     **Arguments:**
 
-        - `pytree`: the PyTree to modify.
-        - `value`: the value to set all `inference` attributes to.
+    - `pytree`: the PyTree to modify.
+    - `value`: the value to set all `inference` attributes to.
 
     **Returns:**
 
-    The new PyTree, of the same structure as `pytree`, with all `inference` flags set to `value`.
+    A copy of `pytree` with all `inference` flags set to `value`.
     """
 
     # For the sake of equinox.experimental.StateIndex. This won't defend against anyone

--- a/equinox/vmap_pmap.py
+++ b/equinox/vmap_pmap.py
@@ -141,6 +141,11 @@ class _VmapWrapper(Module):
         )(__self._fun, bound.args, bound.kwargs)
         return combine(vmapd, nonvmapd.value)
 
+    def __get__(self, instance, owner):
+        if instance is None:
+            return self
+        return jax.tree_util.Partial(self, instance)
+
 
 # Note the use of AxisSpec rather than MapAxisSpec.
 # This is to support seamlessly switching out filter_pmap for filter_vmap.
@@ -410,6 +415,11 @@ class _PmapWrapper(Module):
 
     def lower(__self, *args, **kwargs):
         return __self._fun_wrapper(True, args, kwargs)
+
+    def __get__(self, instance, owner):
+        if instance is None:
+            return self
+        return jax.tree_util.Partial(self, instance)
 
 
 @doc_strip_annotations

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,21 @@
+import functools as ft
+import operator
+
+import jax
+import jax.numpy as jnp
+
+
+def _shaped_allclose(x, y, **kwargs):
+    return jnp.shape(x) == jnp.shape(y) and jnp.allclose(x, y, **kwargs)
+
+
+def shaped_allclose(x, y, **kwargs):
+    """As `jnp.allclose`, except:
+    - It also supports PyTree arguments.
+    - It mandates that shapes match as well (no broadcasting)
+    """
+    same_structure = jax.tree_structure(x) == jax.tree_structure(y)
+    allclose = ft.partial(_shaped_allclose, **kwargs)
+    return same_structure and jax.tree_util.tree_reduce(
+        operator.and_, jax.tree_map(allclose, x, y), True
+    )

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -3,10 +3,32 @@ import operator
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 
 
 def _shaped_allclose(x, y, **kwargs):
-    return jnp.shape(x) == jnp.shape(y) and jnp.allclose(x, y, **kwargs)
+    if type(x) is not type(y):
+        return False
+    if isinstance(x, jnp.ndarray):
+        if jnp.issubdtype(x.dtype, jnp.inexact):
+            return (
+                x.shape == y.shape
+                and x.dtype == y.dtype
+                and jnp.allclose(x, y, **kwargs)
+            )
+        else:
+            return x.shape == y.shape and x.dtype == y.dtype and jnp.all(x == y)
+    elif isinstance(x, np.ndarray):
+        if np.issubdtype(x.dtype, np.inexact):
+            return (
+                x.shape == y.shape
+                and x.dtype == y.dtype
+                and np.allclose(x, y, **kwargs)
+            )
+        else:
+            return x.shape == y.shape and x.dtype == y.dtype and np.all(x == y)
+    else:
+        return x == y
 
 
 def shaped_allclose(x, y, **kwargs):

--- a/tests/test_filter_grad.py
+++ b/tests/test_filter_grad.py
@@ -1,4 +1,3 @@
-import functools as ft
 from typing import Union
 
 import jax
@@ -10,28 +9,38 @@ import pytest
 import equinox as eqx
 
 
-def test_filter_grad1(getkey):
+@pytest.mark.parametrize("api_version", (0, 1))
+def test_filter_grad1(api_version, getkey):
     a = jrandom.normal(getkey(), (2, 3))
 
-    @ft.partial(eqx.filter_grad, filter_spec=lambda _: True)
     def f(x):
         return jnp.sum(x)
+
+    if api_version == 0:
+        f = eqx.filter_grad(f, filter_spec=lambda _: True)
+    else:
+        f = eqx.filter_grad(arg=True)(f)
 
     grad_f = f(a)
     assert jnp.all(grad_f == 1)
 
 
-def test_filter_grad2(getkey):
+@pytest.mark.parametrize("api_version", (0, 1))
+def test_filter_grad2(api_version, getkey):
     a = jrandom.normal(getkey(), (2, 3))
     b = jrandom.normal(getkey(), (2, 3))
 
-    @ft.partial(eqx.filter_grad, filter_spec=eqx.is_inexact_array)
     def f(x):
         sum = 0.0
         for arg in jax.tree_leaves(x):
             if eqx.is_array_like(arg):
                 sum = sum + jnp.sum(arg)
         return sum
+
+    if api_version == 0:
+        f = eqx.filter_grad(f, filter_spec=eqx.is_inexact_array)
+    else:
+        f = eqx.filter_grad(arg=eqx.is_inexact_array)(f)
 
     ga, gb = f([a, b])
     assert jnp.all(ga == 1)
@@ -61,22 +70,31 @@ def test_filter_grad2(getkey):
     assert gnp is None
 
 
-def test_filter_grad3(getkey):
+@pytest.mark.parametrize("api_version", (0, 1))
+def test_filter_grad3(api_version, getkey):
     a = jrandom.normal(getkey(), (2, 3))
     b = jrandom.normal(getkey(), (1, 2))
     c = jrandom.normal(getkey(), ())
 
-    @ft.partial(eqx.filter_grad, filter_spec=[True, False])
     def f(x):
         return jnp.sum(x[0]) + jnp.sum(x[1])
+
+    if api_version == 0:
+        f = eqx.filter_grad(f, filter_spec=[True, False])
+    else:
+        f = eqx.filter_grad(arg=[True, False])(f)
 
     ga, gb = f([a, b])
     assert jnp.all(ga == 1)
     assert gb is None
 
-    @ft.partial(eqx.filter_grad, filter_spec={"a": True, "b": False})
     def h(x, y):
         return jnp.sum(x["a"]) * jnp.sum(x["b"]) * y
+
+    if api_version == 0:
+        h = eqx.filter_grad(h, filter_spec={"a": True, "b": False})
+    else:
+        h = eqx.filter_grad(arg={"a": True, "b": False})(h)
 
     grad = h({"a": a, "b": b}, c)
     assert jnp.allclose(grad["a"], jnp.sum(b) * c)
@@ -87,34 +105,46 @@ def test_filter_grad3(getkey):
 
 
 # TODO: more comprehensive tests on this.
-def test_filter_value_and_grad_(getkey):
+@pytest.mark.parametrize("api_version", (0, 1))
+def test_filter_value_and_grad(api_version, getkey):
     a = jrandom.normal(getkey(), (2, 3))
 
-    @ft.partial(eqx.filter_value_and_grad, filter_spec=eqx.is_inexact_array)
     def f(x):
         return jnp.sum(x)
+
+    if api_version == 0:
+        f = eqx.filter_value_and_grad(f, filter_spec=eqx.is_inexact_array)
+    else:
+        f = eqx.filter_value_and_grad(arg=eqx.is_inexact_array)(f)
 
     val, grad = f(a)
     assert val == jnp.sum(a)
     assert jnp.all(grad == 1)
 
 
-def test_aux(getkey):
+@pytest.mark.parametrize("api_version", (0, 1))
+def test_aux(api_version, getkey):
     a = jrandom.normal(getkey(), (2, 3))
 
-    @ft.partial(eqx.filter_grad, has_aux=True, filter_spec=eqx.is_inexact_array)
     def f(x):
         return jnp.sum(x), "hi"
+
+    if api_version == 0:
+        f = eqx.filter_grad(f, has_aux=True, filter_spec=eqx.is_inexact_array)
+    else:
+        f = eqx.filter_grad(has_aux=True, arg=eqx.is_inexact_array)(f)
 
     grad, aux = f(a)
     assert aux == "hi"
     assert jnp.all(grad == 1)
 
-    @ft.partial(
-        eqx.filter_value_and_grad, has_aux=True, filter_spec=eqx.is_inexact_array
-    )
     def f(x):
         return jnp.sum(x), "hi"
+
+    if api_version == 0:
+        f = eqx.filter_value_and_grad(f, has_aux=True, filter_spec=eqx.is_inexact_array)
+    else:
+        f = eqx.filter_value_and_grad(has_aux=True, arg=eqx.is_inexact_array)(f)
 
     (value, aux), grad = f(a)
     assert value == jnp.sum(a)
@@ -143,16 +173,44 @@ def test_methods(call, outer):
             if not outer:
                 method = eqx.filter_grad(method)
 
-    m = M(5)
-    y = jnp.ndarray(1.0)
+    m = M(jnp.array(5.0))
+    grad_m = M(jnp.array(1.0))
+    y = jnp.array(1.0)
 
     if call:
         if outer:
             assert eqx.filter_grad(m)(y) == 1
         else:
-            assert m(y) == 1
+            assert m(y) == grad_m
     else:
         if outer:
             assert eqx.filter_grad(m.method)(y) == 1
         else:
-            assert m.method(y) == 1
+            assert m.method(y) == grad_m
+
+
+def test_grad_jit():
+    num_traces = 0
+
+    @eqx.filter_custom_vjp
+    def f(x):
+        return x
+
+    def f_fwd(x):
+        return x, None
+
+    def f_bwd(_, g, __):
+        nonlocal num_traces
+        num_traces += 1
+        return g + 2
+
+    f.defvjp(f_fwd, f_bwd)
+    x = jnp.array(1.0)
+
+    jitf = jax.jit(f)
+    assert eqx.filter_grad(jitf)(x) == 3
+    assert eqx.filter_grad(jitf)(x) == 3
+    assert num_traces == 1
+    assert eqx.filter_grad(eqx.filter_jit(f))(x) == 3
+    assert eqx.filter_grad(eqx.filter_jit(f))(x) == 3
+    assert num_traces == 2

--- a/tests/test_filter_jit.py
+++ b/tests/test_filter_jit.py
@@ -256,11 +256,11 @@ def test_function_name_warning(log_compiles_config, caplog):
         in warning_text
     )
 
-    def wrapped_fun(x, y):
-        return x + y
+    def wrapped_fun(y):
+        pass
 
     def the_test_function_name(x, y):
-        return wrapped_fun(x, y)
+        return x + y
 
     fun = eqx.filter_jit(
         ft.wraps(wrapped_fun)(ft.partial(the_test_function_name, jnp.array(1.0)))

--- a/tests/test_filter_jit.py
+++ b/tests/test_filter_jit.py
@@ -236,7 +236,7 @@ def test_methods(call, outer):
             if not outer:
                 method = eqx.filter_jit(method)
 
-    y = jnp.ndarray(1.0)
+    y = jnp.array(1.0)
 
     def run(_m):
         if call:
@@ -258,8 +258,8 @@ def test_methods(call, outer):
     assert run(n) == 3
     assert run(n) == 3
     assert num_traces == 2
-    o = M(jnp.ndarray(1))
-    p = M(jnp.ndarray(2))
+    o = M(jnp.array(1))
+    p = M(jnp.array(2))
     assert run(o) == 2
     assert run(p) == 3
     assert num_traces == 3
@@ -339,7 +339,7 @@ def test_jit_grad():
 
     assert eqx.filter_jit(eqx.filter_value_and_grad(f))(jnp.array(1.0)) == (2, 1)
     assert eqx.filter_jit(eqx.filter_value_and_grad(f))(jnp.array(2.0)) == (3, 1)
-    assert num_traces == 1
+    assert num_traces == 2
 
 
 def test_jit_vmap():

--- a/tests/test_filter_pmap.py
+++ b/tests/test_filter_pmap.py
@@ -1,0 +1,63 @@
+from typing import Union
+
+import jax.numpy as jnp
+import pytest
+from helpers import shaped_allclose
+
+import equinox as eqx
+
+
+@pytest.mark.parametrize("call", [False, True])
+@pytest.mark.parametrize("outer", [False, True])
+def test_methods(call, outer):
+    num_traces = 0
+
+    class M(eqx.Module):
+        increment: Union[int, jnp.ndarray]
+
+        if call:
+
+            def __call__(self, x):
+                nonlocal num_traces
+                num_traces += 1
+                return x + self.increment
+
+            if not outer:
+                __call__ = eqx.filter_pmap(__call__)
+        else:
+
+            def method(self, x):
+                nonlocal num_traces
+                num_traces += 1
+                return x + self.increment
+
+            if not outer:
+                method = eqx.filter_pmap(method)
+
+    y = jnp.ndarray([1, 2])
+
+    def run(_m):
+        if call:
+            if outer:
+                return eqx.filter_pmap(_m)(y)
+            else:
+                return _m(y)
+        else:
+            if outer:
+                return eqx.filter_pmap(_m.method)(y)
+            else:
+                return _m.method(y)
+
+    m = M(1)
+    assert shaped_allclose(run(m), jnp.array([2, 3]))
+    assert shaped_allclose(run(m), jnp.array([2, 3]))
+    assert num_traces == 1
+    n = M(2)
+    assert shaped_allclose(run(n), jnp.array([3, 4]))
+    assert shaped_allclose(run(n), jnp.array([3, 4]))
+    assert num_traces == 2
+    o = M(jnp.ndarray([5, 6]))
+    p = M(jnp.ndarray([6, 7]))
+    assert shaped_allclose(run(o), jnp.array([6, 8]))
+    assert shaped_allclose(run(p), jnp.array([7, 9]))
+    assert num_traces == 3

--- a/tests/test_filter_pmap.py
+++ b/tests/test_filter_pmap.py
@@ -1,10 +1,92 @@
+import functools as ft
 from typing import Union
 
+import jax
 import jax.numpy as jnp
 import pytest
-from helpers import shaped_allclose
+from helpers import shaped_allclose as _shaped_allclose
 
 import equinox as eqx
+
+
+(cpu,) = jax.devices("cpu")
+filter_pmap = ft.partial(eqx.filter_pmap, devices=[cpu])
+
+
+def shaped_allclose(x, y, **kwargs):
+    if isinstance(x, jnp.ndarray):
+        x = jax.device_put(x)
+    return _shaped_allclose(x, y, **kwargs)
+
+
+def _zero_if_inexact_array_else_none(x):
+    return 0 if eqx.is_inexact_array(x) else None
+
+
+def test_args():
+    @filter_pmap(args=(_zero_if_inexact_array_else_none, [{"a": None}], 0))
+    def f(a, b, c, d):
+        return a + b[0]["a"] + c + d
+
+    out = f(jnp.array([1]), [{"a": jnp.array([2])}], jnp.array([3]), 4)
+    assert shaped_allclose(out, jnp.array([[10]]))
+
+
+def test_kwargs():
+    @filter_pmap(kwargs=dict(a=_zero_if_inexact_array_else_none, b=[{"a": None}], c=0))
+    def f(a, b, c, d):
+        return a + b[0]["a"] + c + d
+
+    out = f(jnp.array([1]), [{"a": jnp.array([2])}], jnp.array([3]), 4)
+    assert shaped_allclose(out, jnp.array([[10]]))
+
+
+def test_default():
+    @filter_pmap(default=_zero_if_inexact_array_else_none)
+    def f(a, b):
+        return a + b
+
+    assert shaped_allclose(f(jnp.array(3), jnp.array([3.0])), jnp.array([6.0]))
+
+    with pytest.raises(ValueError):
+        assert shaped_allclose(f(jnp.array(3.0), jnp.array([3.0])), jnp.array([6.0]))
+
+
+def test_fn():
+    class M(eqx.Module):
+        increment: jnp.ndarray
+
+        def __call__(self, x):
+            return x + self.increment
+
+    m = M(jnp.array([1]))
+    o1 = filter_pmap(m, fn=0)(1)
+    o2 = filter_pmap(m, fn=0)(jnp.array([3]))
+    o3 = filter_pmap(m, default=None, fn=0)(jnp.array([3]))
+    assert shaped_allclose(o1, jnp.array([2]))
+    assert shaped_allclose(o2, jnp.array([4]))
+    assert shaped_allclose(o3, jnp.array([[4]]))
+
+
+def test_out():
+    def f(x):
+        return x
+
+    o1 = filter_pmap(f, default=None, out=None, axis_size=1)(jnp.array([3, 4]))
+    o2 = filter_pmap(f, out=0, axis_size=1)(1)
+    o3 = filter_pmap(f, default=None, out=0, axis_size=1)(jnp.array([3, 4]))
+
+    assert shaped_allclose(o1, jnp.array([3, 4]))
+    assert shaped_allclose(o2, jnp.array([1]))
+    assert shaped_allclose(o3, jnp.array([[3, 4]]))
+
+
+def test_no_arrays():
+    @filter_pmap(out=None, axis_size=1)
+    def f(x):
+        return x
+
+    assert shaped_allclose(f(1), 1)
 
 
 @pytest.mark.parametrize("call", [False, True])
@@ -34,7 +116,7 @@ def test_methods(call, outer):
             if not outer:
                 method = eqx.filter_pmap(method)
 
-    y = jnp.ndarray([1, 2])
+    y = jnp.array([1])
 
     def run(_m):
         if call:
@@ -49,15 +131,19 @@ def test_methods(call, outer):
                 return _m.method(y)
 
     m = M(1)
-    assert shaped_allclose(run(m), jnp.array([2, 3]))
-    assert shaped_allclose(run(m), jnp.array([2, 3]))
+    assert shaped_allclose(run(m), jnp.array([2]))
+    assert shaped_allclose(run(m), jnp.array([2]))
     assert num_traces == 1
     n = M(2)
-    assert shaped_allclose(run(n), jnp.array([3, 4]))
-    assert shaped_allclose(run(n), jnp.array([3, 4]))
+    assert shaped_allclose(run(n), jnp.array([3]))
+    assert shaped_allclose(run(n), jnp.array([3]))
     assert num_traces == 2
-    o = M(jnp.ndarray([5, 6]))
-    p = M(jnp.ndarray([6, 7]))
-    assert shaped_allclose(run(o), jnp.array([6, 8]))
-    assert shaped_allclose(run(p), jnp.array([7, 9]))
+    o = M(jnp.array([5]))
+    p = M(jnp.array([6]))
+    if outer:
+        assert shaped_allclose(run(o), jnp.array([[6]]))
+        assert shaped_allclose(run(p), jnp.array([[7]]))
+    else:
+        assert shaped_allclose(run(o), jnp.array([6]))
+        assert shaped_allclose(run(p), jnp.array([7]))
     assert num_traces == 3

--- a/tests/test_filter_vmap.py
+++ b/tests/test_filter_vmap.py
@@ -1,9 +1,112 @@
 from typing import Union
 
 import jax.numpy as jnp
+import jax.random as jr
 import pytest
+from helpers import shaped_allclose
 
 import equinox as eqx
+
+
+def _zero_if_inexact_array_else_none(x):
+    return 0 if eqx.is_inexact_array(x) else None
+
+
+def _zero_if_array_else_none(x):
+    return 0 if eqx.is_array(x) else None
+
+
+def test_args():
+    @eqx.filter_vmap(args=(_zero_if_inexact_array_else_none, [{"a": None}], 0))
+    def f(a, b, c, d):
+        return a + b[0]["a"] + c + d
+
+    out = f(jnp.array([1]), [{"a": jnp.array([2])}], jnp.array([3]), 4)
+    assert shaped_allclose(out, jnp.array([[10]]))
+
+
+def test_kwargs():
+    @eqx.filter_vmap(
+        kwargs=dict(a=_zero_if_inexact_array_else_none, b=[{"a": None}], c=0)
+    )
+    def f(a, b, c, d):
+        return a + b[0]["a"] + c + d
+
+    out = f(jnp.array([1]), [{"a": jnp.array([2])}], jnp.array([3]), 4)
+    assert shaped_allclose(out, jnp.array([[10]]))
+
+
+def test_default():
+    @eqx.filter_vmap(default=_zero_if_inexact_array_else_none)
+    def f(a, b):
+        return a + b
+
+    assert shaped_allclose(f(jnp.array(3), jnp.array([3.0])), jnp.array([6.0]))
+
+    with pytest.raises(ValueError):
+        assert shaped_allclose(f(jnp.array(3.0), jnp.array([3.0])), jnp.array([6.0]))
+
+
+def test_fn():
+    class M(eqx.Module):
+        increment: jnp.ndarray
+
+        def __call__(self, x):
+            return x + self.increment
+
+    m = M(jnp.array([1, 2]))
+    o1 = eqx.filter_vmap(m, fn=0)(1)
+    o2 = eqx.filter_vmap(m, fn=0)(jnp.array([3, 4]))
+    o3 = eqx.filter_vmap(m, default=None, fn=0)(jnp.array([3, 4]))
+    assert shaped_allclose(o1, jnp.array([2, 3]))
+    assert shaped_allclose(o2, jnp.array([4, 6]))
+    assert shaped_allclose(o3, jnp.array([[4, 5], [5, 6]]))
+
+
+def test_out():
+    def f(x):
+        return x
+
+    o1 = eqx.filter_vmap(f, out=None, axis_size=5)(1)
+    o2 = eqx.filter_vmap(f, default=None, out=None, axis_size=5)(jnp.array([3, 4]))
+    o3 = eqx.filter_vmap(f, out=0, axis_size=5)(1)
+    o4 = eqx.filter_vmap(f, default=None, out=0, axis_size=5)(jnp.array([3, 4]))
+
+    assert shaped_allclose(o1, 1)
+    assert shaped_allclose(o2, jnp.array([3, 4]))
+    assert shaped_allclose(o3, jnp.array([1, 1, 1, 1, 1]))
+    assert shaped_allclose(o4, jnp.array([[3, 4], [3, 4], [3, 4], [3, 4], [3, 4]]))
+
+
+def test_no_arrays():
+    @eqx.filter_vmap(out=_zero_if_inexact_array_else_none, axis_size=5)
+    def f(x):
+        return x
+
+    assert shaped_allclose(f(1), 1)
+
+
+def test_ensemble(getkey):
+    def make(key):
+        return eqx.nn.MLP(5, 4, 3, 2, key=getkey())
+
+    keys = jr.split(getkey(), 7)
+    models = eqx.filter_vmap(make, out=lambda x: 0 if eqx.is_array(x) else None)(keys)
+
+    def call(model, x):
+        return model(x)
+
+    xs1 = jr.normal(getkey(), (7, 5))
+    assert eqx.filter_vmap(call)(models, xs1).shape == (7, 4)
+    assert eqx.filter_vmap(models, fn=_zero_if_array_else_none)(xs1).shape == (7, 4)
+
+    xs2 = jr.normal(getkey(), (5,))
+    assert eqx.filter_vmap(call, args=(_zero_if_array_else_none, None))(
+        models, xs2
+    ).shape == (7, 4)
+    assert eqx.filter_vmap(models, default=None, fn=_zero_if_array_else_none,)(
+        xs2
+    ).shape == (7, 4)
 
 
 @pytest.mark.parametrize("call", [False, True])
@@ -28,15 +131,39 @@ def test_methods(call, outer):
                 method = eqx.filter_vmap(method)
 
     m = M(5)
-    y = jnp.ndarray(1.0)
+    y = jnp.array([1.0])
 
     if call:
         if outer:
-            assert eqx.filter_vmap(m)(y) == 1
+            assert eqx.filter_vmap(m)(y) == 6
         else:
-            assert m(y) == 1
+            assert m(y) == 6
     else:
         if outer:
-            assert eqx.filter_vmap(m.method)(y) == 1
+            assert eqx.filter_vmap(m.method)(y) == 6
         else:
-            assert m.method(y) == 1
+            assert m.method(y) == 6
+
+
+def test_args_kwargs():
+    @eqx.filter_vmap(kwargs=dict(x=0))
+    def f(*args, **kwargs):
+        return kwargs["x"]
+
+    # check we can use other kwargs
+    assert shaped_allclose(f(x=jnp.array([3]), y=4), jnp.array([3]))
+    assert shaped_allclose(f(x=jnp.array([3]), y=jnp.array([4])), jnp.array([3]))
+
+    with pytest.raises(ValueError):
+        f(x=jnp.array([3]), y=jnp.array(4))
+
+    with pytest.raises(ValueError):
+        f(x=jnp.array(3))
+
+    @eqx.filter_vmap(args=(_zero_if_array_else_none,))
+    def h(*args, **kwargs):
+        return args[0]
+
+    # check we can use other args
+    assert h(1, jnp.array([2])) == 1
+    assert shaped_allclose(h(jnp.array([2]), 3), jnp.array([2]))

--- a/tests/test_filter_vmap.py
+++ b/tests/test_filter_vmap.py
@@ -1,0 +1,42 @@
+from typing import Union
+
+import jax.numpy as jnp
+import pytest
+
+import equinox as eqx
+
+
+@pytest.mark.parametrize("call", [False, True])
+@pytest.mark.parametrize("outer", [False, True])
+def test_methods(call, outer):
+    class M(eqx.Module):
+        increment: Union[int, jnp.ndarray]
+
+        if call:
+
+            def __call__(self, x):
+                return x + self.increment
+
+            if not outer:
+                __call__ = eqx.filter_vmap(__call__)
+        else:
+
+            def method(self, x):
+                return x + self.increment
+
+            if not outer:
+                method = eqx.filter_vmap(method)
+
+    m = M(5)
+    y = jnp.ndarray(1.0)
+
+    if call:
+        if outer:
+            assert eqx.filter_vmap(m)(y) == 1
+        else:
+            assert m(y) == 1
+    else:
+        if outer:
+            assert eqx.filter_vmap(m.method)(y) == 1
+        else:
+            assert m.method(y) == 1

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -109,7 +109,7 @@ def test_filter(getkey):
     ]
     filtered = eqx.filter(pytree, filter_spec=filter_spec)
     none_linear = jax.tree_map(lambda _: None, eqx.nn.Linear(1, 1, key=getkey()))
-    assert filtered[0] is None
+    assert filtered[0] == none_linear
     assert filtered[1] == pytree[1]
     assert filtered[2][0] == none_linear
     assert filtered[2][1] is sentinel

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -139,3 +139,8 @@ def test_partition_and_combine(getkey):
             assert not isinstance(arg, int)
         assert eqx.combine(filtered, unfiltered) == pytree
         assert eqx.combine(unfiltered, filtered) == pytree
+
+
+def test_partition_subtree():
+    a, b = eqx.partition([(1,), 2], [True, False])
+    eqx.combine(a, b)

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -565,6 +565,14 @@ def test_batch_norm(getkey):
     with pytest.raises(RuntimeError):
         jax.vmap(bn, axis_name="batch")(x1)
 
+    # Test that it handles multiple axis_names
+
+    bn = eqx.experimental.BatchNorm(6, ("batch1", "batch2"))
+    assert (
+        jax.vmap(jax.vmap(bn, axis_name="batch1"), axis_name="batch2")(x2).shape
+        == x2.shape
+    )
+
     # Test that it normalises
 
     x1alt = jrandom.normal(jrandom.PRNGKey(5678), (10, 5))  # avoid flakey test

--- a/tests/test_stateful.py
+++ b/tests/test_stateful.py
@@ -197,13 +197,12 @@ def test_inference_no_state():
         eqx.experimental.get_state(index, jnp.array(1))
 
 
-@pytest.mark.skip
 def test_inference_not_set_under_jit():
     index = eqx.experimental.StateIndex()
 
     @jax.jit
     def f(i):
-        eqx.tree_at(lambda j: j.inference, i, True)
+        eqx.tree_inference(i, True)
 
     with pytest.raises(RuntimeError):
         f(index)


### PR DESCRIPTION
This is a big one.

- **Feature**: Added `eqx.filter_vmap` and `eqx.filter_pmap`. Closes #65.
  - Yay, we're rounding out our collection of filtered transformations.
- **Feature**: Prevented unnecessary recompilation in some edge cases like calling `filter_jit(filter_grad(...))` twice, i.e. when materialising a new gradient function twice. See https://github.com/google/jax/discussions/10284; in particular we do it by using appropriately-structured PyTrees rather than caching, which is good.
- **Feature**: Added `eqx.tree_inference` as a convenience.
- **Refactor**: Improved the interface to `filter_{jit,grad,value_and_grad}`:
  - Supports optional currying (a plain `@eqx.filter_jit` will still work):
    ```python
    @eqx.filter_jit(default=...)
    def f(...):
        ...
    ```
  - A much neater way of specifying the necessary filter specifications is now available. Instead of using `filter_spec`, `filter_spec_return` and `filter_spec_fun`, a much more fine-grained approach is available via the `default`, `args`, `kwargs`, `fn`, `out` arguments. This improves user ergonomics. For example we can now specify a default filter spec, and vary it only for one argument:
    ```python
    @eqx.filter_jit(default=eqx.is_array_like, kwargs=dict(x=False))
    def f(x, y, z, w):
        ...
    ```
    In addition this now binds against the function signature, *not* the call-time signature. e.g. we could could call the above as f`(1, 2, 3, 4)`; we don't have to call in the specific way `f(x=..., ...)`.
  - The older interface is still available for backward compatibility, don't worry! It's still part of the tests. Whilst deprecated it won't be disappearing for a while.
  - Closes #48.
- **Refactor**: Many documentation tweaks and improvements.
- **Bugfix**: `eqx.nn.MultiheadAttention.__call__` now uses a `deterministic` argument rather than an `inference` argument. This should suppress an unnecessary warning.