### PR TITLE
eqx.filter_{vmap,pmap}(out=...) not experimental

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -2,8 +2,6 @@ name: Run tests
 
 on:
   pull_request:
-  schedule:
-    - cron: "0 2 * * 6"
 
 jobs:
   run-test:

--- a/docs/api/filtering/filtered-transformations.md
+++ b/docs/api/filtering/filtered-transformations.md
@@ -27,3 +27,7 @@ Practically speaking these are usually the only kind of filtering you ever have 
 ---
 
 ::: equinox.filter_pmap
+
+---
+
+::: equinox.filter_eval_shape

--- a/equinox/__init__.py
+++ b/equinox/__init__.py
@@ -1,4 +1,5 @@
 from . import experimental, nn
+from .eval_shape import filter_eval_shape
 from .filters import (
     combine,
     filter,

--- a/equinox/__init__.py
+++ b/equinox/__init__.py
@@ -19,4 +19,4 @@ from .update import apply_updates
 from .vmap_pmap import filter_pmap, filter_vmap
 
 
-__version__ = "0.5.3"
+__version__ = "0.5.4"

--- a/equinox/compile_utils.py
+++ b/equinox/compile_utils.py
@@ -23,12 +23,20 @@ class Static(Module):
     value: Any = static_field()
 
 
-def strip_wrapped_partial(fun):
+def _strip_wrapped_partial(fun):
     if hasattr(fun, "__wrapped__"):  # ft.wraps
-        return strip_wrapped_partial(fun.__wrapped__)
+        return _strip_wrapped_partial(fun.__wrapped__)
     if isinstance(fun, ft.partial):
-        return strip_wrapped_partial(fun.func)
+        return _strip_wrapped_partial(fun.func)
     return fun
+
+
+def get_fun_names(fun):
+    fun = _strip_wrapped_partial(fun)
+    try:
+        return fun.__name__, fun.__qualname__
+    except AttributeError:
+        return type(fun).__name__, type(fun).__qualname__
 
 
 def compile_cache(fun):

--- a/equinox/eval_shape.py
+++ b/equinox/eval_shape.py
@@ -1,0 +1,28 @@
+import functools as ft
+from typing import Callable
+
+import jax
+
+from .compile_utils import Static
+from .filters import combine, is_array_like, partition
+
+
+def _filter(x):
+    return isinstance(x, jax.ShapeDtypeStruct) or is_array_like(x)
+
+
+def filter_eval_shape(fun: Callable, *args, **kwargs):
+    """As `jax.eval_shape`, but allows any Python object as inputs and outputs.
+
+    (`jax.eval_shape` is constrained to only work with JAX arrays, Python float/int/etc.)
+    """
+
+    def _fn(_static, _dynamic):
+        _args, _kwargs = combine(_static, _dynamic)
+        _out = fun(*_args, **_kwargs)
+        _dynamic_out, _static_out = partition(_out, _filter)
+        return _dynamic_out, Static(_static_out)
+
+    dynamic, static = partition((args, kwargs), _filter)
+    dynamic_out, static_out = jax.eval_shape(ft.partial(_fn, static), dynamic)
+    return combine(dynamic_out, static_out.value)

--- a/tests/test_eval_shape.py
+++ b/tests/test_eval_shape.py
@@ -1,0 +1,30 @@
+import jax
+import jax.nn as jnn
+import jax.numpy as jnp
+
+import equinox as eqx
+
+
+def test_eval_shape(getkey):
+    mlp = eqx.nn.MLP(1, 2, 5, 2, key=getkey())
+    sentinel1 = object()
+    sentinel2 = object()
+    sentinel3 = object()
+
+    def call(fn1, fn2, x, flag):
+        if flag is sentinel1:
+            return fn1(x), sentinel2
+        else:
+            return fn2(x), sentinel3
+
+    y = jnp.array([1.0])
+    z = jax.ShapeDtypeStruct(shape=y.shape, dtype=y.dtype)
+    out1 = eqx.filter_eval_shape(call, mlp, jnn.relu, y, sentinel1)
+    out2 = eqx.filter_eval_shape(call, mlp, jnn.relu, y, object())
+    assert out1 == (jax.ShapeDtypeStruct(shape=(2,), dtype=y.dtype), sentinel2)
+    assert out2 == (jax.ShapeDtypeStruct(shape=(1,), dtype=y.dtype), sentinel3)
+
+    out3 = eqx.filter_eval_shape(call, mlp, jnn.relu, z, sentinel1)
+    out4 = eqx.filter_eval_shape(call, mlp, jnn.relu, z, object())
+    assert out3 == (jax.ShapeDtypeStruct(shape=(2,), dtype=y.dtype), sentinel2)
+    assert out4 == (jax.ShapeDtypeStruct(shape=(1,), dtype=y.dtype), sentinel3)


### PR DESCRIPTION
1. Previously using a callable `out` parameter was experimental for
   `filter_vmap` -- because it monkey-patched JAX internals -- and
   unavailable for `filter_pmap`. It has now been updated to work for both,
   and using only the public JAX API. (Hurrah.)

2. Drive-by: Added `eqx.filter_eval_shape` as it looked like this was
   going to useful as part of implementing the previous feature. In the
   end this wasn't the case, but we get a new feature anyway.

3. Drive-by: Fixed a crash bug when filter-jit'ing a partial-wrapped
   function whilst using a PyTree as its filter spec (`fn`).

Closes #115.

CC @jatentaki WDYT?