### PR TITLE
Added max and avg pool, alongside tests and docs

### DIFF
--- a/docs/api/nn/pool.md
+++ b/docs/api/nn/pool.md
@@ -1,0 +1,43 @@
+# Pooling
+
+::: equinox.nn.Pool
+    selection:
+        members:
+            - __init__
+            - __call__
+
+---
+
+::: equinox.nn.AvgPool1D
+    selection:
+        members: false
+
+---
+
+::: equinox.nn.MaxPool1D
+    selection:
+        members: false
+
+---
+
+::: equinox.nn.AvgPool2D
+    selection:
+        members: false
+
+---
+
+::: equinox.nn.MaxPool2D
+    selection:
+        members: false
+
+---
+
+::: equinox.nn.AvgPool3D
+    selection:
+        members: false
+
+---
+
+::: equinox.nn.MaxPool3D
+    selection:
+        members: false

--- a/equinox/nn/__init__.py
+++ b/equinox/nn/__init__.py
@@ -14,4 +14,5 @@ from .dropout import Dropout
 from .embedding import Embedding
 from .linear import Identity, Linear
 from .normalisation import LayerNorm
+from .pool import AvgPool1D, AvgPool2D, AvgPool3D, MaxPool1D, MaxPool2D, MaxPool3D, Pool
 from .rnn import GRUCell, LSTMCell

--- a/equinox/nn/pool.py
+++ b/equinox/nn/pool.py
@@ -1,0 +1,259 @@
+from typing import Callable, Optional, Sequence, Tuple, Union
+
+import jax.lax as lax
+import jax.numpy as jnp
+import jax.random
+import numpy as np
+
+from ..custom_types import Array
+from ..module import Module, static_field
+
+
+class Pool(Module):
+    """General N-dimensional downsampling over a sliding window."""
+
+    init: Union[int, float, Array] = static_field()
+    operation: Callable[[Array, Array], Array]
+    num_spatial_dims: int = static_field()
+    kernel_size: Union[int, Sequence[int]] = static_field()
+    stride: Union[int, Sequence[int]] = static_field()
+    padding: Union[int, Sequence[int]] = static_field()
+
+    def __init__(
+        self,
+        init: Union[int, float, Array],
+        operation: Callable[[Array, Array], Array],
+        num_spatial_dims: int,
+        kernel_size: Union[int, Sequence[int]],
+        stride: Union[int, Sequence[int]] = 1,
+        padding: Union[int, Sequence[int], Sequence[Tuple[int, int]]] = 0,
+        **kwargs,
+    ):
+        """**Arguments:**
+        - `init': The initial value for the reduction.
+        - `operation`: The operation applied to the inputs of each window.
+        - `num_spatial_dims`: The number of spatial dimensions.
+        - `kernel_size`: The size of the convolutional kernel.
+        - `stride`: The stride of the convolution.
+        - `padding`: The amount of padding to apply before and after each
+            spatial dimension.
+
+        !!! info
+
+            In order for `Pool' to be differentiable, `operation(init, x)=x' needs to
+            be true for all finite `x'. For further details see
+            https://www.tensorflow.org/xla/operation_semantics#reducewindow  and
+            https://github.com/google/jax/issues/7718.
+
+        """
+        super().__init__(**kwargs)
+
+        self.operation = operation
+        self.init = init
+        self.num_spatial_dims = num_spatial_dims
+
+        if isinstance(kernel_size, int):
+            self.kernel_size = (kernel_size,) * num_spatial_dims
+        elif isinstance(kernel_size, Sequence):
+            self.kernel_size = kernel_size
+        else:
+            raise ValueError(
+                "`kernel_size` must either be an int or tuple of length "
+                f"{num_spatial_dims} containing ints."
+            )
+
+        if isinstance(stride, int):
+            self.stride = (stride,) * num_spatial_dims
+        elif isinstance(stride, Sequence):
+            self.stride = stride
+        else:
+            raise ValueError(
+                "`stride` must either be an int or tuple of length "
+                f"{num_spatial_dims} containing ints."
+            )
+
+        if isinstance(padding, int):
+            self.padding = tuple((padding, padding) for _ in range(num_spatial_dims))
+        elif isinstance(padding, Sequence) and all(
+            isinstance(element, Sequence) for element in padding
+        ):
+            self.padding = padding
+        elif isinstance(padding, Sequence) and len(padding) == num_spatial_dims:
+            self.padding = tuple((p, p) for p in padding)
+        else:
+            raise ValueError(
+                "`padding` must either be an int or tuple of length "
+                f"{num_spatial_dims} containing ints or tuples of length 2."
+            )
+
+    def __call__(
+        self, x: Array, *, key: Optional["jax.random.PRNGKey"] = None
+    ) -> Array:
+        """**Arguments:**
+        - `x`: The input. Should be a JAX array of shape `(channels, dim_1, ..., dim_N)`, where
+            `N = num_spatial_dims`.
+        - `key`: Ignored; provided for compatibility with the rest of the Equinox API.
+            (Keyword only argument.)
+        **Returns:**
+        A JAX array of shape `(channels, new_dim_1, ..., new_dim_N)`.
+        """
+        assert len(x.shape) == self.num_spatial_dims + 1, (
+            f"Input should have {self.num_spatial_dims} spatial dimensions, "
+            f"but input has shape {x.shape}"
+        )
+
+        x = jnp.moveaxis(x, 0, -1)
+        x = jnp.expand_dims(x, axis=0)
+        x = lax.reduce_window(
+            x,
+            self.init,
+            self.operation,
+            (1,) + self.kernel_size + (1,),
+            (1,) + self.stride + (1,),
+            ((0, 0),) + self.padding + ((0, 0),),
+        )
+
+        x = jnp.squeeze(x, axis=0)
+        x = jnp.moveaxis(x, -1, 0)
+        return x
+
+
+class AvgPool1D(Pool):
+    """One-dimensional downsample using an average over a sliding window."""
+
+    def __init__(
+        self,
+        kernel_size,
+        stride=None,
+        padding=0,
+        **kwargs,
+    ):
+        super().__init__(
+            init=0,
+            num_spatial_dims=1,
+            kernel_size=kernel_size,
+            operation=lax.add,
+            stride=stride,
+            padding=padding,
+            **kwargs,
+        )
+
+    def __call__(
+        self, x: Array, *, key: Optional["jax.random.PRNGKey"] = None
+    ) -> Array:
+        return super().__call__(x) / np.prod(self.kernel_size)
+
+
+class MaxPool1D(Pool):
+    """One-dimensional downsample using the maximum over a sliding window."""
+
+    def __init__(
+        self,
+        kernel_size,
+        stride=None,
+        padding=0,
+        **kwargs,
+    ):
+        super().__init__(
+            init=-jnp.inf,
+            num_spatial_dims=1,
+            kernel_size=kernel_size,
+            operation=lax.max,
+            stride=stride,
+            padding=padding,
+            **kwargs,
+        )
+
+
+class AvgPool2D(Pool):
+    """Two-dimensional downsample using an average over a sliding window."""
+
+    def __init__(
+        self,
+        kernel_size,
+        stride=None,
+        padding=0,
+        **kwargs,
+    ):
+        super().__init__(
+            init=0,
+            num_spatial_dims=2,
+            kernel_size=kernel_size,
+            operation=lax.add,
+            stride=stride,
+            padding=padding,
+            **kwargs,
+        )
+
+    def __call__(
+        self, x: Array, *, key: Optional["jax.random.PRNGKey"] = None
+    ) -> Array:
+        return super().__call__(x) / np.prod(self.kernel_size)
+
+
+class MaxPool2D(Pool):
+    """Two-dimensional downsample using the maximum over a sliding window."""
+
+    def __init__(
+        self,
+        kernel_size,
+        stride=None,
+        padding=0,
+        **kwargs,
+    ):
+        super().__init__(
+            init=-jnp.inf,
+            num_spatial_dims=2,
+            kernel_size=kernel_size,
+            operation=lax.max,
+            stride=stride,
+            padding=padding,
+            **kwargs,
+        )
+
+
+class AvgPool3D(Pool):
+    """Three-dimensional downsample using an average over a sliding window."""
+
+    def __init__(
+        self,
+        kernel_size,
+        stride=None,
+        padding=0,
+        **kwargs,
+    ):
+        super().__init__(
+            init=0,
+            num_spatial_dims=3,
+            kernel_size=kernel_size,
+            operation=lax.add,
+            stride=stride,
+            padding=padding,
+            **kwargs,
+        )
+
+    def __call__(
+        self, x: Array, *, key: Optional["jax.random.PRNGKey"] = None
+    ) -> Array:
+        return super().__call__(x) / np.prod(self.kernel_size)
+
+
+class MaxPool3D(Pool):
+    """Three-dimensional downsample using the maximum over a sliding window."""
+
+    def __init__(
+        self,
+        kernel_size,
+        stride=None,
+        padding=0,
+        **kwargs,
+    ):
+        super().__init__(
+            init=-jnp.inf,
+            num_spatial_dims=3,
+            kernel_size=kernel_size,
+            operation=lax.max,
+            stride=stride,
+            padding=padding,
+            **kwargs,
+        )

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -102,6 +102,7 @@ nav:
         - Neural network layers:
             - 'api/nn/linear.md'
             - 'api/nn/conv.md'
+            - 'api/nn/pool.md'
             - 'api/nn/rnn.md'
             - 'api/nn/attention.md'
             - 'api/nn/dropout.md'


### PR DESCRIPTION
I currently use einops.rearrange so that the pooling layers and conv layers take the same tensor format as input, BCHW. For some reason lax.conv_general_dilated and lax.reduce_window are BCHW and BHWC respectively. Can do this not using einops if you would prefer to not have the extra dependency. 