### PR TITLE
Fix GroupNorm channels argument and docstring

### DIFF
--- a/equinox/nn/normalisation.py
+++ b/equinox/nn/normalisation.py
@@ -134,7 +134,7 @@ class GroupNorm(Module):
     def __init__(
         self,
         groups: int,
-        channels: Optional[int]=None,
+        channels: Optional[int] = None,
         eps: float = 1e-5,
         channelwise_affine: bool = True,
         **kwargs,
@@ -150,7 +150,9 @@ class GroupNorm(Module):
         if (channels is not None) and (channels % groups != 0):
             raise ValueError("The number of groups must divide the number of channels.")
         if (channels is None) and channelwise_affine:
-            raise ValueError("The number of channels should be specified if `channelwise_affine=True`")
+            raise ValueError(
+                "The number of channels should be specified if `channelwise_affine=True`"
+            )
         super().__init__(**kwargs)
         self.groups = groups
         self.channels = channels

--- a/equinox/nn/normalisation.py
+++ b/equinox/nn/normalisation.py
@@ -149,8 +149,8 @@ class GroupNorm(Module):
         """
         if (channels is not None) and (channels % groups != 0):
             raise ValueError("The number of groups must divide the number of channels.")
-        if (channels is None) and (channelwise_affine==True):
-            raise ValueError("The number of channels should be specified if `channel_wise_affine=True`")
+        if (channels is None) and channelwise_affine:
+            raise ValueError("The number of channels should be specified if `channelwise_affine=True`")
         super().__init__(**kwargs)
         self.groups = groups
         self.channels = channels
@@ -172,7 +172,7 @@ class GroupNorm(Module):
 
         A JAX array of shape `(channels, ...)`.
         """
-        channels = x.shape[0] if self.channels is None else self.channels
+        channels = x.shape[0]
         y = x.reshape(self.groups, channels // self.groups, *x.shape[1:])
         mean = jax.vmap(ft.partial(jnp.mean, keepdims=True))(y)
         variance = jax.vmap(ft.partial(jnp.var, keepdims=True))(y)

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -606,6 +606,19 @@ def test_group_norm(getkey):
     assert jnp.allclose(gn(x1), gn(x2), atol=1e-4)
     assert jnp.allclose(gn(x1), x3, atol=1e-4)
 
+    # channels not divisible by groups
+    with pytest.raises(ValueError):
+        gn = eqx.nn.GroupNorm(groups=3, channels=4)
+
+    # test w/ channels=None
+    gn = eqx.nn.GroupNorm(groups=4, channelwise_affine=False)
+    x = jrandom.uniform(getkey(), (128,))
+    assert gn(x).shape == (128,)
+
+    # Unknown channels w/ channelwise_affine=True
+    with pytest.raises(ValueError):
+        gn = eqx.nn.GroupNorm(groups=4, channels=None, channelwise_affine=True)
+
 
 def test_batch_norm(getkey):
     x0 = jrandom.uniform(getkey(), (5,))


### PR DESCRIPTION
- Removes erroneous `shape` parameter from docstring
- Fixes #127 
- Adds tests for various argument combinations