### PR TITLE
Add len and iter methods to nn.Sequential

### DIFF
--- a/equinox/nn/composed.py
+++ b/equinox/nn/composed.py
@@ -137,6 +137,12 @@ class Sequential(Module):
         else:
             raise TypeError(f"Indexing with type {type(i)} is not supported")
 
+    def __iter__(self):
+        yield from self.layers
+
+    def __len__(self):
+        return len(self.layers)
+
 
 Sequential.__init__.__doc__ = """**Arguments:**
 

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -136,6 +136,9 @@ def test_sequential(getkey):
     with pytest.raises(TypeError):
         seq[[0, 1, 2]]
 
+    assert len(seq) == 3
+    assert eqx.nn.Sequential(list(seq)) == seq
+
 
 def test_mlp(getkey):
     mlp = eqx.nn.MLP(2, 3, 8, 2, key=getkey())


### PR DESCRIPTION
Adds the `__len__` and `__iter__` methods to `eqx.nn.Sequential`

It isn't that hard to write `len(seq.layers)` or `zip(seq.layers, ...)`, but this does make it just slightly cleaner and also mimics the behavior of pytorch Sequential module.