### PR TITLE
make `Sequential` indexable and add tests

### DIFF
--- a/equinox/nn/composed.py
+++ b/equinox/nn/composed.py
@@ -1,5 +1,5 @@
 import typing
-from typing import Any, Callable, List, Optional, Sequence
+from typing import Any, Callable, List, Optional, Sequence, Union
 
 import jax
 import jax.nn as jnn
@@ -44,7 +44,7 @@ class MLP(Module):
         final_activation: Callable = _identity,
         *,
         key: "jax.random.PRNGKey",
-        **kwargs
+        **kwargs,
     ):
         """**Arguments**:
 
@@ -123,6 +123,14 @@ class Sequential(Module):
         for layer, key in zip(self.layers, keys):
             x = layer(x, key=key)
         return x
+
+    def __getitem__(self, i: Union[int, slice]) -> Module:
+        if isinstance(i, int):
+            return self.layers[i]
+        elif isinstance(i, slice):
+            return Sequential(self.layers[i])
+        else:
+            raise TypeError(f"Indexing with type {type(i)} is not supported")
 
 
 Sequential.__init__.__doc__ = """**Arguments:**

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -125,6 +125,14 @@ def test_sequential(getkey):
     )
     x = jrandom.normal(getkey(), (2,))
     assert seq(x).shape == (3,)
+    # Test indexing
+    assert isinstance(seq[0], eqx.nn.Linear)
+    assert isinstance(seq[1:], eqx.nn.Sequential)
+    x = jrandom.normal(getkey(), (4,))
+    assert seq[1:](x).shape == (3,)
+
+    with pytest.raises(TypeError):
+        seq[[0, 1, 2]]
 
 
 def test_mlp(getkey):


### PR DESCRIPTION
- Implements #152 
- Adds indexing tests for `Sequential`