### PR TITLE
Add attention functions and tests

### DIFF
--- a/equinox/nn/attention.py
+++ b/equinox/nn/attention.py
@@ -40,7 +40,7 @@ def dot_product_attention(
 ) -> Array["query_seq_length", "value_size"]:  # noqa: F821
 
     weights = dot_product_attention_weights(query, key, mask)
-    if dropout_fn:
+    if dropout_fn is not None:
         weights = dropout_fn(weights)
     attn = jnp.einsum("sS,Sd->sd", weights, value)
     return attn
@@ -259,7 +259,7 @@ class MultiheadAttention(Module):
         )
         # vmap over attention heads
         in_axes = (1, 1, 1, None if mask is None else 1, None)
-        attn = jax.vmap(dot_product_attention, in_axes)(
+        attn = jax.vmap(dot_product_attention, in_axes, out_axes=1)(
             query_heads, key_heads, value_heads, mask, dropout_fn
         )
         attn = attn.reshape(query_seq_length, -1)

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -524,6 +524,29 @@ def test_convtranspose3d(getkey):
     assert jnp.all(conv(data) == answer)
 
 
+def test_dot_product_attention_weights(getkey):
+    q = jnp.array([[0.0, 2**0.5]])
+    k = jnp.array([[1.0, 0.0], [0.0, 1.0]])
+    weights = eqx.nn.attention.dot_product_attention_weights(q, k)
+    assert weights.shape == (1, 2)
+    assert jnp.allclose(weights, jnp.array([[1, jnp.e]]) / (1 + jnp.e))
+    mask = jnp.array([[True, False]])
+    weights = eqx.nn.attention.dot_product_attention_weights(q, k, mask)
+    assert jnp.allclose(weights, jnp.array([[1.0, 0.0]]))
+
+
+def test_dot_product_attention(getkey):
+    q = jnp.array([[0.0, 2**0.5]])
+    k = jnp.array([[1.0, 0.0], [0.0, 1.0]])
+    v = jnp.array([[1.0], [0.0]])
+    attn = eqx.nn.attention.dot_product_attention(q, k, v)
+    assert attn.shape == (1, 1)
+    assert jnp.allclose(attn, jnp.array([[1 / (1 + jnp.e)]]))
+    mask = jnp.array([[True, False]])
+    attn = eqx.nn.attention.dot_product_attention(q, k, v, mask)
+    assert attn == jnp.array([[1.0]])
+
+
 def test_multihead_attention(getkey):
     attn = eqx.nn.MultiheadAttention(
         num_heads=2,


### PR DESCRIPTION
Adds `dot_product_attention_weights` and `dot_product_attention` functions and tests

**Design considerations**:
- `dot_product_attention` and `dot_product_attention_weights` don't take multi-head inputs -- instead attention heads are vmap'd over in `MultiheadAttention`. This allows for greater flexibility when creating other types of attention modules
- To simplify the `dot_product_attention` signature -- `dropout_fn` is added as a single argument callable, which should close over the dropout arguments like `key` and `inference`. The alternative I think would be to add a functional version of dropout and add its arguments to `dot_product_attention`, however this would make changing the dropout rate after initializing the module less intuitive -- since dropout rate would have to be an attribute of `MultiheadAttention`.
- `mask` shape check is kept inside `dot_product_attention_weights`. The downside to this is that errors raised inside vmap'd functions are less obvious -- i.e. if the heads don't match then `vmap` function will raise an error. The alternative is to pull the shape check out and put it back in `MultiheadAttention`