### PR TITLE
Improved `tree_at`

### DIFF
--- a/equinox/custom_types.py
+++ b/equinox/custom_types.py
@@ -4,7 +4,7 @@ from typing import Any, Callable, Generic, Tuple, TypeVar, Union
 
 import jax
 
-from .doc_utils import WithRepr
+from .doc_utils import doc_repr
 
 
 # Custom flag we set when generating documentation.
@@ -96,8 +96,6 @@ if getattr(typing, "GENERATING_DOCUMENTATION", False):
     Array.__module__ = "builtins"
     PyTree.__module__ = "builtins"
 
-    sentinel = WithRepr("sentinel")
-
 else:
 
     class Array:
@@ -108,8 +106,8 @@ else:
         def __class_getitem__(cls, item):
             return PyTree
 
-    sentinel = object()
 
+sentinel = doc_repr(object(), "sentinel")
 
 TreeDef = type(jax.tree_structure(0))
 

--- a/equinox/doc_utils.py
+++ b/equinox/doc_utils.py
@@ -1,13 +1,21 @@
 import typing
 from types import FunctionType
+from typing import Any
 
 
-class WithRepr:
+class _WithRepr:
     def __init__(self, string):
         self.string = string
 
     def __repr__(self):
         return self.string
+
+
+def doc_repr(obj: Any, string: str):
+    if getattr(typing, "GENERATING_DOCUMENTATION", False):
+        return _WithRepr(string)
+    else:
+        return obj
 
 
 def doc_strip_annotations(fn: FunctionType) -> FunctionType:


### PR DESCRIPTION
Closes #47.

- Can now substitute arbitrary nodes, not just leaves
- These substituted nodes can now have different structures to each other.
- Will raise an error if `where` depends on the values of the leaves of the PyTree.

In addition, `tree_equal` should now work under JIT.