### PR TITLE
Fix vmap with pytree out

### DIFF
--- a/equinox/vmap_pmap.py
+++ b/equinox/vmap_pmap.py
@@ -142,7 +142,7 @@ class _VmapWrapper(Module):
         if __self._callable_out_axes:  # `out` of type AxisSpec
             out_axes = (jax.tree_map(_VmapFilter, __self._out), None)
         else:  # `out` of type ResolvedAxisSpec
-            out_axes = _map_axes(__self._out)
+            out_axes = (_map_axes(__self._out), None)
         vmapd, nonvmapd = jax.vmap(
             _fun_wrapper, in_axes=in_axes, out_axes=out_axes, **__self._vmapkwargs
         )(__self._fun, bound.args, bound.kwargs)

--- a/tests/test_filter_pmap.py
+++ b/tests/test_filter_pmap.py
@@ -250,3 +250,39 @@ def test_named_reduction():
     output = eqx.filter_pmap(f, axis_name="device")(jnp.zeros(n))
 
     assert shaped_allclose(output, n * jnp.ones(n))
+
+
+def test_map_non_jax():
+    devices = jax.local_devices()
+
+    # this contains a non-jax value for the `activation` field
+    # and will therefore break filter_pmap if not filtered out
+    # at input and output
+    pytree = eqx.nn.MLP(
+        2,
+        2,
+        2,
+        2,
+        activation=jax.nn.relu,
+        key=jax.random.PRNGKey(42),
+    )
+
+    def maybe_replicate(value):
+        if eqx.is_array(value):
+            return jax.device_put_replicated(value, devices)
+        else:
+            return value
+
+    pytree_sharded = jax.tree_map(maybe_replicate, pytree)
+
+    def identity(x):
+        """will return a pytree with non-jax fields, which could break filter_pmap"""
+        return x
+
+    _ = eqx.filter_pmap(
+        identity,
+        out=jax.tree_map(
+            lambda value: 0 if eqx.is_array(value) else None,
+            pytree_sharded,
+        ),
+    )(pytree_sharded)

--- a/tests/test_filter_vmap.py
+++ b/tests/test_filter_vmap.py
@@ -179,3 +179,29 @@ def test_named_reduction():
     output = eqx.filter_vmap(f, axis_name="device")(jnp.zeros(n))
 
     assert shaped_allclose(output, n * jnp.ones(n))
+
+
+def test_map_non_jax():
+    # this contains a non-jax value for the `activation` field
+    # and will therefore break filter_vmap if not filtered out
+    # at input and output
+    pytree = eqx.nn.MLP(
+        2,
+        2,
+        2,
+        2,
+        activation=jax.nn.relu,
+        key=jax.random.PRNGKey(42),
+    )
+
+    def identity(x):
+        """will return a pytree with non-jax fields, which could break filter_vmap"""
+        return x
+
+    _ = eqx.filter_vmap(
+        identity,
+        out=jax.tree_map(
+            lambda value: 0 if eqx.is_array(value) else None,
+            pytree,
+        ),
+    )(pytree)


### PR DESCRIPTION
Partially addresses https://github.com/patrick-kidger/equinox/issues/115 by fixing a bug in filter_vmap to allow using a pytree as filter spec for the out parameter of filter_vmap. Adding tests for this case for both p- and vmap, just in case :)

Recreating this PR because with the previous I managed to introduce a merge conflict with myself...