### PR TITLE
Added `eqx.experimental.noinline`

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -2,8 +2,6 @@ name: Run tests
 
 on:
   pull_request:
-  schedule:
-    - cron: "0 2 * * 6"
 
 jobs:
   run-test:

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -3,3 +3,4 @@ force_alphabetical_sort_within_sections=true
 lines_after_imports=2
 profile=black
 treat_comments_as_code=true
+extra_standard_library=typing_extensions

--- a/benchmarks/noinline.py
+++ b/benchmarks/noinline.py
@@ -1,0 +1,78 @@
+"""Benchmarks the effect of `equinox.experimental.noinline`.
+
+On my CPU-only machine:
+```
+bash> python noinline.py noinline
+Compile+run time 25.181116838008165
+Run time 0.5995359329972416
+
+bash> python noinline.py inline
+Compile+run time 35.71804388705641
+Run time 0.0017542819259688258
+```
+"""
+import functools as ft
+import sys
+import timeit
+
+import diffrax as dfx
+import jax.numpy as jnp
+import jax.random as jr
+
+import equinox as eqx
+
+
+# inline vs no-inline are done through separate executions of the script, to
+# be sure that there's no jaxpr caching making the second compilation faster.
+_, inline = sys.argv
+if inline == "inline":
+    noinline = False
+elif inline == "noinline":
+    noinline = True
+else:
+    raise ValueError
+
+
+def _weight(in_, out, key):
+    return [[w_ij for w_ij in w_i] for w_i in jr.normal(key, (out, in_))]
+
+
+class VectorField(eqx.Module):
+    weights: list
+
+    def __init__(self, in_, out, width, depth, *, key):
+        keys = jr.split(key, depth + 1)
+        self.weights = [_weight(in_, width, keys[0])]
+        for i in range(1, depth):
+            self.weights.append(_weight(width, width, keys[i]))
+        self.weights.append(_weight(width, out, keys[depth]))
+
+    def __call__(self, t, y, args):
+        # Inefficient computation graph to make a toy example more expensive.
+        y = [y_i for y_i in y]
+        for w in self.weights:
+            y = [sum(w_ij * y_j for w_ij, y_j in zip(w_i, y)) for w_i in w]
+        return jnp.stack(y)
+
+
+vf = VectorField(1, 1, 16, 2, key=jr.PRNGKey(0))
+if noinline:
+    vf = eqx.experimental.noinline(vf)
+term = dfx.ODETerm(vf)
+solver = dfx.Kvaerno5()
+stepsize_controller = dfx.PIDController(rtol=1e-3, atol=1e-6)
+t0 = 0
+t1 = 1
+dt0 = None
+
+
+@eqx.filter_jit
+def solve(y0):
+    return dfx.diffeqsolve(
+        term, solver, t0, t1, dt0, y0, stepsize_controller=stepsize_controller
+    )
+
+
+solve_ = ft.partial(solve, jnp.array([1.0]))
+print("Compile+run time", timeit.timeit(solve_, number=1))
+print("Run time", timeit.timeit(solve_, number=1))

--- a/docs/api/experimental/noinline.md
+++ b/docs/api/experimental/noinline.md
@@ -1,0 +1,6 @@
+# No-inline
+
+This offers tools to trade runtime for compile time. (Increase runtime to
+decrease compile time.)
+
+::: equinox.experimental.noinline

--- a/docs/api/filtering/filtered-transformations.md
+++ b/docs/api/filtering/filtered-transformations.md
@@ -27,3 +27,7 @@ Practically speaking these are usually the only kind of filtering you ever have 
 ---
 
 ::: equinox.filter_pmap
+
+---
+
+::: equinox.filter_eval_shape

--- a/equinox/__init__.py
+++ b/equinox/__init__.py
@@ -1,4 +1,5 @@
 from . import experimental, nn
+from .eval_shape import filter_eval_shape
 from .filters import (
     combine,
     filter,

--- a/equinox/compile_utils.py
+++ b/equinox/compile_utils.py
@@ -23,12 +23,20 @@ class Static(Module):
     value: Any = static_field()
 
 
-def strip_wrapped_partial(fun):
+def _strip_wrapped_partial(fun):
     if hasattr(fun, "__wrapped__"):  # ft.wraps
-        return strip_wrapped_partial(fun.__wrapped__)
+        return _strip_wrapped_partial(fun.__wrapped__)
     if isinstance(fun, ft.partial):
-        return strip_wrapped_partial(fun.func)
+        return _strip_wrapped_partial(fun.func)
     return fun
+
+
+def get_fun_names(fun):
+    fun = _strip_wrapped_partial(fun)
+    try:
+        return fun.__name__, fun.__qualname__
+    except AttributeError:
+        return type(fun).__name__, type(fun).__qualname__
 
 
 def compile_cache(fun):

--- a/equinox/eval_shape.py
+++ b/equinox/eval_shape.py
@@ -1,0 +1,28 @@
+import functools as ft
+from typing import Callable
+
+import jax
+
+from .compile_utils import Static
+from .filters import combine, is_array_like, partition
+
+
+def _filter(x):
+    return isinstance(x, jax.ShapeDtypeStruct) or is_array_like(x)
+
+
+def filter_eval_shape(fun: Callable, *args, **kwargs):
+    """As `jax.eval_shape`, but allows any Python object as inputs and outputs.
+
+    (`jax.eval_shape` is constrained to only work with JAX arrays, Python float/int/etc.)
+    """
+
+    def _fn(_static, _dynamic):
+        _args, _kwargs = combine(_static, _dynamic)
+        _out = fun(*_args, **_kwargs)
+        _dynamic_out, _static_out = partition(_out, _filter)
+        return _dynamic_out, Static(_static_out)
+
+    dynamic, static = partition((args, kwargs), _filter)
+    dynamic_out, static_out = jax.eval_shape(ft.partial(_fn, static), dynamic)
+    return combine(dynamic_out, static_out.value)

--- a/equinox/experimental/__init__.py
+++ b/equinox/experimental/__init__.py
@@ -1,3 +1,4 @@
 from .batch_norm import BatchNorm
+from .noinline import noinline
 from .spectral_norm import SpectralNorm
 from .stateful import get_state, set_state, StateIndex

--- a/equinox/experimental/noinline.py
+++ b/equinox/experimental/noinline.py
@@ -194,7 +194,8 @@ def _monkey_patch():
                     *args_flat,
                     arg_treedef=arg_treedef,
                     result_treedef=result_treedef,
-                    callback=callback**params
+                    callback=callback,
+                    **params
                 )
 
         class _Vmap(Module):
@@ -293,7 +294,8 @@ def _monkey_patch():
                     batch_axes_flat,
                     arg_treedef=arg_treedef,
                     result_treedef=result_treedef,
-                    callback=callback**params,
+                    callback=callback,
+                    **params
                 )
 
         ad.primitive_jvps[hcb.outside_call_p] = _outside_call_jvp_rule

--- a/equinox/experimental/noinline.py
+++ b/equinox/experimental/noinline.py
@@ -1,0 +1,420 @@
+import functools as ft
+from typing import Callable, Union
+from typing_extensions import Literal
+
+import jax
+import jax.experimental.host_callback as hcb
+import jax.interpreters.ad as ad
+import jax.interpreters.batching as batching
+import jax.numpy as jnp
+
+from ..compile_utils import hashable_combine, hashable_partition
+from ..custom_types import PyTree, sentinel, TreeDef
+from ..filters import is_array
+from ..module import Module, static_field
+
+
+class _NoInlineArg(Module):
+    dynamic: PyTree
+    args: PyTree
+    kwargs: PyTree
+
+
+# Monkey-patch the batching rule for host_callback.call to work with noinline
+_have_monkey_patched = False
+
+
+# To explain how this works.
+#
+# `noinline` is built on top of `host_callback.call`; we use it as a convenient
+# way to produce a separate XLA computation graph.
+#
+# However `host_callback` works by rewriting computation graphs; in particular
+# this means that it only works with those primitives which already exist
+# within JAX, and adding a new primitive isn't really supported. (It would be
+# very difficult to add support for a new primitive that copy-pastes
+# `host_callback` and makes the appropriate modifications.)
+#
+# So we're stuck with `host_callback.call` as our only mechanism. However, this
+# doesn't support JVPs, batching etc, which we need here.
+#
+# This means we need to monkey-patch in support for JVPs etc. into
+# `host_callback.call`, and we use `_NoInlineArg` to detect when we're calling
+# `noinline` rather than any other `host_callback.call`; we should fall back to
+# the default behaviour for generic `host_callback.call`s. (In particular if
+# anyone else is doing similar monkey-patching; e.g.
+# `eqx.experimental.stateful`.
+#
+# The implementation of each rule is essentially straightforward: we just use
+# the public JAX API applied to the function we're wrapping, and then wrap that
+# in a new `noinline` so that e.g. `jvp(noinline(fn)` becomes
+# `noinline(jvp(fn))`. (It might actually be a bit nicer to use the internal
+# JAX APIs for this purpose, especially if/when this ever gets upstreamed into
+# core JAX.)
+#
+# The only thing to be careful of here are all these `Module`s being used to
+# wrap every transformation.
+#
+# Suppose we have a `noinline(fn)` that we use multiple times in a jaxpr, and that we
+# subsequently e.g. apply `jax.linear_transpose` to this jaxpr.
+# Done naively we might convert `jax.linear_transpose(noinline(fn), x)` into
+# `noinline(jax.linear_transpose(fn), x)` each time.
+# However, each time `jax.linear_transpose(fn)` is called it would produce a new
+# Python function object, with a different hash/equality to every other call to
+# `jax.linear_transpose(fn)`. Meanwhile, `noinline` will JIT its argument (as
+# part of the external secondary computation graph that is the whole point of
+# using `noinline`). As each time it sees a result of `jax.linear_transpose(fn)`
+# it would believe it has a different function, it would have to re-JIT each
+# case separately.
+#
+# This would be unacceptable: the whole point of `noinline` is to avoid
+# re-JIT'ing each time we see the same function!
+#
+# Callable `Module`s are instead used to provide equality and hashing, so that
+# transposing `fn` produces an identical (wrt hash/equality) PyTree each time.
+def _monkey_patch():
+    global _have_monkey_patched
+    if not _have_monkey_patched:
+        _have_monkey_patched = True
+
+        _old_outside_call_jvp_rule = ad.primitive_jvps[hcb.outside_call_p]
+        _old_outside_call_transpose_rule = ad.primitive_transposes[hcb.outside_call_p]
+        _old_outside_call_batching_rule = batching.primitive_batchers[
+            hcb.outside_call_p
+        ]
+
+        class _Jvp(Module):
+            fn: Callable
+
+            def __call__(self, primal, tangent):
+                _, out = jax.jvp(self.fn, (primal,), (tangent,))
+                return out
+
+        def _outside_call_jvp_rule(
+            primal_arg_flat,
+            tangent_arg_flat,
+            *,
+            arg_treedef,
+            result_treedef,
+            callback,
+            **params
+        ):
+            primal_arg = jax.tree_unflatten(arg_treedef, primal_arg_flat)
+            if type(primal_arg) is _NoInlineArg:
+                # TODO: avoid instantiating symbolic zeros
+                tangent_arg_flat = [ad.instantiate_zeros(t) for t in tangent_arg_flat]
+                tangent_arg = jax.tree_unflatten(arg_treedef, tangent_arg_flat)
+                invoke = callback.callback_func
+                assert isinstance(invoke, _Invoke)
+                fn = hashable_combine(
+                    primal_arg.dynamic, invoke.static_leaves, invoke.static_treedef
+                )
+                eval_shape = lambda *_, **__: _get_shape(invoke, primal_arg)
+
+                # Can't get primal_out during the jvp because the noinline
+                # smushes the primal and tangent together, so the unknown (i.e.
+                # PartialVal) tangents produce unknown (PartialVal) primals.
+                # This is verboten - known input primals must produce known
+                #
+                # TODO: this is inefficient as it means we compute the primal
+                # twice
+                primal_out = noinline(fn, eval_shape)(
+                    *primal_arg.args, **primal_arg.kwargs
+                )
+                tangent_out = noinline(_Jvp(invoke), eval_shape)(
+                    primal_arg, tangent_arg
+                )
+                # Also note that we wrote `primal_out = ...` rather than
+                # `primal_out = noinline(invoke, out_shape)(primal_arg)`. This latter
+                # option is semantically correct but triggers extra compilation
+                # as `invoke` and `fn` are different things (despite computing
+                # the same output).
+
+                primal_out_flat, primal_out_treedef = jax.tree_flatten(primal_out)
+                tangent_out_flat, tangent_out_treedef = jax.tree_flatten(tangent_out)
+                assert primal_out_treedef == result_treedef
+                assert tangent_out_treedef == result_treedef
+                return tuple(primal_out_flat), tuple(tangent_out_flat)
+            else:
+                return _old_outside_call_jvp_rule(
+                    primal_arg_flat,
+                    tangent_arg_flat,
+                    arg_treedef=arg_treedef,
+                    result_treedef=result_treedef,
+                    callback=callback,
+                    **params
+                )
+
+        class _LinearTranspose(Module):
+            fn: Callable
+            undefined_arg_flat: list
+            defined_arg_flat: list
+            arg_treedef: TreeDef
+
+            def __call__(self, cts):
+                def _fn(*_undefined_arg_flat):
+                    _arg_flat = [
+                        u if d is None else d
+                        for u, d in zip(_undefined_arg_flat, self.defined_arg_flat)
+                    ]
+                    _arg = jax.tree_unflatten(self.arg_treedef, _arg_flat)
+                    return self.fn(_arg)
+
+                return jax.linear_transpose(_fn, *self.undefined_arg_flat)(cts)
+
+        def _outside_call_transpose_rule(
+            cts_flat, *args_flat, arg_treedef, result_treedef, callback, **params
+        ):
+            arg = jax.tree_unflatten(arg_treedef, args_flat)
+            if type(arg) is _NoInlineArg:
+                # TODO: avoid instantiating symbolic zeros
+                cts_flat = [ad.instantiate_zeros(ct) for ct in cts_flat]
+                cts = jax.tree_unflatten(result_treedef, cts_flat)
+                invoke = callback.callback_func
+                assert isinstance(invoke, _Invoke)
+                arg_flat, arg_treedef = jax.tree_flatten(
+                    arg, is_leaf=ad.is_undefined_primal
+                )
+                undefined_arg_flat = [
+                    x.aval if ad.is_undefined_primal(x) else None for x in arg_flat
+                ]
+                defined_arg_flat = [
+                    None if ad.is_undefined_primal(x) else x for x in arg_flat
+                ]
+                eval_shape = lambda *_: tuple(undefined_arg_flat)
+                return noinline(
+                    _LinearTranspose(
+                        invoke, undefined_arg_flat, defined_arg_flat, arg_treedef
+                    ),
+                    eval_shape,
+                )(cts)
+            else:
+                return _old_outside_call_transpose_rule(
+                    cts,
+                    *args_flat,
+                    arg_treedef=arg_treedef,
+                    result_treedef=result_treedef,
+                    callback=callback**params
+                )
+
+        class _Vmap(Module):
+            fn: Callable
+            arg_treedef: TreeDef = static_field()
+            in_axes_leaves: tuple = static_field()
+            in_axes_treedef: PyTree = static_field()
+
+            def __call__(self, arg_flat):
+                def fn_flat(*_arg_flat):
+                    _arg = jax.tree_unflatten(self.arg_treedef, _arg_flat)
+                    return self.fn(_arg)
+
+                # TODO: support not batching all outputs (would need to dig into
+                # batching.batch_jaxpr etc., and adjust our output shape
+                # calculations)
+                in_axes = jax.tree_unflatten(self.in_axes_treedef, self.in_axes_leaves)
+                return jax.vmap(fn_flat, in_axes=in_axes)(*arg_flat)
+
+        def _index(a, b):
+            if b is None:
+                return a
+            else:
+                # like doing `a[b]`, except that `a` might be an aval so we have
+                # to do this instead.
+                shape = a.shape[:b] + a.shape[b + 1 :]
+                return jax.ShapeDtypeStruct(shape=shape, dtype=a.dtype)
+
+        def _prepend(axis_size):
+            def _prepend_impl(struct):
+                return jax.ShapeDtypeStruct(
+                    shape=(axis_size,) + struct.shape, dtype=struct.dtype
+                )
+
+            return _prepend_impl
+
+        def _outside_call_batching_rule(
+            arg_flat,
+            batch_axes_flat,
+            *,
+            arg_treedef,
+            result_treedef,
+            callback,
+            **params
+        ):
+            arg = jax.tree_unflatten(arg_treedef, arg_flat)
+            if type(arg) is _NoInlineArg:
+                invoke = callback.callback_func
+                assert isinstance(invoke, _Invoke)
+
+                def eval_shape(_):
+                    axis_size = None
+                    for a, b in zip(arg_flat, batch_axes_flat):
+                        if b is not None:
+                            assert isinstance(b, int)
+                            axis_size = a.shape[b]
+                            break
+                    if axis_size is None:
+                        # Very rare that we end up on this branch: the user is
+                        # calling `jax.vmap` without arguments, and specifying
+                        # `jax.vmap(..., axis_size=...)` instead. In this case we
+                        # can't identify the axis size based on the arguments, so we
+                        # bite the bullet and go via `jax.eval_shape` instead.
+                        return sentinel
+                    else:
+                        # More commmon case: we can figure out the output shape
+                        # based on the output shape of the unbatched version, and
+                        # knowledge of the axis size. We can skip the cost
+                        # of evaluating `jax.eval_shape`.
+                        single_arg_flat = jax.tree_map(
+                            _index, arg_flat, batch_axes_flat
+                        )
+                        single_arg = jax.tree_unflatten(arg_treedef, single_arg_flat)
+                        single_out_shape = _get_shape(invoke, single_arg)
+                        return jax.tree_map(_prepend(axis_size), single_out_shape)
+
+                batch_axes_flat_leaves, batch_axes_flat_treedef = jax.tree_flatten(
+                    batch_axes_flat
+                )
+                batch_axes_flat_leaves = tuple(batch_axes_flat_leaves)
+                out = noinline(
+                    _Vmap(
+                        invoke,
+                        arg_treedef,
+                        batch_axes_flat_leaves,
+                        batch_axes_flat_treedef,
+                    ),
+                    eval_shape,
+                )(arg_flat)
+                out_flat, out_treedef = jax.tree_flatten(out)
+                assert out_treedef == result_treedef
+                return out_flat, [0] * len(out_flat)
+            else:
+                return _old_outside_call_batching_rule(
+                    arg_flat,
+                    batch_axes_flat,
+                    arg_treedef=arg_treedef,
+                    result_treedef=result_treedef,
+                    callback=callback**params,
+                )
+
+        ad.primitive_jvps[hcb.outside_call_p] = _outside_call_jvp_rule
+        ad.primitive_transposes[hcb.outside_call_p] = _outside_call_transpose_rule
+        batching.primitive_batchers[hcb.outside_call_p] = _outside_call_batching_rule
+
+
+class _Invoke(Module):
+    static_leaves: PyTree = static_field()
+    static_treedef: PyTree = static_field()
+
+    # Not using eqx.filter_jit, as that has a higher overhead due to the
+    # filtering. It's important that we keep overheads as low as possible as we
+    # call _Invoke many times at runtime.
+    @ft.partial(jax.jit, static_argnums=0)
+    def __call__(self, arg):
+        fn = hashable_combine(arg.dynamic, self.static_leaves, self.static_treedef)
+        return fn(*arg.args, **arg.kwargs)
+
+
+_out_shape_cache = {}
+
+
+def _make_lookup(invoke: _Invoke, arg: _NoInlineArg):
+    in_shape = jax.tree_map(lambda x: (x.shape, x.dtype), arg)
+    lookup_leaves, lookup_treedef = jax.tree_flatten((in_shape, invoke))
+    return tuple(lookup_leaves), lookup_treedef
+
+
+def _get_shape(invoke: _Invoke, arg: _NoInlineArg):
+    lookup = _make_lookup(invoke, arg)
+    return _out_shape_cache[lookup]
+
+
+class _NoInlineFn(Module):
+    invoke: _Invoke
+    dynamic: PyTree
+    eval_shape: Union[Literal[sentinel], Callable]
+
+    def __call__(__self, *args, **kwargs):
+        args, kwargs = jax.tree_map(jnp.asarray, (args, kwargs))
+        arg = _NoInlineArg(__self.dynamic, args, kwargs)
+        lookup = _make_lookup(__self.invoke, arg)
+        try:
+            out_shape = _out_shape_cache[lookup]
+        except KeyError:
+            if __self.eval_shape is sentinel:
+                out_shape = jax.eval_shape(__self.invoke, arg)
+            else:
+                out_shape = __self.eval_shape(*args, **kwargs)
+                if out_shape is sentinel:
+                    out_shape = jax.eval_shape(__self.invoke, arg)
+            _out_shape_cache[lookup] = out_shape
+        return hcb.call(__self.invoke, arg, result_shape=out_shape)
+
+
+def noinline(fn, eval_shape=sentinel):
+    """Compiles `fn` into a separate XLA computation graph, without inlining.
+
+    By default, JAX will trace your entire program into a single computation graph, and
+    then compile the entire graph in one go. This is usually great for efficiency:
+    every operation you perform is "inlined" into a single computation graph, which
+    allows for many compiler optimisations to occur.
+
+    However, it can have some drawbacks: if you call the same operation multiple
+    times then each copy is treated independently by the compiler. This can sometimes
+    produce very long compile times. (Calling something multiple times because it's in
+    a `lax.scan` etc. is fine -- it's if the function has to be traced multiple times
+    that compile times slow down.)
+
+    This decorator marks its function as instead having a separate computation graph,
+    which can be optimised just once and reused each time. This produces faster compile
+    times, at the expense of some runtime performance. (At runtime this introduces two
+    sources of overhead: (1) the no-inline'd function cannot have compiler
+    optimisations applied jointly with its surrounding computation graph. (2) there is
+    the overhead of calling the sub-computation-graph from the main one.)
+
+    **Arguments:**
+
+    - `fn`: The callable to not inline. It need not be a pure Python function,
+      e.g. it can be an instance of `eqx.Module` etc. as well. It must satisfy:
+
+      1. It must be a function from (a PyTree of) JAX arrays to (a PyTree of) JAX arrays.
+         That is to say, arbitrary Python inputs and outputs are not supported. Python
+         int/float/bool/complex will be cast to JAX arrays.
+
+      2. The result of `eqx.filter(fn, is_array, inverse=True)` must be hashable.
+         This is what is looked up to get the same sub-computation-graph each time `fn`
+         is called.
+
+    - `eval_shape`: Optional. If passed, this should satisfy
+      `eval_shape(*args, **kwargs) == jax.eval_shape(fn, *args, **kwargs)`, where
+      `*args` and `**kwargs` denote whatever args and kwargs are passed at runtime.
+      This argument can be used if the output shape is known to the end user, so that
+      the call to `jax.eval_shape` can be skipped.
+
+    **Returns**
+
+    A version of `fn` that will be compiled only once when used inside a `jax.jit`
+    region. It will not be inlined into the surrounding computation graph.
+
+    !!! warning
+
+        A `noinline`'d function is excuted on the CPU. If your main computation is on
+        the GPU then this may be slow, and will necessitate GPU->CPU and CPU->GPU
+        copies. As such `noinline` is only recommended for use in CPU-based computations.
+
+    !!! example
+
+        Differential equation solvers (here we use
+        [Diffrax](https://github.com/patrick-kidger/diffrax)) often evaluate the vector
+        field multiple times in different places. (Precisely, in the code below: twice
+        to determine the initial step size; once to determine the initial state of the
+        solver. Then another 19 times for making a step! (6 non-FSAL stages * 3 traces
+        in the Newton optimiser + 1 for a Jacobian evaluation.) This makes them a great
+        application for `noinline`. See
+        [the benchmark](https://github.com/patrick-kidger/equinox/blob/main/benchmarks/noinline.py)
+        for a code example.
+    """
+
+    _monkey_patch()
+    dynamic, static_leaves, static_treedef = hashable_partition(fn, is_array)
+    invoke = _Invoke(static_leaves, static_treedef)
+    return _NoInlineFn(invoke, dynamic, eval_shape)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -119,6 +119,7 @@ nav:
             - 'api/utilities/miscellaneous.md'
         - Experimental:
             - 'api/experimental/stateful.md'
+            - 'api/experimental/noinline.md'
     - Misc:
         - 'citation.md'
         - 'faq.md'

--- a/tests/test_eval_shape.py
+++ b/tests/test_eval_shape.py
@@ -1,0 +1,30 @@
+import jax
+import jax.nn as jnn
+import jax.numpy as jnp
+
+import equinox as eqx
+
+
+def test_eval_shape(getkey):
+    mlp = eqx.nn.MLP(1, 2, 5, 2, key=getkey())
+    sentinel1 = object()
+    sentinel2 = object()
+    sentinel3 = object()
+
+    def call(fn1, fn2, x, flag):
+        if flag is sentinel1:
+            return fn1(x), sentinel2
+        else:
+            return fn2(x), sentinel3
+
+    y = jnp.array([1.0])
+    z = jax.ShapeDtypeStruct(shape=y.shape, dtype=y.dtype)
+    out1 = eqx.filter_eval_shape(call, mlp, jnn.relu, y, sentinel1)
+    out2 = eqx.filter_eval_shape(call, mlp, jnn.relu, y, object())
+    assert out1 == (jax.ShapeDtypeStruct(shape=(2,), dtype=y.dtype), sentinel2)
+    assert out2 == (jax.ShapeDtypeStruct(shape=(1,), dtype=y.dtype), sentinel3)
+
+    out3 = eqx.filter_eval_shape(call, mlp, jnn.relu, z, sentinel1)
+    out4 = eqx.filter_eval_shape(call, mlp, jnn.relu, z, object())
+    assert out3 == (jax.ShapeDtypeStruct(shape=(2,), dtype=y.dtype), sentinel2)
+    assert out4 == (jax.ShapeDtypeStruct(shape=(1,), dtype=y.dtype), sentinel3)

--- a/tests/test_noinline.py
+++ b/tests/test_noinline.py
@@ -1,0 +1,86 @@
+import jax
+import jax.numpy as jnp
+import jax.random as jr
+from helpers import shaped_allclose
+
+import equinox as eqx
+
+
+def test_unchanged(getkey):
+    mlp = eqx.nn.MLP(2, 2, 512, 2, key=getkey())
+    mlp_noinline = eqx.experimental.noinline(mlp)
+    mlp_jit = eqx.filter_jit(mlp)
+    mlp_jit_noinline = eqx.filter_jit(mlp_noinline)
+    x = jr.normal(getkey(), (2,))
+    o1 = mlp_jit(x)
+    o2 = mlp_noinline(x)
+    o3 = mlp_jit_noinline(x)
+    assert shaped_allclose(o1, o2)
+    assert shaped_allclose(o1, o3)
+
+
+def test_vmap_unchanged(getkey):
+    mlp = eqx.nn.MLP(2, 2, 512, 2, key=getkey())
+    mlp_noinline = eqx.experimental.noinline(mlp)
+    mlp_vmap = jax.vmap(mlp)
+    mlp_jit_vmap = eqx.filter_jit(mlp_vmap)
+    mlp_vmap_noinline = jax.vmap(mlp_noinline)
+    mlp_jit_vmap_noinline = eqx.filter_jit(mlp_vmap_noinline)
+    x = jr.normal(getkey(), (5, 2))
+    o1 = mlp_jit_vmap(x)
+    o2 = mlp_vmap_noinline(x)
+    o3 = mlp_jit_vmap_noinline(x)
+    assert shaped_allclose(o1, o2)
+    assert shaped_allclose(o1, o3)
+
+
+def test_jvp_unchanged(getkey):
+    mlp = eqx.nn.MLP(2, 2, 512, 2, key=getkey())
+    mlp_noinline = eqx.experimental.noinline(mlp)
+    mlp_jvp = lambda p, t: jax.jvp(mlp, (p,), (t,))
+    mlp_jit_jvp = eqx.filter_jit(mlp_jvp)
+    mlp_jvp_noinline = lambda p, t: jax.jvp(mlp_noinline, (p,), (t,))
+    mlp_jit_jvp_noinline = eqx.filter_jit(mlp_jvp_noinline)
+    x = jr.normal(getkey(), (2,))
+    y = jr.normal(getkey(), (2,))
+    o1 = mlp_jit_jvp(x, y)
+    o2 = mlp_jvp_noinline(x, y)
+    o3 = mlp_jit_jvp_noinline(x, y)
+    assert shaped_allclose(o1, o2)
+    assert shaped_allclose(o1, o3)
+
+
+def test_grad_unchanged(getkey):
+    mlp = eqx.nn.MLP(2, 2, 512, 2, key=getkey())
+    mlp_noinline = eqx.experimental.noinline(mlp)
+    mlp_grad = jax.grad(lambda x: jnp.sum(mlp(x)))
+    mlp_jit_grad = eqx.filter_jit(mlp_grad)
+    mlp_grad_noinline = jax.grad(lambda x: jnp.sum(mlp_noinline(x)))
+    mlp_jit_grad_noinline = eqx.filter_jit(mlp_grad_noinline)
+    x = jr.normal(getkey(), (2,))
+    o1 = mlp_jit_grad(x)
+    o2 = mlp_grad_noinline(x)
+    o3 = mlp_jit_grad_noinline(x)
+    assert shaped_allclose(o1, o2)
+    assert shaped_allclose(o1, o3)
+
+
+def test_num_traces():
+    num_traces = 0
+
+    def fn(x):
+        nonlocal num_traces
+        num_traces += 1
+        return x * 2
+
+    fn_noinline = eqx.experimental.noinline(fn)
+    assert shaped_allclose(fn_noinline(1), jnp.array(2))
+    assert num_traces == 2  # eval_shape + jit
+    assert shaped_allclose(fn_noinline(2), jnp.array(4))
+    assert num_traces == 2
+
+    fn_jit_noinline = jax.jit(fn_noinline)
+    assert shaped_allclose(fn_jit_noinline(1), jnp.array(2))
+    assert num_traces == 2
+    assert shaped_allclose(fn_jit_noinline(2), jnp.array(4))
+    assert num_traces == 2


### PR DESCRIPTION
TL;DR: XLA sub-graphs!

### Background

At present, JAX inlines the entire computation into a single XLA graph.

However, many scientific computing applications involve defining some modestly complicated function and then calling this function numerous times in different contexts. For example the vector field for an ODE must be traced 22 times when using the Kvaerno5 solver with automatic initial step size selection. (In ways that cannot easily be tidied up into a `lax.scan` or similar.)

Inlining without awareness of the repeated structure means the compiler is less efficient than it could be. I know of current examples with compile times about an hour long.

To support this use case there's been talk for quite a while about adding support to JAX or XLA for sub-programs, e.g.
https://github.com/google/jax/issues/10974
https://github.com/google/jax/issues/4572
https://github.com/google/jax/issues/3847
https://github.com/google/jax/issues/9298

### no-inline decorator

Introducing `equinox.experimental.noinline`. This decorator places the function in a separate XLA computation graph, and links it up with the main one via `jax.experimental.host_callback.call`. The decorated function is only traced once; only one copy of it exists as a jaxpr; it is only compiled once. It can still be transformed via grad, vmap etc.

Running the included benchmark `benchmarks/noinline.py` we obtain a reduction in compile time 36 seconds -> 25 seconds, at the expense of a large runtime increase, 0.002 seconds -> 0.6 seconds. In practice that's still a good net saving (36 seconds -> 25.6 seconds) in the common use-case that you're developing + debugging your program.

Going further and switching the solver in the benchmark from `dfx.Kvaerno5()` to `dfx.Dopri8()` gives even better results: a compile time reduction of 23 seconds -> 8 seconds (!), with a runtime increase of 0.002 seconds -> 0.16 seconds. (I chose not to implement this as the default benchmark, just because I have other unrelated plans for improving the compile time of `Dopri8`.)

### Limitations

1. All the awful hackery and monkey-patching of JAX internals needed to make this work.
2. This will only be efficient on the CPU. On the GPU it'll entail copies to and from the device. However I speculate that this isn't actually necessary, and may just be a limitation of our current use of `host_callback`?
3. The runtime performance has cratered. I speculate a lot of that cost is due to the back-and-forth switching via Python, again due to our use of `host_callback`. (Flame graphs TBD.) Possibly also something GIL related?

Nonetheless, our main use-case is on the CPU and the overall compile-time improvements on the benchmark represent compile speed improvements of 1.5x to 3x, which is enough to make me happy. This is something we're looking forward to relying on as those 1+ hour compile times are really biting us.

### CC

@shoyer and @YouJiacheng as I know you've both wanted this functionality in the past.
@federicov (+team) for using this.

Also speculatively tagging @gnecula (I have it in my head that you're behind `host_callback`?) @mattjj for possible interest. (Feel free to ignore this.)