### PR TITLE
fix two small typos in documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ Finally, open a pull request on GitHub!
 Make your changes. You can then build the documentation by doing
 
 ```bash
-pip install docs/requirements.txt
+pip install -r docs/requirements.txt
 mkdocs serve
 ```
 Then doing `Control-C`, and running:

--- a/equinox/nn/pool.py
+++ b/equinox/nn/pool.py
@@ -44,7 +44,7 @@ class Pool(Module):
             In order for `Pool` to be differentiable, `operation(init, x) == x' needs to
             be true for all finite `x'. For further details see
             [https://www.tensorflow.org/xla/operation_semantics#reducewindow](https://www.tensorflow.org/xla/operation_semantics#reducewindow)
-            and [https://github.com/google/jax/issues/7718.](https://github.com/google/jax/issues/7718.)
+            and [https://github.com/google/jax/issues/7718](https://github.com/google/jax/issues/7718).
         """
         super().__init__(**kwargs)
 


### PR DESCRIPTION
This link in the `eqx.nn.Pooling` docstring was broken, and then I stumbled on a small typo in the contrib docs while fixing that