### PR TITLE
`is_array` now returns True for NumPy arrays

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,1 @@
-include LICENSE
+prune tests

--- a/docs/all-of-equinox.md
+++ b/docs/all-of-equinox.md
@@ -111,7 +111,7 @@ loss(params, static, x, y)
 
 Here, `params` and `static` are both instances of `AnotherModule`: `params` keeps just the leaves that are JAX arrays; `static` keeps everything else. Then `combine` merges the two PyTrees back together after crossing the `jax.jit` and `jax.grad` API boundaries.
 
-The choice of `eqx.is_array` is a *filter function*: a boolean function specifying whether each leaf should go into `params` or into `static`. In this case very simply `eqx.is_array(x) == isinstance(x, jax.numpy.ndarray)`.
+The choice of `eqx.is_array` is a *filter function*: a boolean function specifying whether each leaf should go into `params` or into `static`. In this case very simply `eqx.is_array(x)` returns `True` for JAX and NumPy arrays.
 
 **Option 2: use filtered transformations, which automate the above process for you.**
 

--- a/equinox/__init__.py
+++ b/equinox/__init__.py
@@ -24,4 +24,4 @@ from .update import apply_updates
 from .vmap_pmap import filter_pmap, filter_vmap
 
 
-__version__ = "0.7.1"
+__version__ = "0.8.0"

--- a/equinox/filters.py
+++ b/equinox/filters.py
@@ -14,8 +14,8 @@ from .custom_types import BoolAxisSpec, ResolvedBoolAxisSpec
 
 
 def is_array(element: Any) -> bool:
-    """Returns `True` if `element` is a JAX array (but not a NumPy array)."""
-    return isinstance(element, jnp.ndarray)
+    """Returns `True` if `element` is a JAX array or NumPy array."""
+    return isinstance(element, (np.ndarray, jnp.ndarray))
 
 
 # Chosen to match
@@ -30,8 +30,13 @@ def is_array_like(element: Any) -> bool:
 
 
 def is_inexact_array(element: Any) -> bool:
-    """Returns `True` if `element` is an inexact (i.e. floating point) JAX array."""
-    return is_array(element) and jnp.issubdtype(element.dtype, jnp.inexact)
+    """Returns `True` if `element` is an inexact (i.e. floating point) JAX/NumPy array."""
+    if isinstance(element, np.ndarray):
+        return np.issubdtype(element.dtype, np.inexact)
+    elif isinstance(element, jnp.ndarray):
+        return jnp.issubdtype(element.dtype, jnp.inexact)
+    else:
+        return False
 
 
 def is_inexact_array_like(element: Any) -> bool:
@@ -40,10 +45,12 @@ def is_inexact_array_like(element: Any) -> bool:
     """
     if hasattr(element, "__jax_array__"):
         element = element.__jax_array__()
-    return (
-        isinstance(element, (jnp.ndarray, np.ndarray))
-        and jnp.issubdtype(element.dtype, jnp.inexact)
-    ) or isinstance(element, (float, complex))
+    if isinstance(element, np.ndarray):
+        return np.issubdtype(element.dtype, np.inexact)
+    elif isinstance(element, jnp.ndarray):
+        return jnp.issubdtype(element.dtype, jnp.inexact)
+    else:
+        return isinstance(element, (float, complex))
 
 
 #

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ classifiers = [
 
 python_requires = "~=3.7"
 
-install_requires = ["jax>=0.3.4", "jaxtyping>=0.2.3"]
+install_requires = ["jax>=0.3.4", "jaxtyping>=0.2.5"]
 
 setuptools.setup(
     name=name,

--- a/tests/test_filter_grad.py
+++ b/tests/test_filter_grad.py
@@ -68,7 +68,7 @@ def test_filter_grad2(api_version, getkey):
     assert jnp.all(gdict["hi"].bias == 1)
     assert g5 is None
     assert g1 is None
-    assert gnp is None
+    assert jnp.all(gnp == 1)
 
 
 @pytest.mark.parametrize("api_version", (0, 1))

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -21,7 +21,7 @@ def test_is_array(getkey):
         np.array(1),
         eqx.nn.Linear(1, 1, key=getkey()),
     ]
-    results = [False, False, False, False, False, True, True, False, False, False]
+    results = [False, False, False, False, False, True, True, True, True, False]
     for o, r in zip(objs, results):
         assert eqx.is_array(o) == r
 
@@ -57,7 +57,7 @@ def test_is_inexact_array(getkey):
         np.array(1),
         eqx.nn.Linear(1, 1, key=getkey()),
     ]
-    results = [False, False, False, False, False, False, True, False, False, False]
+    results = [False, False, False, False, False, False, True, True, False, False]
     for o, r in zip(objs, results):
         assert eqx.is_inexact_array(o) == r
 


### PR DESCRIPTION
Likewise for `is_inexact_array`.

This is motivated by two main use-cases:
- Passing NumPy arrays as the data to a JIT'd model: in practice it's common to have your data pipeline use NumPy arrays. (It certainly shouldn't use JAX arrays, since those can't be sliced etc.) It'd be convenient to be able to pass these into a JIT'd `make_step` function without needing to change the defaults.
- `JAX_DEBUG_NANS=1` will re-run your code using NumPy arrays rather than JAX arrays. We should generally behave the same irrespective of this distinction.