### PR TITLE
Use jaxtyping

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
 max-line-length = 120
-ignore = W291,W293,W503,W504,E123,E126,E203,E402,E701,E731
+ignore = W291,W293,W503,W504,E123,E126,E203,E402,E701,E731,F722
 per-file-ignores = __init__.py: F401

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,8 @@ jobs:
         with:
             python-version: "3.8"
             test-script: |
-                python -m pip install pytest jaxlib
                 cp -r ${{ github.workspace }}/tests ./tests
+                python -m pip install -f ./tests/requirements.txt
                 pytest
             pypi-token: ${{ secrets.pypi_token }}
             github-user: patrick-kidger

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
             python-version: "3.8"
             test-script: |
                 cp -r ${{ github.workspace }}/tests ./tests
-                python -m pip install -f ./tests/requirements.txt
+                python -m pip install -r ./tests/requirements.txt
                 pytest
             pypi-token: ${{ secrets.pypi_token }}
             github-user: patrick-kidger

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -f ./tests/requirements.txt
+          python -m pip install -r ./tests/requirements.txt
 
       - name: Checks with pre-commit
         uses: pre-commit/action@v2.0.3

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pytest wheel optax jaxlib
+          python -m pip install -f ./tests/requirements.txt
 
       - name: Checks with pre-commit
         uses: pre-commit/action@v2.0.3

--- a/equinox/custom_types.py
+++ b/equinox/custom_types.py
@@ -1,115 +1,11 @@
-import inspect
-import typing
-from typing import Any, Callable, Generic, Tuple, TypeVar, Union
+from typing import Any, Callable, Union
 
 import jax.tree_util as jtu
 
 from .doc_utils import doc_repr
 
 
-# Custom flag we set when generating documentation.
-# We do a lot of custom hackery in here to produce nice-looking docs.
-if getattr(typing, "GENERATING_DOCUMENTATION", False):
-
-    def _item_to_str(item: Union[str, type, slice]) -> str:
-        if isinstance(item, slice):
-            if item.step is not None:
-                raise NotImplementedError
-            return _item_to_str(item.start) + ": " + _item_to_str(item.stop)
-        elif item is ...:
-            return "..."
-        elif inspect.isclass(item):
-            return item.__name__
-        else:
-            return repr(item)
-
-    def _maybe_tuple_to_str(
-        item: Union[str, type, slice, Tuple[Union[str, type, slice], ...]]
-    ) -> str:
-        if isinstance(item, tuple):
-            if len(item) == 0:
-                # Explicit brackets
-                return "()"
-            else:
-                # No brackets
-                return ", ".join([_item_to_str(i) for i in item])
-        else:
-            return _item_to_str(item)
-
-    #
-    # First we have Generic versions of Array and PyTree.
-    #
-    # Crucially the __module__ and __qualname__ are overridden. This particular combo
-    # makes Python's typing module just use the __qualname__ as what is displayed in
-    # stringified type annotations.
-    # (For some strange reason typing uses a custom stringifiation algorithm, rather
-    # than just str(...) or repr(...).)
-    #
-    # c.f.
-    # https://github.com/python/cpython/blob/634984d7dbdd91e0a51a793eed4d870e139ae1e0/Lib/typing.py#L203  # noqa: E501
-    #
-    # Note that in general overriding __module__ can be a bit dangerous, and will break
-    # functionality in the inspect standard library.
-    #
-
-    _Annotation = TypeVar("_Annotation")
-
-    class _Array(Generic[_Annotation]):
-        pass
-
-    class _PyTree(Generic[_Annotation]):
-        pass
-
-    _Array.__module__ = "builtins"
-    _Array.__qualname__ = "Array"
-    _PyTree.__module__ = "builtins"
-    _PyTree.__qualname__ = "PyTree"
-
-    #
-    # Now we have Array and PyTree themselves. In order to get the desired behaviour in
-    # docs, we now pass in a type variable with the right __qualname__ (and __module__
-    # set to "builtins" as usual) that will render in the desired way.
-    #
-
-    class Array:
-        def __class_getitem__(cls, item):
-            class X:
-                pass
-
-            X.__module__ = "builtins"
-            X.__qualname__ = _maybe_tuple_to_str(item)
-            return _Array[X]
-
-    class PyTree:
-        def __class_getitem__(cls, item):
-            class X:
-                pass
-
-            X.__module__ = "builtins"
-            X.__qualname__ = _maybe_tuple_to_str(item)
-            return _PyTree[X]
-
-    # Same __module__ trick here again. (So that we get the correct display when
-    # doing `def f(x: Array)` as well as `def f(x: Array["dim"])`.
-    #
-    # Don't need to set __qualname__ as that's already correct.
-    Array.__module__ = "builtins"
-    PyTree.__module__ = "builtins"
-
-else:
-
-    class Array:
-        def __class_getitem__(cls, item):
-            return Array
-
-    class PyTree:
-        def __class_getitem__(cls, item):
-            return PyTree
-
-
 sentinel = doc_repr(object(), "sentinel")
-
 TreeDef = type(jtu.tree_structure(0))
-
 ResolvedBoolAxisSpec = bool
 BoolAxisSpec = Union[ResolvedBoolAxisSpec, Callable[[Any], ResolvedBoolAxisSpec]]

--- a/equinox/experimental/batch_norm.py
+++ b/equinox/experimental/batch_norm.py
@@ -70,7 +70,7 @@ class BatchNorm(Module):
     def __init__(
         self,
         input_size: int,
-        axis_name: str,
+        axis_name: Union[Hashable, Sequence[Hashable]],
         eps: float = 1e-5,
         channelwise_affine: bool = True,
         momentum: float = 0.99,

--- a/equinox/experimental/batch_norm.py
+++ b/equinox/experimental/batch_norm.py
@@ -3,8 +3,8 @@ from typing import Hashable, Optional, Sequence, Union
 import jax
 import jax.lax as lax
 import jax.numpy as jnp
+from jaxtyping import Array, Float
 
-from ..custom_types import Array
 from ..module import Module, static_field
 from .stateful import get_state, set_state, StateIndex
 
@@ -56,8 +56,8 @@ class BatchNorm(Module):
         `BatchNorm` is considered experimental. Let us know how you find it!
     """  # noqa: E501
 
-    weight: Optional[Array["input_size"]]
-    bias: Optional[Array["input_size"]]
+    weight: Optional[Float[Array, "input_size"]]
+    bias: Optional[Float[Array, "input_size"]]
     first_time_index: StateIndex
     state_index: StateIndex
     axis_name: Union[Hashable, Sequence[Hashable]]

--- a/equinox/experimental/spectral_norm.py
+++ b/equinox/experimental/spectral_norm.py
@@ -4,8 +4,8 @@ import jax
 import jax.lax as lax
 import jax.numpy as jnp
 import jax.random as jr
+from jaxtyping import Array
 
-from ..custom_types import Array
 from ..module import Module, static_field
 from .stateful import get_state, set_state, StateIndex
 

--- a/equinox/experimental/stateful.py
+++ b/equinox/experimental/stateful.py
@@ -10,8 +10,8 @@ import jax.interpreters.xla as xla
 import jax.lax as lax
 import jax.numpy as jnp
 import jax.tree_util as jtu
+from jaxtyping import Array, PyTree
 
-from ..custom_types import Array, PyTree
 from ..filters import is_array
 from ..module import Module, static_field
 from ..tree import tree_at

--- a/equinox/experimental/stateful.py
+++ b/equinox/experimental/stateful.py
@@ -1,6 +1,6 @@
 import weakref
 from dataclasses import field
-from typing import Tuple
+from typing import List
 
 import jax
 import jax.experimental.host_callback as hcb
@@ -383,7 +383,7 @@ mlir.register_lowering(
 class _GetStateArg(Module):
     index: StateIndex
     like: PyTree[Array]
-    batch_axes: Tuple[int] = static_field()
+    batch_axes: List[int] = static_field()
 
 
 def _get_state_hcb(arg: _GetStateArg) -> PyTree:
@@ -398,9 +398,7 @@ def _get_state_hcb(arg: _GetStateArg) -> PyTree:
     return current_state
 
 
-def _get_state(
-    index: StateIndex, like: PyTree[Array], batch_axes: Tuple[int]
-) -> PyTree:
+def _get_state(index: StateIndex, like: PyTree[Array], batch_axes: List[int]) -> PyTree:
     arg = _GetStateArg(index, like, batch_axes)
     like_shape = jax.eval_shape(lambda: like)
     # Will raise an error if `like_shape` does not match the result.
@@ -513,7 +511,7 @@ def get_state(index: StateIndex, like: PyTree[Array]) -> PyTree[Array]:
 class _SetStateArg(Module):
     index: StateIndex
     state: PyTree[Array]
-    batch_axes: Tuple[int] = static_field()
+    batch_axes: List[int] = static_field()
 
 
 def _set_state_hcb(arg: _SetStateArg) -> None:
@@ -599,6 +597,6 @@ def set_state(index: StateIndex, state: PyTree[Array]) -> None:
     _set_state(index, state, [])
 
 
-def _set_state(index: StateIndex, state: PyTree[Array], batch_axes: Tuple[int]) -> None:
+def _set_state(index: StateIndex, state: PyTree[Array], batch_axes: List[int]) -> None:
     arg = _SetStateArg(index, state, batch_axes)
     hcb.call(_set_state_hcb, arg)

--- a/equinox/experimental/stateful.py
+++ b/equinox/experimental/stateful.py
@@ -215,8 +215,8 @@ def _delete_smuggled_state(x: StateIndex) -> StateIndex:
     # involves a flatten. Meanwhile `StateIndex` sneakily modifies its structure
     # under flatten, and this trips a false positive.
 
-    leaves, treedef = jax.tree_flatten(x)
-    x = jax.tree_unflatten(treedef, leaves)
+    leaves, treedef = jtu.tree_flatten(x)
+    x = jtu.tree_unflatten(treedef, leaves)
     object.__setattr__(x, "_state", None)
     return x
 

--- a/equinox/filters.py
+++ b/equinox/filters.py
@@ -3,8 +3,9 @@ from typing import Any, Callable, Optional
 import jax.numpy as jnp
 import jax.tree_util as jtu
 import numpy as np
+from jaxtyping import PyTree
 
-from .custom_types import BoolAxisSpec, PyTree, ResolvedBoolAxisSpec
+from .custom_types import BoolAxisSpec, ResolvedBoolAxisSpec
 
 
 #

--- a/equinox/filters.py
+++ b/equinox/filters.py
@@ -52,7 +52,7 @@ def is_inexact_array_like(element: Any) -> bool:
 
 
 def _make_filter_tree(is_leaf):
-    def _filter_tree(mask: BoolAxisSpec, arg: Any) -> ResolvedBoolAxisSpec:
+    def _filter_tree(mask: BoolAxisSpec, arg: Any) -> PyTree[ResolvedBoolAxisSpec]:
         if isinstance(mask, bool):
             return jtu.tree_map(lambda _: mask, arg, is_leaf=is_leaf)
         elif callable(mask):

--- a/equinox/grad.py
+++ b/equinox/grad.py
@@ -6,8 +6,9 @@ from typing import Any, Callable, Dict
 
 import jax
 import jax.tree_util as jtu
+from jaxtyping import PyTree
 
-from .custom_types import BoolAxisSpec, PyTree, sentinel
+from .custom_types import BoolAxisSpec, sentinel
 from .doc_utils import doc_strip_annotations
 from .filters import combine, is_array, is_inexact_array, partition
 from .module import Module, module_update_wrapper

--- a/equinox/jit.py
+++ b/equinox/jit.py
@@ -6,6 +6,7 @@ from typing import Any, Callable, Sequence
 
 import jax
 import jax.tree_util as jtu
+from jaxtyping import PyTree
 
 from .compile_utils import (
     compile_cache,
@@ -14,7 +15,7 @@ from .compile_utils import (
     hashable_partition,
     Static,
 )
-from .custom_types import BoolAxisSpec, PyTree, sentinel, TreeDef
+from .custom_types import BoolAxisSpec, sentinel, TreeDef
 from .doc_utils import doc_strip_annotations
 from .filters import combine, is_array, partition
 from .module import Module, module_update_wrapper

--- a/equinox/nn/array_utils.py
+++ b/equinox/nn/array_utils.py
@@ -4,6 +4,6 @@ import jax.numpy as jnp
 from jaxtyping import Array
 
 
-def left_broadcast_to(arr: Array, shape: Tuple[int]):
+def left_broadcast_to(arr: Array, shape: Tuple[int, ...]) -> Array:
     arr = arr.reshape(arr.shape + (1,) * (len(shape) - arr.ndim))
     return jnp.broadcast_to(arr, shape)

--- a/equinox/nn/array_utils.py
+++ b/equinox/nn/array_utils.py
@@ -1,8 +1,7 @@
 from typing import Tuple
 
 import jax.numpy as jnp
-
-from ..custom_types import Array
+from jaxtyping import Array
 
 
 def left_broadcast_to(arr: Array, shape: Tuple[int]):

--- a/equinox/nn/composed.py
+++ b/equinox/nn/composed.py
@@ -4,8 +4,8 @@ from typing import Any, Callable, List, Optional, Sequence, Tuple, Union
 import jax
 import jax.nn as jnn
 import jax.random as jrandom
+from jaxtyping import Array
 
-from ..custom_types import Array
 from ..module import Module, static_field
 from .linear import Linear
 

--- a/equinox/nn/conv.py
+++ b/equinox/nn/conv.py
@@ -6,8 +6,8 @@ import jax.lax as lax
 import jax.numpy as jnp
 import jax.random as jrandom
 import numpy as np
+from jaxtyping import Array
 
-from ..custom_types import Array
 from ..module import Module, static_field
 
 

--- a/equinox/nn/dropout.py
+++ b/equinox/nn/dropout.py
@@ -4,8 +4,8 @@ from typing import Optional
 import jax
 import jax.numpy as jnp
 import jax.random as jrandom
+from jaxtyping import Array
 
-from ..custom_types import Array
 from ..module import Module
 
 

--- a/equinox/nn/embedding.py
+++ b/equinox/nn/embedding.py
@@ -2,8 +2,8 @@ from typing import Optional
 
 import jax
 import jax.random as jrandom
+from jaxtyping import Array, Float
 
-from ..custom_types import Array
 from ..module import Module, static_field
 
 
@@ -18,7 +18,7 @@ class Embedding(Module):
         self,
         num_embeddings: int,
         embedding_size: int,
-        weight: Optional[Array["num_embeddings", "embedding_size"]] = None,
+        weight: Optional[Float[Array, "num_embeddings embedding_size"]] = None,
         *,
         key: "jax.random.PRNGKey",
         **kwargs,

--- a/equinox/nn/linear.py
+++ b/equinox/nn/linear.py
@@ -3,8 +3,8 @@ from typing import Optional, TypeVar
 
 import jax
 import jax.random as jrandom
+from jaxtyping import Array
 
-from ..custom_types import Array
 from ..module import Module, static_field
 
 

--- a/equinox/nn/normalisation.py
+++ b/equinox/nn/normalisation.py
@@ -3,8 +3,8 @@ from typing import Optional, Sequence, Union
 
 import jax
 import jax.numpy as jnp
+from jaxtyping import Array
 
-from ..custom_types import Array
 from ..module import Module, static_field
 from .array_utils import left_broadcast_to
 

--- a/equinox/nn/pool.py
+++ b/equinox/nn/pool.py
@@ -4,8 +4,8 @@ import jax.lax as lax
 import jax.numpy as jnp
 import jax.random
 import numpy as np
+from jaxtyping import Array
 
-from ..custom_types import Array
 from ..module import Module, static_field
 
 

--- a/equinox/nn/rnn.py
+++ b/equinox/nn/rnn.py
@@ -5,8 +5,8 @@ import jax
 import jax.nn as jnn
 import jax.numpy as jnp
 import jax.random as jrandom
+from jaxtyping import Array
 
-from ..custom_types import Array
 from ..module import Module, static_field
 
 

--- a/equinox/pretty_print.py
+++ b/equinox/pretty_print.py
@@ -7,8 +7,7 @@ import jax
 import jax._src.pretty_printer as pp
 import jax.numpy as jnp
 import numpy as np
-
-from .custom_types import Array, PyTree
+from jaxtyping import Array, PyTree
 
 
 Dataclass = Any

--- a/equinox/pretty_print.py
+++ b/equinox/pretty_print.py
@@ -1,16 +1,17 @@
 import dataclasses
 import functools as ft
 import types
-from typing import Any, Callable, Dict, List, NamedTuple, Tuple
+from typing import Any, Callable, Dict, List, Tuple, Union
 
 import jax
 import jax._src.pretty_printer as pp
 import jax.numpy as jnp
 import numpy as np
-from jaxtyping import Array, PyTree
+from jaxtyping import PyTree
 
 
 Dataclass = Any
+NamedTuple = Any  # workaround typeguard bug
 PrettyPrintAble = PyTree
 
 
@@ -109,7 +110,7 @@ def _pformat_dataclass(obj: Dataclass, **kwargs) -> pp.Doc:
     )
 
 
-def _pformat_array(obj: Array, **kwargs) -> pp.Doc:
+def _pformat_array(obj: Union[jnp.ndarray, np.ndarray], **kwargs) -> pp.Doc:
     short = kwargs["short_arrays"]
     if short:
         dtype_str = (

--- a/equinox/serialisation.py
+++ b/equinox/serialisation.py
@@ -4,9 +4,9 @@ from typing import Any, BinaryIO, Callable, Optional, Union
 import jax.numpy as jnp
 import jax.tree_util as jtu
 import numpy as np
+from jaxtyping import PyTree
 
 from . import experimental
-from .custom_types import PyTree
 from .pretty_print import tree_pformat
 
 

--- a/equinox/tree.py
+++ b/equinox/tree.py
@@ -4,8 +4,9 @@ import jax
 import jax.numpy as jnp
 import jax.tree_util as jtu
 import numpy as np
+from jaxtyping import PyTree
 
-from .custom_types import PyTree, sentinel
+from .custom_types import sentinel
 from .doc_utils import doc_repr
 
 

--- a/equinox/tree.py
+++ b/equinox/tree.py
@@ -4,7 +4,7 @@ import jax
 import jax.numpy as jnp
 import jax.tree_util as jtu
 import numpy as np
-from jaxtyping import PyTree
+from jaxtyping import Array, Bool, PyTree
 
 from .custom_types import sentinel
 from .doc_utils import doc_repr
@@ -211,7 +211,7 @@ def tree_at(
     return out
 
 
-def tree_equal(*pytrees: PyTree) -> bool:
+def tree_equal(*pytrees: PyTree) -> Union[bool, np.bool_, Bool[Array, ""]]:
     """Returns `True` if all input PyTrees are equal. Every PyTree must have the same
     structure. Any JAX or NumPy arrays (as leaves) must have the same shape, dtype, and
     values to be considered equal. JAX arrays and NumPy arrays are not considered equal

--- a/equinox/update.py
+++ b/equinox/update.py
@@ -1,6 +1,5 @@
 import jax.tree_util as jtu
-
-from .custom_types import PyTree
+from jaxtyping import PyTree
 
 
 def _apply_update(u, p):

--- a/equinox/vmap_pmap.py
+++ b/equinox/vmap_pmap.py
@@ -5,6 +5,7 @@ from typing import Any, Callable, Dict, Union
 import jax
 import jax.numpy as jnp
 import jax.tree_util as jtu
+from jaxtyping import PyTree
 
 from .compile_utils import (
     compile_cache,
@@ -13,7 +14,7 @@ from .compile_utils import (
     hashable_partition,
     Static,
 )
-from .custom_types import BoolAxisSpec, PyTree, ResolvedBoolAxisSpec, sentinel
+from .custom_types import BoolAxisSpec, ResolvedBoolAxisSpec, sentinel
 from .doc_utils import doc_strip_annotations
 from .filters import combine, filter, is_array, is_array_like, partition
 from .module import Module, module_update_wrapper

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,6 +75,8 @@ plugins:
         handlers:
             python:
                 setup_commands:
+                    - import jaxtyping
+                    - jaxtyping.set_array_name_format("array")
                     - import pytkdocs_tweaks
                     - pytkdocs_tweaks.main()
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --jaxtyping-packages=equinox,typeguard.typechecked

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ classifiers = [
 
 python_requires = "~=3.7"
 
-install_requires = ["jax>=0.3.4"]
+install_requires = ["jax>=0.3.4", "jaxtyping>=0.2.2"]
 
 setuptools.setup(
     name=name,

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,3 @@
+jaxlib
+pytest
+typeguard

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -574,10 +574,10 @@ def test_multihead_attention(getkey):
         attn,
         [jnp.arange(16).reshape(4, 4) for _ in range(4)],
     )
-    x = jnp.array([[1, 2, 3, 4]])
+    x = jnp.array([[1.0, 2.0, 3.0, 4.0]])
     assert jnp.allclose(attn(x, x, x), jnp.array([[680.0, 1960.0, 3240.0, 4520.0]]))
 
-    x = jnp.arange(1, 13).reshape(3, 4)
+    x = jnp.arange(1, 13, dtype=jnp.float32).reshape(3, 4)
     mask = jnp.broadcast_to(jnp.array([True, False, False]), (2, 3, 3))
     assert jnp.allclose(
         attn(x, x, x, mask),

--- a/tests/test_pformat.py
+++ b/tests/test_pformat.py
@@ -76,8 +76,8 @@ def test_function():
     i = jax.custom_vjp(f)
     j = jax.custom_jvp(f)
 
-    assert eqx.tree_pformat(f, "<function f>")
-    assert eqx.tree_pformat(g, "<function f>")
-    assert eqx.tree_pformat(h, "<function f>")
-    assert eqx.tree_pformat(i, "<function f>")
-    assert eqx.tree_pformat(j, "<function f>")
+    assert eqx.tree_pformat(f) == "<function f>"
+    assert eqx.tree_pformat(g) == "<wrapped function f>"
+    assert eqx.tree_pformat(h) == "<wrapped function f>"
+    assert eqx.tree_pformat(i) == "<function f>"
+    assert eqx.tree_pformat(j) == "<function f>"

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,4 +1,5 @@
 import jax.numpy as jnp
+import numpy as np
 import pytest
 
 import equinox as eqx
@@ -18,7 +19,7 @@ def test_apply_updates2():
     def f(p):
         return p[1] + p[2]
 
-    grads = eqx.filter_grad(f, filter_spec=lambda x: x == 3)(params)
+    grads = eqx.filter_grad(f, filter_spec=lambda x: np.array(x == 3).item())(params)
     new_params = eqx.apply_updates(params, grads)
     assert new_params == [o, jnp.array([4.0]), jnp.array([2.0])]
 


### PR DESCRIPTION
- Updated all type annotations to use jaxtyping.
- Added runtime type checking to tests. (+Fixed a few minor issues as a result of this!)
- Drive-by: tidied up test requirements into a `tests/requirements.txt` file