### PR TITLE
fix attention with mask and add tests

### DIFF
--- a/equinox/__init__.py
+++ b/equinox/__init__.py
@@ -24,4 +24,4 @@ from .update import apply_updates
 from .vmap_pmap import filter_pmap, filter_vmap
 
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"

--- a/equinox/nn/attention.py
+++ b/equinox/nn/attention.py
@@ -263,7 +263,7 @@ class MultiheadAttention(Module):
         )
         keys = None if key is None else jax.random.split(key, query_heads.shape[1])
         attn = jax.vmap(attn_fn, in_axes=1, out_axes=1)(
-            query_heads, key_heads, value_heads, mask, key=keys
+            query_heads, key_heads, value_heads, mask=mask, key=keys
         )
         attn = attn.reshape(query_seq_length, -1)
 

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -577,6 +577,10 @@ def test_multihead_attention(getkey):
     x = jnp.array([[1, 2, 3, 4]])
     assert jnp.allclose(attn(x, x, x), jnp.array([[680.0, 1960.0, 3240.0, 4520.0]]))
 
+    x = jnp.arange(1, 13).reshape(3, 4)
+    mask = jnp.broadcast_to(jnp.array([True, False, False]), (2, 3, 3))
+    assert jnp.allclose(attn(x, x, x, mask), jnp.broadcast_to(jnp.array([[680.0, 1960.0, 3240.0, 4520.0]]), (3, 4))) 
+
 
 def test_embedding(getkey):
     emb = eqx.nn.Embedding(100, 512, key=getkey())

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -579,7 +579,10 @@ def test_multihead_attention(getkey):
 
     x = jnp.arange(1, 13).reshape(3, 4)
     mask = jnp.broadcast_to(jnp.array([True, False, False]), (2, 3, 3))
-    assert jnp.allclose(attn(x, x, x, mask), jnp.broadcast_to(jnp.array([[680.0, 1960.0, 3240.0, 4520.0]]), (3, 4))) 
+    assert jnp.allclose(
+        attn(x, x, x, mask),
+        jnp.broadcast_to(jnp.array([[680.0, 1960.0, 3240.0, 4520.0]]), (3, 4)),
+    )
 
 
 def test_embedding(getkey):


### PR DESCRIPTION
https://github.com/patrick-kidger/equinox/blob/18d260d4abab92b6853f2bdbd8335fe2ec316416/equinox/nn/attention.py#L221-L223

https://github.com/patrick-kidger/equinox/blob/18d260d4abab92b6853f2bdbd8335fe2ec316416/equinox/nn/attention.py#L265-L267


The right axis for mask to map over is the first axis, so pass mask as keyword to make it map over axis index 0.
