### PR TITLE
Implement num_feature_groups for Conv

### DIFF
--- a/equinox/nn/conv.py
+++ b/equinox/nn/conv.py
@@ -77,8 +77,13 @@ class Conv(Module):
         - `padding`: The amount of padding to apply before and after each spatial
             dimension. The same amount of padding is applied both before and after.
         - `dilation`: The dilation of the convolution.
-        - `num_feature_groups`: The number of input channels contributing to each
-            output channel. `in_channels` must be divisible by `num_feature_groups`.
+        - `num_feature_groups`: The number of input channel groups. At `num_feature_groups`
+            equal to 1, all input channels contribute to all output channels. Values
+            higher than 1 are equivalent to running `num_channels_groups` independent
+            Conv operations side-by-side, each having access only to
+            `in_channels` // `num_feature_groups` input channels, and
+            concatenating the results along the output channel dimension.
+            `in_channels` must be divisible by `num_feature_groups`.
         - `use_bias`: Whether to add on a bias after the convolution.
         - `key`: A `jax.random.PRNGKey` used to provide randomness for parameter
             initialisation. (Keyword only argument.)

--- a/equinox/nn/conv.py
+++ b/equinox/nn/conv.py
@@ -48,7 +48,7 @@ class Conv(Module):
     stride: Tuple[int, ...] = static_field()
     padding: Tuple[Tuple[int, int], ...] = static_field()
     dilation: Tuple[int, ...] = static_field()
-    num_feature_groups: int = static_field()
+    groups: int = static_field()
     use_bias: bool = static_field()
 
     def __init__(
@@ -60,7 +60,7 @@ class Conv(Module):
         stride: Union[int, Sequence[int]] = 1,
         padding: Union[int, Sequence[int]] = 0,
         dilation: Union[int, Sequence[int]] = 1,
-        num_feature_groups: int = 1,
+        groups: int = 1,
         use_bias: bool = True,
         *,
         key: "jax.random.PRNGKey",
@@ -77,13 +77,13 @@ class Conv(Module):
         - `padding`: The amount of padding to apply before and after each spatial
             dimension. The same amount of padding is applied both before and after.
         - `dilation`: The dilation of the convolution.
-        - `num_feature_groups`: The number of input channel groups. At `num_feature_groups`
+        - `groups`: The number of input channel groups. At `groups`
             equal to 1, all input channels contribute to all output channels. Values
-            higher than 1 are equivalent to running `num_channels_groups` independent
+            higher than 1 are equivalent to running `groups` independent
             Conv operations side-by-side, each having access only to
-            `in_channels` // `num_feature_groups` input channels, and
+            `in_channels` // `groups` input channels, and
             concatenating the results along the output channel dimension.
-            `in_channels` must be divisible by `num_feature_groups`.
+            `in_channels` must be divisible by `groups`.
         - `use_bias`: Whether to add on a bias after the convolution.
         - `key`: A `jax.random.PRNGKey` used to provide randomness for parameter
             initialisation. (Keyword only argument.)
@@ -106,13 +106,13 @@ class Conv(Module):
         stride = parse(stride)
         dilation = parse(dilation)
 
-        if in_channels % num_feature_groups != 0:
+        if in_channels % groups != 0:
             raise ValueError(
                 f"`in_channels` (={in_channels}) must be divisible "
-                f"by `num_feature_groups` (={num_feature_groups})."
+                f"by `groups` (={groups})."
             )
 
-        grouped_in_channels = in_channels // num_feature_groups
+        grouped_in_channels = in_channels // groups
         lim = 1 / np.sqrt(grouped_in_channels * np.prod(kernel_size))
         self.weight = jrandom.uniform(
             wkey,
@@ -145,7 +145,7 @@ class Conv(Module):
                 f"{num_spatial_dims}."
             )
         self.dilation = dilation
-        self.num_feature_groups = num_feature_groups
+        self.groups = groups
         self.use_bias = use_bias
 
     def __call__(
@@ -176,7 +176,7 @@ class Conv(Module):
             window_strides=self.stride,
             padding=self.padding,
             rhs_dilation=self.dilation,
-            feature_group_count=self.num_feature_groups,
+            feature_group_count=self.groups,
         )
         if self.use_bias:
             x = x + self.bias
@@ -195,7 +195,7 @@ class Conv1d(Conv):
         stride=1,
         padding=0,
         dilation=1,
-        num_feature_groups=1,
+        groups=1,
         use_bias=True,
         *,
         key,
@@ -209,7 +209,7 @@ class Conv1d(Conv):
             stride=stride,
             padding=padding,
             dilation=dilation,
-            num_feature_groups=num_feature_groups,
+            groups=groups,
             use_bias=use_bias,
             key=key,
             **kwargs,
@@ -227,7 +227,7 @@ class Conv2d(Conv):
         stride=(1, 1),
         padding=(0, 0),
         dilation=(1, 1),
-        num_feature_groups=1,
+        groups=1,
         use_bias=True,
         *,
         key,
@@ -241,7 +241,7 @@ class Conv2d(Conv):
             stride=stride,
             padding=padding,
             dilation=dilation,
-            num_feature_groups=num_feature_groups,
+            groups=groups,
             use_bias=use_bias,
             key=key,
             **kwargs,
@@ -259,7 +259,7 @@ class Conv3d(Conv):
         stride=(1, 1, 1),
         padding=(0, 0, 0),
         dilation=(1, 1, 1),
-        num_feature_groups=1,
+        groups=1,
         use_bias=True,
         *,
         key,
@@ -273,7 +273,7 @@ class Conv3d(Conv):
             stride=stride,
             padding=padding,
             dilation=dilation,
-            num_feature_groups=num_feature_groups,
+            groups=groups,
             use_bias=use_bias,
             key=key,
             **kwargs,

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -234,6 +234,42 @@ def test_conv2d(getkey):
     answer = jnp.array([-37, -31, -9, 25, 61, 49, 23, 41, 27]).reshape(1, 3, 3)
     assert jnp.allclose(conv(data), answer)
 
+    # Test num_feature_groups
+    conv = eqx.nn.Conv2d(
+        2, 2, kernel_size=3, padding=1, key=getkey(), num_feature_groups=2
+    )
+    # we will duplicate the weights from the "value matches" case
+    # and multiply one copy by 2. Also, we modify the bias
+    new_weight = jnp.concatenate(
+        [
+            1 * jnp.arange(9).reshape(1, 1, 3, 3),
+            2 * jnp.arange(9).reshape(1, 1, 3, 3),
+        ],
+        axis=0,
+    )
+    new_bias = jnp.array([1, 2]).reshape(2, 1, 1)
+
+    data = jnp.broadcast_to(
+        jnp.arange(-4, 5).reshape(1, 3, 3),
+        (2, 3, 3),
+    )
+    assert new_weight.shape == conv.weight.shape
+    assert new_bias.shape == conv.bias.shape
+    conv = eqx.tree_at(lambda x: (x.weight, x.bias), conv, (new_weight, new_bias))
+    # this is the multiplication part, without the bias
+    answer_part = jnp.array([-38, -32, -10, 24, 60, 48, 22, 40, 26]).reshape(1, 3, 3)
+    answer = (
+        jnp.concatenate(
+            [
+                1 * answer_part,
+                2 * answer_part,
+            ],
+            axis=0,
+        )
+        + new_bias
+    )
+    assert jnp.allclose(conv(data), answer)
+
 
 def test_conv3d(getkey):
     # Positional arguments

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -234,10 +234,8 @@ def test_conv2d(getkey):
     answer = jnp.array([-37, -31, -9, 25, 61, 49, 23, 41, 27]).reshape(1, 3, 3)
     assert jnp.allclose(conv(data), answer)
 
-    # Test num_feature_groups
-    conv = eqx.nn.Conv2d(
-        2, 2, kernel_size=3, padding=1, key=getkey(), num_feature_groups=2
-    )
+    # Test groups
+    conv = eqx.nn.Conv2d(2, 2, kernel_size=3, padding=1, key=getkey(), groups=2)
     # we will duplicate the weights from the "value matches" case
     # and multiply one copy by 2. Also, we modify the bias
     new_weight = jnp.concatenate(


### PR DESCRIPTION
As in the title: your implementation of `eqx.nn.Conv` doesn't expose the ability to subdivide feature channels into groups. This PR implements that feature.