### PR TITLE
fix tree_inference

### DIFF
--- a/equinox/tree.py
+++ b/equinox/tree.py
@@ -253,21 +253,17 @@ def tree_equal(*pytrees: PyTree) -> Union[bool, np.bool_, Bool[Array, ""]]:
     return out
 
 
-def _subinferences(pytree):
-    is_leaf = lambda x: hasattr(x, "inference") and x is not pytree
-    out = [x for x in jtu.tree_leaves(pytree, is_leaf=is_leaf) if is_leaf(x)]
-    for x in out:
-        out.extend(_subinferences(x))
-    return out
-
-
 def _inferences(pytree):
-    is_leaf = lambda x: hasattr(x, "inference")
-    out = [x for x in jtu.tree_leaves(pytree, is_leaf=is_leaf) if is_leaf(x)]
+    is_leaf = lambda x: hasattr(x, "inference") and x is not pytree
+
+    out = [pytree.inference] if hasattr(pytree, "inference") else []
+
+    leaves = [x for x in jtu.tree_leaves(pytree, is_leaf=is_leaf) if is_leaf(x)]
     # Nodes with an inference flag might have sub-nodes with an inference flag.
-    for x in out:
-        out.extend(_subinferences(x))
-    return [x.inference for x in out]
+
+    for x in leaves:
+        out.extend(_inferences(x))
+    return out
 
 
 def tree_inference(pytree: PyTree, value: bool) -> PyTree:


### PR DESCRIPTION
https://github.com/patrick-kidger/equinox/blob/253522cd23b0522e57088d4c886a753b2594e0d7/equinox/tree.py#L259-L260

https://github.com/patrick-kidger/equinox/blob/253522cd23b0522e57088d4c886a753b2594e0d7/equinox/tree.py#L268-L269

The `out.extend` inside the for loop of `out` will cause the same node to be added many times. 

For example:
```python

import equinox as eqx
import time
class Model(eqx.Module):
  sub_module: eqx.Module
  inference: bool
  def __init__(self, sub_module):
    self.sub_module=sub_module
    self.inference=False

model = Model(None)
for i in range(11):
  model = Model(model)

now = time.time()
eqx.tree_inference(model, True)
print(time.time()-now) # 5s+

def _inferences(pytree):
  out = eqx.tree._inferences(pytree)
  print(len(out), len(set(out))) # 82500 12
  return out

eqx.tree_at(_inferences, model, replace_fn=lambda _: True)
```