### PR TITLE
`{Avg,Max}Pool{1,2,3}D` -> `{Avg,Max}Pool{1,2,3}d`. Removed wrong stride default.

### DIFF
--- a/docs/api/nn/pool.md
+++ b/docs/api/nn/pool.md
@@ -8,7 +8,7 @@
 
 ---
 
-::: equinox.nn.AvgPool1D
+::: equinox.nn.AvgPool1d
     selection:
         members:
             - __init__
@@ -16,7 +16,7 @@
 
 ---
 
-::: equinox.nn.AvgPool2D
+::: equinox.nn.AvgPool2d
     selection:
         members:
             - __init__
@@ -24,7 +24,7 @@
 
 ---
 
-::: equinox.nn.AvgPool3D
+::: equinox.nn.AvgPool3d
     selection:
         members:
             - __init__
@@ -32,7 +32,7 @@
 
 ---
 
-::: equinox.nn.MaxPool1D
+::: equinox.nn.MaxPool1d
     selection:
         members:
             - __init__
@@ -40,7 +40,7 @@
 
 ---
 
-::: equinox.nn.MaxPool2D
+::: equinox.nn.MaxPool2d
     selection:
         members:
             - __init__
@@ -48,7 +48,7 @@
 
 ---
 
-::: equinox.nn.MaxPool3D
+::: equinox.nn.MaxPool3d
     selection:
         members:
             - __init__

--- a/equinox/nn/__init__.py
+++ b/equinox/nn/__init__.py
@@ -23,11 +23,17 @@ from .pool import (
     AdaptiveMaxPool3d,
     AdaptivePool,
     AvgPool1D,
+    AvgPool1d,
     AvgPool2D,
+    AvgPool2d,
     AvgPool3D,
+    AvgPool3d,
     MaxPool1D,
+    MaxPool1d,
     MaxPool2D,
+    MaxPool2d,
     MaxPool3D,
+    MaxPool3d,
     Pool,
 )
 from .rnn import GRUCell, LSTMCell

--- a/equinox/nn/pool.py
+++ b/equinox/nn/pool.py
@@ -120,13 +120,13 @@ class Pool(Module):
         return x
 
 
-class AvgPool1D(Pool):
+class AvgPool1d(Pool):
     """One-dimensional downsample using an average over a sliding window."""
 
     def __init__(
         self,
         kernel_size,
-        stride=None,
+        stride,
         padding=0,
         **kwargs,
     ):
@@ -165,13 +165,13 @@ class AvgPool1D(Pool):
         return super().__call__(x) / np.prod(self.kernel_size)
 
 
-class MaxPool1D(Pool):
+class MaxPool1d(Pool):
     """One-dimensional downsample using the maximum over a sliding window."""
 
     def __init__(
         self,
         kernel_size,
-        stride=None,
+        stride,
         padding=0,
         **kwargs,
     ):
@@ -211,13 +211,13 @@ class MaxPool1D(Pool):
         return super().__call__(x)
 
 
-class AvgPool2D(Pool):
+class AvgPool2d(Pool):
     """Two-dimensional downsample using an average over a sliding window."""
 
     def __init__(
         self,
         kernel_size,
-        stride=None,
+        stride,
         padding=0,
         **kwargs,
     ):
@@ -256,13 +256,13 @@ class AvgPool2D(Pool):
         return super().__call__(x) / np.prod(self.kernel_size)
 
 
-class MaxPool2D(Pool):
+class MaxPool2d(Pool):
     """Two-dimensional downsample using the maximum over a sliding window."""
 
     def __init__(
         self,
         kernel_size,
-        stride=None,
+        stride,
         padding=0,
         **kwargs,
     ):
@@ -302,13 +302,13 @@ class MaxPool2D(Pool):
         return super().__call__(x)
 
 
-class AvgPool3D(Pool):
+class AvgPool3d(Pool):
     """Three-dimensional downsample using an average over a sliding window."""
 
     def __init__(
         self,
         kernel_size,
-        stride=None,
+        stride,
         padding=0,
         **kwargs,
     ):
@@ -348,13 +348,13 @@ class AvgPool3D(Pool):
         return super().__call__(x) / np.prod(self.kernel_size)
 
 
-class MaxPool3D(Pool):
+class MaxPool3d(Pool):
     """Three-dimensional downsample using the maximum over a sliding window."""
 
     def __init__(
         self,
         kernel_size,
-        stride=None,
+        stride,
         padding=0,
         **kwargs,
     ):
@@ -392,6 +392,15 @@ class MaxPool3D(Pool):
         """
 
         return super().__call__(x)
+
+
+# Backward compatability: these were originally misnamed.
+AvgPool1D = AvgPool1d
+AvgPool2D = AvgPool2d
+AvgPool3D = AvgPool3d
+MaxPool1D = MaxPool1d
+MaxPool2D = MaxPool2d
+MaxPool3D = MaxPool3d
 
 
 def _adaptive_pool1d(x: Array, target_size: int, operation: Callable) -> Array:

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -761,7 +761,7 @@ def test_spectral_norm(getkey):
 def test_maxpool1d():
 
     x = jnp.arange(14).reshape(1, 14)
-    max_pool = eqx.nn.MaxPool1D(2, 3)
+    max_pool = eqx.nn.MaxPool1d(2, 3)
     output = max_pool(x)
     answer = jnp.array([1, 4, 7, 10, 13])
 
@@ -771,7 +771,7 @@ def test_maxpool1d():
 def test_avgpool1d():
 
     x = jnp.arange(14).reshape(1, 14)
-    avg_pool = eqx.nn.AvgPool1D(2, 3)
+    avg_pool = eqx.nn.AvgPool1d(2, 3)
     output = avg_pool(x)
     answer = jnp.array([0.5, 3.5, 6.5, 9.5, 12.5])
 
@@ -805,7 +805,7 @@ def test_adaptive_maxpool1d():
 def test_maxpool2d():
 
     x = jnp.arange(36).reshape(1, 6, 6)
-    max_pool = eqx.nn.MaxPool2D(2, (3, 2))
+    max_pool = eqx.nn.MaxPool2d(2, (3, 2))
     output = max_pool(x)
     answer = jnp.array([[7, 9, 11], [25, 27, 29]])
 
@@ -815,7 +815,7 @@ def test_maxpool2d():
 def test_avgpool2d():
 
     x = jnp.arange(36).reshape(1, 6, 6)
-    avg_pool = eqx.nn.AvgPool2D((1, 3), 2)
+    avg_pool = eqx.nn.AvgPool2d((1, 3), 2)
     output = avg_pool(x)
     answer = jnp.array([[1, 3], [13, 15], [25, 27]])
 
@@ -849,7 +849,7 @@ def test_adaptive_maxpool2d():
 def test_maxpool3d():
 
     x = jnp.arange(64).reshape(1, 4, 4, 4)
-    max_pool = eqx.nn.MaxPool3D(2, (3, 2, 1))
+    max_pool = eqx.nn.MaxPool3d(2, (3, 2, 1))
     output = max_pool(x)
     answer = jnp.array([[[21, 22, 23], [29, 30, 31]]])
 
@@ -859,7 +859,7 @@ def test_maxpool3d():
 def test_avgpool3d():
 
     x = jnp.arange(64).reshape(1, 4, 4, 4)
-    avg_pool = eqx.nn.AvgPool3D((1, 3, 1), 2)
+    avg_pool = eqx.nn.AvgPool3d((1, 3, 1), 2)
     output = avg_pool(x)
     answer = jnp.array([[[4, 6]], [[36, 38]]])
 
@@ -892,7 +892,7 @@ def test_adaptive_maxpool3d():
 
 def test_poolpadding():
     x = jnp.arange(64).reshape(1, 4, 4, 4)
-    max_pool = eqx.nn.MaxPool3D(2, 1, ((0, 1), (0, 1), (0, 1)))
+    max_pool = eqx.nn.MaxPool3d(2, 1, ((0, 1), (0, 1), (0, 1)))
     output = max_pool(x)
 
     assert output.shape == (1, 4, 4, 4)
@@ -900,7 +900,7 @@ def test_poolpadding():
 
 def test_poolbackprop():
     def max_pool_mean(x):
-        max_pool = eqx.nn.MaxPool3D((2, 2, 2), (1, 1, 1), ((0, 1), (0, 1), (0, 1)))
+        max_pool = eqx.nn.MaxPool3d((2, 2, 2), (1, 1, 1), ((0, 1), (0, 1), (0, 1)))
         return jnp.mean(max_pool(x))
 
     x = jnp.arange(64, dtype=jnp.float32).reshape(1, 4, 4, 4)
@@ -911,12 +911,12 @@ def test_poolbackprop():
 
 def test_poolnetworkbackprop(getkey):
     class CNN(eqx.Module):
-        conv_layer: List[Union[eqx.nn.Conv2d, eqx.nn.MaxPool2D]]
+        conv_layer: List[Union[eqx.nn.Conv2d, eqx.nn.MaxPool2d]]
         linear_layers: List[eqx.nn.Linear]
 
         def __init__(self, key):
             key1, key2, key3 = jax.random.split(key, 3)
-            self.conv_layer = [eqx.nn.Conv2d(3, 2, 3, key=key1), eqx.nn.MaxPool2D(2, 2)]
+            self.conv_layer = [eqx.nn.Conv2d(3, 2, 3, key=key1), eqx.nn.MaxPool2d(2, 2)]
             self.linear_layers = [
                 eqx.nn.Linear(450, 256, key=key2),
                 eqx.nn.Linear(256, 10, key=key3),


### PR DESCRIPTION
Just noticed this minor issue. CC @paganpasta for interest.