### PR TITLE
Added ONNX export; finalise_jaxpr, nontraceable

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ _(In other words, why should you care? Because Equinox is really simple to learn
 pip install equinox
 ```
 
-Requires Python 3.7+ and JAX 0.3.4+.
+Requires Python 3.7+ and JAX 0.3.25+.
 
 ## Documentation
 

--- a/equinox/internal/__init__.py
+++ b/equinox/internal/__init__.py
@@ -1,13 +1,26 @@
 from ..compile_utils import hashable_combine, hashable_partition
 from ..doc_utils import doc_repr, doc_strip_annotations
 from ..module import Static
-from .ad import nondifferentiable, nondifferentiable_backward
-from .debug import announce_transform, debug_backward_nan
-from .errors import branched_error_if, error_if
+from .ad import (
+    nondifferentiable,
+    nondifferentiable_backward,
+    nondifferentiable_backward_p,
+    nondifferentiable_p,
+)
+from .debug import announce_jaxpr_p, announce_transform, debug_backward_nan
+from .errors import branched_error_if, branched_error_p, error_if
+from .finalise_jaxpr import (
+    finalise_eval_jaxpr,
+    finalise_fn,
+    finalise_jaxpr,
+    finalise_jaxpr_as_fn,
+)
 from .misc import ContainerMeta, left_broadcast_to
 from .nextafter import nextafter, prevbefore
-from .noinline import noinline
+from .noinline import noinline, noinline_p
+from .nontraceable import nontraceable, nontraceable_p
 from .omega import ω
+from .onnx import to_onnx
 from .primitive import (
     create_vprim,
     filter_primitive_batching,
@@ -18,4 +31,11 @@ from .primitive import (
     materialise_zeros,
 )
 from .str2jax import str2jax
-from .unvmap import unvmap_all, unvmap_any, unvmap_max
+from .unvmap import (
+    unvmap_all,
+    unvmap_all_p,
+    unvmap_any,
+    unvmap_any_p,
+    unvmap_max,
+    unvmap_max_p,
+)

--- a/equinox/internal/ad.py
+++ b/equinox/internal/ad.py
@@ -16,7 +16,7 @@ from .errors import error_if
 _identity = lambda x, *, msg: x
 
 
-_nondifferentiable_p = jax.core.Primitive("nondifferentiable")
+nondifferentiable_p = jax.core.Primitive("nondifferentiable")
 
 
 def _nondifferentiable_batch(x, batch_axes, *, msg):
@@ -29,19 +29,19 @@ def _nondifferentiable_jvp(primals, tangents, *, msg):
     raise RuntimeError(msg)
 
 
-_nondifferentiable_p.def_impl(_identity)
-_nondifferentiable_p.def_abstract_eval(_identity)
-batching.primitive_batchers[_nondifferentiable_p] = _nondifferentiable_batch
+nondifferentiable_p.def_impl(_identity)
+nondifferentiable_p.def_abstract_eval(_identity)
+batching.primitive_batchers[nondifferentiable_p] = _nondifferentiable_batch
 if hasattr(xla, "lower_fun"):
     xla.register_translation(
-        _nondifferentiable_p,
+        nondifferentiable_p,
         xla.lower_fun(_identity, multiple_results=False, new_style=True),
     )
 mlir.register_lowering(
-    _nondifferentiable_p,
+    nondifferentiable_p,
     mlir.lower_fun(_identity, multiple_results=False),
 )
-ad.primitive_jvps[_nondifferentiable_p] = _nondifferentiable_jvp
+ad.primitive_jvps[nondifferentiable_p] = _nondifferentiable_jvp
 
 
 def nondifferentiable(
@@ -58,12 +58,12 @@ def nondifferentiable(
         if name is None:
             name = "This operation"
         msg = f"Unexpected tangent. {name} cannot be autodifferentiated."
-    bind = ft.partial(_nondifferentiable_p.bind, msg=msg)
+    bind = ft.partial(nondifferentiable_p.bind, msg=msg)
     flat = map(bind, flat)
     return combine(jtu.tree_unflatten(treedef, flat), static)
 
 
-_nondifferentiable_backward_p = jax.core.Primitive("nondifferentiable_backward")
+nondifferentiable_backward_p = jax.core.Primitive("nondifferentiable_backward")
 
 
 def _nondifferentiable_backward_batch(x, batch_axes, *, msg):
@@ -95,23 +95,23 @@ def _nondifferentiable_backward_transpose(cts_in, _, *, msg):
         return [error_if(cts_in, (cts_in != 0).any(), msg)]
 
 
-_nondifferentiable_backward_p.def_impl(_identity)
-_nondifferentiable_backward_p.def_abstract_eval(_identity)
+nondifferentiable_backward_p.def_impl(_identity)
+nondifferentiable_backward_p.def_abstract_eval(_identity)
 batching.primitive_batchers[
-    _nondifferentiable_backward_p
+    nondifferentiable_backward_p
 ] = _nondifferentiable_backward_batch
 if hasattr(xla, "lower_fun"):
     xla.register_translation(
-        _nondifferentiable_backward_p,
+        nondifferentiable_backward_p,
         xla.lower_fun(_identity, multiple_results=False, new_style=True),
     )
 mlir.register_lowering(
-    _nondifferentiable_backward_p,
+    nondifferentiable_backward_p,
     mlir.lower_fun(_identity, multiple_results=False),
 )
-ad.primitive_jvps[_nondifferentiable_backward_p] = _nondifferentiable_backward_jvp
+ad.primitive_jvps[nondifferentiable_backward_p] = _nondifferentiable_backward_jvp
 ad.primitive_transposes[
-    _nondifferentiable_backward_p
+    nondifferentiable_backward_p
 ] = _nondifferentiable_backward_transpose
 
 
@@ -129,6 +129,6 @@ def nondifferentiable_backward(
         if name is None:
             name = "This operation"
         msg = f"Unexpected cotangent. {name} cannot be reverse-mode autodifferentiated."
-    bind = ft.partial(_nondifferentiable_backward_p.bind, msg=msg)
+    bind = ft.partial(nondifferentiable_backward_p.bind, msg=msg)
     flat = map(bind, flat)
     return combine(jtu.tree_unflatten(treedef, flat), static)

--- a/equinox/internal/finalise_jaxpr.py
+++ b/equinox/internal/finalise_jaxpr.py
@@ -1,0 +1,63 @@
+import functools as ft
+from typing import Any, Dict
+
+import jax
+import jax.tree_util as jtu
+
+
+def _safe_map(f, *args):
+    args = list(map(list, args))
+    n = len(args[0])
+    for arg in args[1:]:
+        assert len(arg) == n, f"length mismatch: {list(map(len, args))}"
+    return list(map(f, *args))
+
+
+def finalise_eval_jaxpr(jaxpr: jax.core.Jaxpr, consts, *args, wrapper_prims=()):
+    def read(v: jax.core.Atom) -> Any:
+        return v.val if isinstance(v, jax.core.Literal) else env[v]
+
+    def write(v: jax.core.Var, val: Any) -> None:
+        env[v] = val
+
+    env: Dict[jax.core.Var, Any] = {}
+    _safe_map(write, jaxpr.constvars, consts)
+    _safe_map(write, jaxpr.invars, args)
+    for eqn in jaxpr.eqns:
+        subfuns, bind_params = eqn.primitive.get_bind_params(eqn.params)
+        prim = eqn.primitive
+        call = prim.impl if prim in wrapper_prims else prim.bind
+        ans = call(*subfuns, *_safe_map(read, eqn.invars), **bind_params)
+        if eqn.primitive.multiple_results:
+            _safe_map(write, eqn.outvars, ans)
+        else:
+            write(eqn.outvars[0], ans)
+    return _safe_map(read, jaxpr.outvars)
+
+
+def finalise_jaxpr_as_fn(jaxpr: jax.core.ClosedJaxpr, *, wrapper_prims=()):
+    return ft.partial(
+        finalise_eval_jaxpr, jaxpr.jaxpr, jaxpr.consts, wrapper_prims=wrapper_prims
+    )
+
+
+def finalise_jaxpr(
+    jaxpr: jax.core.ClosedJaxpr, *, return_shape=False, wrapper_prims=()
+):
+    fn = finalise_jaxpr_as_fn(jaxpr, wrapper_prims=wrapper_prims)
+    args = [
+        jax.ShapeDtypeStruct(x.aval.shape, x.aval.dtype) for x in jaxpr.jaxpr.invars
+    ]
+    return jax.make_jaxpr(fn, return_shape=return_shape)(*args)
+
+
+def finalise_fn(fn, *, wrapper_prims=()):
+    def _finalise_fn(*args):
+        jaxpr, struct = jax.make_jaxpr(fn, return_shape=True)(*args)
+        out = finalise_eval_jaxpr(
+            jaxpr.jaxpr, jaxpr.consts, *args, wrapper_prims=wrapper_prims
+        )
+        treedef = jtu.tree_structure(struct)
+        return jtu.tree_unflatten(treedef, out)
+
+    return _finalise_fn

--- a/equinox/internal/nontraceable.py
+++ b/equinox/internal/nontraceable.py
@@ -1,0 +1,37 @@
+import functools as ft
+
+import jax
+import jax.interpreters.ad as ad
+import jax.interpreters.batching as batching
+import jax.interpreters.mlir as mlir
+import jax.tree_util as jtu
+
+from ..filters import combine, is_array, partition
+
+
+_identity = lambda x, *, name: x
+
+
+def _make_error(opname):
+    def _error(*args, name):
+        raise RuntimeError("Detected {opname} of {name}")
+
+    return _error
+
+
+nontraceable_p = jax.core.Primitive("nontraceable")
+nontraceable_p.def_impl(_identity)
+nontraceable_p.def_abstract_eval(_identity)
+ad.primitive_jvps[nontraceable_p] = _make_error("differentiation")
+ad.primitive_transposes[nontraceable_p] = _make_error("transposition")
+batching.primitive_batchers[nontraceable_p] = _make_error("batching")
+mlir.register_lowering(
+    nontraceable_p, mlir.lower_fun(_identity, multiple_results=False)
+)
+
+
+def nontraceable(x, *, name="nontraceable operation"):
+    dynamic, static = partition(x, is_array)
+    bind = ft.partial(nontraceable_p.bind, name=name)
+    dynamic = jtu.tree_map(bind, dynamic)
+    return combine(dynamic, static)

--- a/equinox/internal/onnx.py
+++ b/equinox/internal/onnx.py
@@ -1,0 +1,18 @@
+import jax.numpy as jnp
+
+from .finalise_jaxpr import finalise_fn
+
+
+def to_onnx(fn, *, wrapper_prims=()):
+    import jax.experimental.jax2tf as jax2tf
+    import tensorflow as tf
+    import tf2onnx
+
+    def _to_onnx(*args):
+        finalised_fn = finalise_fn(fn, wrapper_prims=wrapper_prims)
+        tf_fn = tf.function(jax2tf.convert(finalised_fn, enable_xla=False))
+        tf_args = [tf.TensorSpec(jnp.shape(x), jnp.result_type(x)) for x in args]
+        onnx_fn = tf2onnx.convert.from_function(tf_fn, input_signature=tf_args)
+        return onnx_fn
+
+    return _to_onnx

--- a/equinox/internal/unvmap.py
+++ b/equinox/internal/unvmap.py
@@ -7,12 +7,12 @@ import jax.numpy as jnp
 
 # unvmap_all
 
-_unvmap_all_p = jax.core.Primitive("unvmap_all")
+unvmap_all_p = jax.core.Primitive("unvmap_all")
 
 
 def unvmap_all(x):
     """As `jnp.all`, but ignores batch dimensions."""
-    return _unvmap_all_p.bind(x)
+    return unvmap_all_p.bind(x)
 
 
 def _unvmap_all_impl(x):
@@ -28,27 +28,27 @@ def _unvmap_all_batch(x, batch_axes):
     return unvmap_all(x), batching.not_mapped
 
 
-_unvmap_all_p.def_impl(_unvmap_all_impl)
-_unvmap_all_p.def_abstract_eval(_unvmap_all_abstract_eval)
-batching.primitive_batchers[_unvmap_all_p] = _unvmap_all_batch
+unvmap_all_p.def_impl(_unvmap_all_impl)
+unvmap_all_p.def_abstract_eval(_unvmap_all_abstract_eval)
+batching.primitive_batchers[unvmap_all_p] = _unvmap_all_batch
 if hasattr(xla, "lower_fun"):
     xla.register_translation(
-        _unvmap_all_p,
+        unvmap_all_p,
         xla.lower_fun(_unvmap_all_impl, multiple_results=False, new_style=True),
     )
 mlir.register_lowering(
-    _unvmap_all_p,
+    unvmap_all_p,
     mlir.lower_fun(_unvmap_all_impl, multiple_results=False),
 )
 
 # unvmap_any
 
-_unvmap_any_p = jax.core.Primitive("unvmap_any")
+unvmap_any_p = jax.core.Primitive("unvmap_any")
 
 
 def unvmap_any(x):
     """As `jnp.any`, but ignores batch dimensions."""
-    return _unvmap_any_p.bind(x)
+    return unvmap_any_p.bind(x)
 
 
 def _unvmap_any_impl(x):
@@ -64,27 +64,27 @@ def _unvmap_any_batch(x, batch_axes):
     return unvmap_any(x), batching.not_mapped
 
 
-_unvmap_any_p.def_impl(_unvmap_any_impl)
-_unvmap_any_p.def_abstract_eval(_unvmap_any_abstract_eval)
-batching.primitive_batchers[_unvmap_any_p] = _unvmap_any_batch
+unvmap_any_p.def_impl(_unvmap_any_impl)
+unvmap_any_p.def_abstract_eval(_unvmap_any_abstract_eval)
+batching.primitive_batchers[unvmap_any_p] = _unvmap_any_batch
 if hasattr(xla, "lower_fun"):
     xla.register_translation(
-        _unvmap_any_p,
+        unvmap_any_p,
         xla.lower_fun(_unvmap_any_impl, multiple_results=False, new_style=True),
     )
 mlir.register_lowering(
-    _unvmap_any_p,
+    unvmap_any_p,
     mlir.lower_fun(_unvmap_any_impl, multiple_results=False),
 )
 
 # unvmap_max
 
-_unvmap_max_p = jax.core.Primitive("unvmap_max")
+unvmap_max_p = jax.core.Primitive("unvmap_max")
 
 
 def unvmap_max(x):
     """As `jnp.max`, but ignores batch dimensions."""
-    return _unvmap_max_p.bind(x)
+    return unvmap_max_p.bind(x)
 
 
 def _unvmap_max_impl(x):
@@ -100,15 +100,15 @@ def _unvmap_max_batch(x, batch_axes):
     return unvmap_max(x), batching.not_mapped
 
 
-_unvmap_max_p.def_impl(_unvmap_max_impl)
-_unvmap_max_p.def_abstract_eval(_unvmap_max_abstract_eval)
-batching.primitive_batchers[_unvmap_max_p] = _unvmap_max_batch
+unvmap_max_p.def_impl(_unvmap_max_impl)
+unvmap_max_p.def_abstract_eval(_unvmap_max_abstract_eval)
+batching.primitive_batchers[unvmap_max_p] = _unvmap_max_batch
 if hasattr(xla, "lower_fun"):
     xla.register_translation(
-        _unvmap_max_p,
+        unvmap_max_p,
         xla.lower_fun(_unvmap_max_impl, multiple_results=False, new_style=True),
     )
 mlir.register_lowering(
-    _unvmap_max_p,
+    unvmap_max_p,
     mlir.lower_fun(_unvmap_max_impl, multiple_results=False),
 )

--- a/equinox/jit.py
+++ b/equinox/jit.py
@@ -1,8 +1,7 @@
 import functools as ft
 import inspect
 import warnings
-from types import FunctionType
-from typing import Any, Callable, Sequence, Tuple
+from typing import Any, Callable
 
 import jax
 import jax.tree_util as jtu
@@ -14,7 +13,7 @@ from .compile_utils import (
     hashable_combine,
     hashable_partition,
 )
-from .custom_types import sentinel, TreeDef
+from .custom_types import sentinel
 from .doc_utils import doc_strip_annotations
 from .filters import combine, is_array, partition
 from .module import Module, module_update_wrapper, Static
@@ -45,9 +44,9 @@ def _filter_jit_cache(fun_names, donate_default, **jitkwargs):
 
 class _JitWrapper(Module):
     _signature: inspect.Signature
-    _dynamic_fun: PyTree[Any]
-    _static_fun: Tuple[TreeDef, Sequence[Any]]
-    _cached: FunctionType
+    _dynamic_fun: PyTree
+    _static_fun: Any
+    _cached: Any
     _filter_warning: bool
 
     def _fun_wrapper(self, is_lower, args, kwargs):

--- a/equinox/nn/linear.py
+++ b/equinox/nn/linear.py
@@ -1,5 +1,5 @@
 import math
-from typing import Optional, TypeVar
+from typing import Any, Optional, TypeVar
 
 import jax
 import jax.random as jrandom
@@ -86,7 +86,7 @@ class Identity(Module):
     another Module.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any):
         """Consumes arbitrary `*args` and `**kwargs` but ignores them."""
         # Ignores args and kwargs
         super().__init__()

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ classifiers = [
 
 python_requires = "~=3.7"
 
-install_requires = ["jax>=0.3.4", "jaxtyping>=0.2.5"]
+install_requires = ["jax>=0.3.25", "jaxtyping>=0.2.9"]
 
 setuptools.setup(
     name=name,

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -29,7 +29,10 @@ treedefs = [
 ]
 
 
-def _shaped_allclose(x, y, **kwargs):
+def _shaped_allclose(x, y, *, match_weak, **kwargs):
+    if match_weak:
+        x = jnp.asarray(x)
+        y = jnp.asarray(y)
     if type(x) is not type(y):
         return False
     if isinstance(x, jnp.ndarray):
@@ -54,13 +57,13 @@ def _shaped_allclose(x, y, **kwargs):
         return x == y
 
 
-def shaped_allclose(x, y, **kwargs):
+def shaped_allclose(x, y, *, match_weak=False, **kwargs):
     """As `jnp.allclose`, except:
     - It also supports PyTree arguments.
     - It mandates that shapes match as well (no broadcasting)
     """
     same_structure = jtu.tree_structure(x) == jtu.tree_structure(y)
-    allclose = ft.partial(_shaped_allclose, **kwargs)
+    allclose = ft.partial(_shaped_allclose, match_weak=match_weak, **kwargs)
     return same_structure and jtu.tree_reduce(
         operator.and_, jtu.tree_map(allclose, x, y), True
     )

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,5 @@
 jaxlib
 pytest
 typeguard
+tensorflow
+tf2onnx

--- a/tests/test_finalise_jaxpr.py
+++ b/tests/test_finalise_jaxpr.py
@@ -1,0 +1,113 @@
+import jax
+import jax.numpy as jnp
+
+import equinox.internal as eqxi
+
+from .helpers import shaped_allclose
+
+
+def _safe_zip(*args):
+    length = len(args[0])
+    assert all(len(a) == length for a in args[1:])
+    return zip(*args)
+
+
+def _assert_vars_equal(obj1, obj2, varnames):
+    for varname in varnames:
+        vars1 = getattr(obj1, varname)
+        vars2 = getattr(obj2, varname)
+        for a, b in _safe_zip(vars1, vars2):
+            assert a.aval.strip_weak_type() == b.aval.strip_weak_type()
+
+
+def _assert_jaxpr_equal(jaxpr1: jax.core.ClosedJaxpr, jaxpr2: jax.core.ClosedJaxpr):
+    assert jaxpr1.consts == jaxpr2.consts
+    jaxpr1 = jaxpr1.jaxpr
+    jaxpr2 = jaxpr2.jaxpr
+    _assert_vars_equal(jaxpr1, jaxpr2, ("invars", "outvars", "constvars"))
+    for eqn1, eqn2 in _safe_zip(jaxpr1.eqns, jaxpr2.eqns):
+        assert eqn1.primitive == eqn2.primitive
+        assert eqn1.effects == eqn2.effects
+        assert eqn1.params == eqn2.params
+        _assert_vars_equal(eqn1, eqn2, ("invars", "outvars"))
+
+
+def test_jaxpr2jaxpr_nocustom_idempotent():
+    def fn(x):
+        x = x + 1
+        x + x * 2
+        return x
+
+    jaxpr = jax.make_jaxpr(fn)(1)
+    jaxpr2 = eqxi.finalise_jaxpr(jaxpr)
+    _assert_jaxpr_equal(jaxpr, jaxpr2)
+
+
+def test_jaxpr2jaxpr_custom_idempotent():
+    def fn(x):
+        x = jnp.invert(x)
+        x = eqxi.unvmap_any(x)
+        x = jnp.invert(x)
+        return x
+
+    jaxpr = jax.make_jaxpr(fn)(True)
+    jaxpr2 = eqxi.finalise_jaxpr(jaxpr, wrapper_prims=[eqxi.unvmap_any_p])
+    jaxpr3 = eqxi.finalise_jaxpr(jaxpr2, wrapper_prims=[eqxi.unvmap_any_p])
+    _assert_jaxpr_equal(jaxpr2, jaxpr3)
+
+    jaxpr = jax.make_jaxpr(jax.vmap(fn))(jnp.array([True, False]))
+    jaxpr2 = eqxi.finalise_jaxpr(jaxpr, wrapper_prims=[eqxi.unvmap_any_p])
+    jaxpr3 = eqxi.finalise_jaxpr(jaxpr2, wrapper_prims=[eqxi.unvmap_any_p])
+    _assert_jaxpr_equal(jaxpr2, jaxpr3)
+
+
+def test_fn2fn_nocustom_idempotent():
+    def fn(x):
+        x = x + 1
+        x + x * 2
+        return x
+
+    finalised_fn = eqxi.finalise_fn(fn)
+    assert shaped_allclose(fn(1), finalised_fn(1), match_weak=True)
+    assert shaped_allclose(fn(5), finalised_fn(5), match_weak=True)
+    assert shaped_allclose(fn(-1), finalised_fn(-1), match_weak=True)
+
+    jaxpr = jax.make_jaxpr(fn)(1)
+    finalised_jaxpr = jax.make_jaxpr(finalised_fn)(1)
+    _assert_jaxpr_equal(finalised_jaxpr, jaxpr)
+
+
+def test_fn2fn_custom_idempotent():
+    def fn(x):
+        x = jnp.invert(x)
+        x = eqxi.unvmap_any(x)
+        x = jnp.invert(x)
+        return x
+
+    finalised_fn = eqxi.finalise_fn(fn, wrapper_prims=[eqxi.unvmap_any_p])
+    assert shaped_allclose(fn(False), finalised_fn(False))
+    assert shaped_allclose(fn(True), finalised_fn(True))
+
+    finalised_jaxpr = jax.make_jaxpr(finalised_fn)(True)
+    finalised_finalised_jaxpr = jax.make_jaxpr(eqxi.finalise_fn(finalised_fn))(True)
+    _assert_jaxpr_equal(finalised_jaxpr, finalised_finalised_jaxpr)
+    for eqn in finalised_jaxpr.eqns:
+        assert eqn.primitive != eqxi.unvmap_any_p
+
+    vmap_fn = jax.vmap(fn)
+    finalised_vmap_fn = eqxi.finalise_fn(vmap_fn, wrapper_prims=[eqxi.unvmap_any_p])
+    for arg in (
+        jnp.array([False, False]),
+        jnp.array([False, True]),
+        jnp.array([True, False]),
+        jnp.array([True, True]),
+    ):
+        assert shaped_allclose(vmap_fn(arg), finalised_vmap_fn(arg))
+
+    finalised_vmap_jaxpr = jax.make_jaxpr(finalised_vmap_fn)(jnp.array([False, False]))
+    finalised_finalised_vmap_jaxpr = jax.make_jaxpr(
+        eqxi.finalise_fn(finalised_vmap_fn)
+    )(jnp.array([False, False]))
+    for eqn in finalised_vmap_jaxpr.eqns:
+        assert eqn.primitive != eqxi.unvmap_any_p
+    _assert_jaxpr_equal(finalised_vmap_jaxpr, finalised_finalised_vmap_jaxpr)

--- a/tests/test_jit.py
+++ b/tests/test_jit.py
@@ -269,10 +269,11 @@ def test_function_name_warning(log_compiles_config, caplog):
     # Trigger compile to log a warning message
     the_test_function_name(jnp.array(1.0))
 
-    warning_text = caplog.text
-
     # Check that the warning message contains the function name
-    assert "Finished XLA compilation of the_test_function_name in" in warning_text
+    old = "Finished XLA compilation of the_test_function_name in" in caplog.text
+    new = "Finished XLA compilation of jit(the_test_function_name) in" in caplog.text
+    assert old or new
+    caplog.clear()
 
     @eqx.filter_jit
     @eqx.filter_value_and_grad
@@ -282,12 +283,16 @@ def test_function_name_warning(log_compiles_config, caplog):
     # Trigger compile to log a warning message
     the_test_function_name_value_and_grad(jnp.array(1.0))
 
-    warning_text = caplog.text
-
-    assert (
+    old = (
         "Finished XLA compilation of the_test_function_name_value_and_grad in"
-        in warning_text
+        in caplog.text
     )
+    new = (
+        "Finished XLA compilation of jit(the_test_function_name_value_and_grad) in"
+        in caplog.text
+    )
+    assert old or new
+    caplog.clear()
 
     def wrapped_fun(y):
         pass
@@ -301,9 +306,9 @@ def test_function_name_warning(log_compiles_config, caplog):
 
     fun(jnp.array(1.0))
 
-    warning_text = caplog.text
-
-    assert "Finished XLA compilation of wrapped_fun in" in warning_text
+    old = "Finished XLA compilation of wrapped_fun in" in caplog.text
+    new = "Finished XLA compilation of jit(wrapped_fun) in" in caplog.text
+    caplog.clear()
 
 
 def test_wrap_jax_partial(getkey):

--- a/tests/test_onnx.py
+++ b/tests/test_onnx.py
@@ -1,0 +1,16 @@
+import jax
+import jax.numpy as jnp
+
+import equinox.internal as eqxi
+
+
+def test_onnx_export():
+    @jax.vmap
+    def fn(x, y):
+        x = x + 1
+        y = eqxi.unvmap_any(y)
+        return jnp.where(y, x, 1)
+
+    onnx_fn = eqxi.to_onnx(fn, wrapper_prims=[eqxi.unvmap_any_p])
+    args = jnp.array([1, 2]), jnp.array([True, False])
+    onnx_fn(*args)

--- a/tests/test_pformat.py
+++ b/tests/test_pformat.py
@@ -43,10 +43,9 @@ def test_named_tuple():
 def test_jax_array():
     assert eqx.tree_pformat(jnp.array(1)) == "i32[]"
     assert eqx.tree_pformat(jnp.arange(12).reshape(3, 4)) == "i32[3,4]"
-    assert (
-        eqx.tree_pformat(jnp.array(1), short_arrays=False)
-        == "DeviceArray(1, dtype=int32, weak_type=True)"
-    )
+    array = "Array(1, dtype=int32, weak_type=True)"
+    device_array = "DeviceArray(1, dtype=int32, weak_type=True)"
+    assert eqx.tree_pformat(jnp.array(1), short_arrays=False) in (array, device_array)
 
 
 def test_numpy_array():

--- a/tests/test_stateful.py
+++ b/tests/test_stateful.py
@@ -110,8 +110,8 @@ def test_vmap(with_jit, with_pytree):
         return eqx.experimental.get_state(i, x)
 
     if with_jit:
-        vmap_set_state = eqx.filter_jit(vmap_set_state)
-        vmap_get_state = eqx.filter_jit(vmap_get_state)
+        vmap_set_state = eqx.filter_jit(vmap_set_state, donate="none")
+        vmap_get_state = eqx.filter_jit(vmap_get_state, donate="none")
 
     a = jnp.array([1, 2])
     b = jnp.array([3, 4])


### PR DESCRIPTION
New features:
- `equinox.internal.to_onnx` for export to ONNX.
- `equinox.internal.{finalise_jaxpr,finalise_fn,finalise_eval_jaxpr,finalise_jaxpr_as_fun}`. The main one here is `finalise_jaxpr`, which is essentially a jaxpr-to-jaxpr transformation that rewrites all custom primitives in terms of their `impl` rule. This is useful prior to ONNX export: this can be the final transformation applied to a jaxpr, so that it is now written in terms of primitives that have ONNX export rules. (But naturally this will break anything further jaxpr processing via vmap/grad/etc.)
- `equinox.internal.nontraceable` is an operation that cannot be vmap'd, grad'd etc. (Useful to check that there were no closed-over tracers at the end of a final-style higher order primitive.)