### PR TITLE
Removed extra tracing call made by filter_vmap

### DIFF
--- a/equinox/vmap_pmap.py
+++ b/equinox/vmap_pmap.py
@@ -88,12 +88,12 @@ def _check_map_out_axis(max_out_size, x):
     elif isinstance(x, int):
         if x < -max_out_size or x >= max_out_size:
             raise ValueError(
-                f"integers in filter_pmap(..., out=...) must correspond to a "
+                "integers in filter_pmap(..., out=...) must correspond to a "
                 "dimension of the output array"
             )
     else:
         raise ValueError(
-            f"filter_pmap(..., out=...) must contain only integers and Nones"
+            "filter_pmap(..., out=...) must contain only integers and Nones"
         )
 
 

--- a/equinox/vmap_pmap.py
+++ b/equinox/vmap_pmap.py
@@ -189,10 +189,10 @@ class _VmapWrapper(Module):
             _fun_wrapper, in_axes=in_axes, out_axes=(0, None), **__self._vmapkwargs
         )(__self._fun, bound.args, bound.kwargs)
         out_axes, nonvmapd = static.value
-        
+
         assert jtu.tree_structure(vmapd) == jtu.tree_structure(out_axes)
         vmapd = jtu.tree_map(_swapaxes, vmapd, out_axes)
-        
+
         return combine(vmapd, nonvmapd)
 
     def __get__(self, instance, owner):

--- a/equinox/vmap_pmap.py
+++ b/equinox/vmap_pmap.py
@@ -165,8 +165,8 @@ class _VmapWrapper(Module):
             _out = _fun(*_args, **_kwargs)
             _out_axes = _resolve_axes(_out, __self._out)
             _out_axes = _map_axes(_out_axes)
-            _int_axes = jtu.tree_map(lambda _: True, _out_axes)
-            _vmapd, _nonvmapd = partition(_out, _int_axes)
+            _none_axes = jtu.tree_map(_is_none, _out_axes, is_leaf=_is_none)
+            _nonvmapd, _vmapd = partition(_out, _none_axes)
             return _vmapd, Static((_out_axes, _nonvmapd))
 
         bound = __self._signature.bind(*args, **kwargs)
@@ -470,7 +470,6 @@ class _PmapWrapper(Module):
             bound.kwargs,
             map_in_axes_no_dummy,
             self._pmapkwargs,
-            cache=True,
         )
 
         cached = _filter_pmap_cache(

--- a/tests/test_filter_jit.py
+++ b/tests/test_filter_jit.py
@@ -354,11 +354,11 @@ def test_jit_vmap():
 
     out = eqx.filter_jit(eqx.filter_vmap(f))(jnp.array([1, 2]))
     assert shaped_allclose(out, jnp.array([2, 3]))
-    assert num_traces == 2
+    assert num_traces == 1
 
     out = eqx.filter_jit(eqx.filter_vmap(f))(jnp.array([2, 3]))
     assert shaped_allclose(out, jnp.array([3, 4]))
-    assert num_traces == 2
+    assert num_traces == 1
 
 
 @pytest.fixture

--- a/tests/test_filter_pmap.py
+++ b/tests/test_filter_pmap.py
@@ -216,11 +216,11 @@ def test_pmap_vmap():
 
     out = eqx.filter_pmap(eqx.filter_vmap(f))(jnp.array([[1, 2]]))
     assert shaped_allclose(out, jnp.array([[2, 3]]))
-    assert num_traces == 4  # eval_shape in vmap + vmap + eval_shape in pmap + pmap
+    assert num_traces == 2  # eval_shape in pmap + pmap
 
     out = eqx.filter_pmap(eqx.filter_vmap(f))(jnp.array([[2, 3]]))
     assert shaped_allclose(out, jnp.array([[3, 4]]))
-    assert num_traces == 4  # all cached
+    assert num_traces == 2  # both cached
 
 
 def test_args_kwargs():


### PR DESCRIPTION
At the moment, `filter_vmap` traces its input function to determine the shape of its outputs, so that it can handle `out_axes` correctly.

After this change, its wrapped `jax.vmap` will instead output all arrays with batch axis 0, and then have the batch axis swapped afterwards if necessary.

This mean we can elide the extra tracing call, which reduces compile time.