### PR TITLE
Added `clear_cache` method to `filter_{jit,pmap}`. Made `compile_cache` take a weakref to the function being compiled.

### DIFF
--- a/equinox/jit.py
+++ b/equinox/jit.py
@@ -7,13 +7,7 @@ from typing import Any, Callable, Sequence
 import jax
 import jax.tree_util as jtu
 
-from .compile_utils import (
-    compile_cache,
-    get_fun_names,
-    hashable_combine,
-    hashable_partition,
-    Static,
-)
+from .compile_utils import compile_cache, hashable_combine, hashable_partition, Static
 from .custom_types import BoolAxisSpec, PyTree, sentinel, TreeDef
 from .doc_utils import doc_strip_annotations
 from .filters import combine, is_array, partition
@@ -96,6 +90,9 @@ class _JitWrapper(Module):
 
     def lower(__self, *args, **kwargs):
         return __self._fun_wrapper(True, args, kwargs)
+
+    def clear_cache(self):
+        return self._cached._clear_cache()
 
     def __get__(self, instance, owner):
         if instance is None:
@@ -272,7 +269,7 @@ def filter_jit(
     dynamic_fun, static_fun_leaves, static_fun_treedef = hashable_partition(
         fun, filter_fn
     )
-    cached = _filter_jit_cache(get_fun_names(fun), **jitkwargs)
+    cached = _filter_jit_cache(fun, **jitkwargs)
 
     jit_wrapper = _JitWrapper(
         _new_style=new_style,

--- a/tests/test_filter_jit.py
+++ b/tests/test_filter_jit.py
@@ -435,3 +435,11 @@ def test_wrap_jax_partial(getkey):
     g = jtu.Partial(f, jrandom.normal(getkey(), ()))
     fn = jtu.Partial(f, True)
     eqx.filter_jit(g, fn=fn)
+
+
+def test_clear_cache():
+    @eqx.filter_jit
+    def f(x):
+        return x
+
+    f.clear_cache()

--- a/tests/test_filter_pmap.py
+++ b/tests/test_filter_pmap.py
@@ -306,3 +306,11 @@ def test_map_non_jax():
             pytree_sharded,
         ),
     )(pytree_sharded)
+
+
+def test_clear_cache():
+    @eqx.filter_pmap
+    def f(x):
+        return x
+
+    f.clear_cache()


### PR DESCRIPTION
The `clear_cache` method is useful for handling growing memory issues, see https://github.com/patrick-kidger/diffrax/issues/142.

Note that the weakref change here is different to that proposed in the link above, and is essentially an unrelated improvement. The link above suggests taking weakrefs to function-valued arguments to the annotated function. The weakref change here takes a weakref to the annotated function itself.

The change made here is much less important, but taking weakrefs to static arguments is something that can only be done at the `jax.jit` level, as so far as I know it does not expose an API for removing particular elements from its compilation cache.