### PR TITLE
Add support for asymmetric padding in Conv and ConvTransposed.

### DIFF
--- a/equinox/nn/conv.py
+++ b/equinox/nn/conv.py
@@ -345,7 +345,9 @@ class ConvTranspose(Module):
             the sequence should be of length equal to `num_spatial_dims`, and specify
             the value of each property down each spatial dimension in turn.. If they
             are an integer then the same kernel size / stride / padding / dilation will
-            be used along every spatial dimension.
+            be used along every spatial dimension. `padding` can also be a sequence of 2 elements tuples
+            each representing the padding to apply before and after the spatial dimension,
+            with the sequence of length equal to `num_spatial_dims`.
 
         !!! tip
 
@@ -407,13 +409,14 @@ class ConvTranspose(Module):
         if isinstance(padding, int):
             self.padding = tuple((padding, padding) for _ in range(num_spatial_dims))
         elif isinstance(padding, Sequence) and len(padding) == num_spatial_dims:
-            self.padding = tuple((p, p) for p in padding)
-        elif isinstance(padding, Sequence) and len(padding) == 2 * num_spatial_dims:
-            self.padding = tuple(zip(padding[::2], padding[1::2]))
+            if all(isinstance(element, Sequence) for element in padding):
+                self.padding = padding
+            else:
+                self.padding = tuple((p, p) for p in padding)
         else:
             raise ValueError(
                 "`padding` must either be an int or tuple of length "
-                f"{num_spatial_dims}."
+                f"{num_spatial_dims} containing ints or tuples of length 2."
             )
         self.output_padding = output_padding
         self.dilation = dilation

--- a/equinox/nn/conv.py
+++ b/equinox/nn/conv.py
@@ -75,7 +75,10 @@ class Conv(Module):
         - `kernel_size`: The size of the convolutional kernel.
         - `stride`: The stride of the convolution.
         - `padding`: The amount of padding to apply before and after each spatial
-            dimension. The same amount of padding is applied both before and after.
+            dimension. If `padding` is an `int`, the same amount of padding is applied for each dimension,
+            both before and after. If it is a `tuple` of size `num_spatial_dim`, the same amount of padding is applied
+            both before and after, but different for each dimension. If it is a `tuple` of size `2 * num_spatial_dim`,
+            the amount of padding is applied as `(before dim 1, after dim 1, before dim 2, after dim 2, ...)`.
         - `dilation`: The dilation of the convolution.
         - `groups`: The number of input channel groups. At `groups=1`,
             all input channels contribute to all output channels. Values
@@ -139,6 +142,8 @@ class Conv(Module):
             self.padding = tuple((padding, padding) for _ in range(num_spatial_dims))
         elif isinstance(padding, Sequence) and len(padding) == num_spatial_dims:
             self.padding = tuple((p, p) for p in padding)
+        elif isinstance(padding, Sequence) and len(padding) == 2 * num_spatial_dims:
+            self.padding = tuple(zip(padding[::2], padding[1::2]))
         else:
             raise ValueError(
                 "`padding` must either be an int or tuple of length "
@@ -404,6 +409,8 @@ class ConvTranspose(Module):
             self.padding = tuple((padding, padding) for _ in range(num_spatial_dims))
         elif isinstance(padding, Sequence) and len(padding) == num_spatial_dims:
             self.padding = tuple((p, p) for p in padding)
+        elif isinstance(padding, Sequence) and len(padding) == 2 * num_spatial_dims:
+            self.padding = tuple(zip(padding[::2], padding[1::2]))
         else:
             raise ValueError(
                 "`padding` must either be an int or tuple of length "

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -330,6 +330,13 @@ def test_conv3d(getkey):
     assert jnp.allclose(conv(data), answer)
 
 
+def test_conv_padding(getkey):
+    x = jrandom.normal(getkey(), (3, 32, 32))
+    conv = eqx.nn.Conv2d(3, 8, 1, 2, padding=((0, 1), (0, 3)), key=getkey())
+    output = conv(x)
+    assert output.shape == (8, 17, 18)
+
+
 def test_convtranspose1d(getkey):
     # Positional arguments
     conv = eqx.nn.ConvTranspose1d(1, 3, 3, key=getkey())
@@ -522,6 +529,13 @@ def test_convtranspose3d(getkey):
         ]
     ).reshape(1, 3, 3, 3)
     assert jnp.all(conv(data) == answer)
+
+
+def test_convtranspose_padding(getkey):
+    x = jrandom.normal(getkey(), (8, 17, 18))
+    conv = eqx.nn.ConvTranspose2d(8, 3, 1, 2, padding=((0, 1), (0, 3)), key=getkey())
+    output = conv(x)
+    assert output.shape == (3, 32, 32)
 
 
 def test_dot_product_attention_weights(getkey):


### PR DESCRIPTION
 - Adds asymmetric padding to convolutions. The asymmetric padding is defined as a `Sequence` of `int` of length `2 * num_spatial_dim`, analog to `torch.nn.functional.pad`.