### PR TITLE
Fixed deterministic=True being ignored in MultiheadAttention

### DIFF
--- a/equinox/nn/attention.py
+++ b/equinox/nn/attention.py
@@ -1,4 +1,5 @@
 import math
+import warnings
 from functools import partial
 from typing import Optional
 
@@ -245,6 +246,13 @@ class MultiheadAttention(Module):
 
         A JAX array of shape `(query_seq_length, output_size)`.
         """
+
+        if deterministic is not None:
+            inference = deterministic
+            warnings.warn(
+                "MultiheadAttention()(deterministic=...) is deprecated "
+                "in favour of MultiheadAttention()(inference=...)"
+            )
 
         query_seq_length, _ = query.shape
         kv_seq_length, _ = key_.shape

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -608,6 +608,39 @@ def test_multihead_attention(getkey):
     )
 
 
+def test_multihead_attention_inference(getkey):
+    attn = eqx.nn.MultiheadAttention(
+        num_heads=2, query_size=10, dropout_p=0.5, key=getkey()
+    )
+    x = jrandom.normal(getkey(), (3, 10))
+    z1 = attn(x, x, x, key=getkey(), inference=True)
+    z2 = attn(x, x, x, inference=True)
+    assert jnp.all(z1 == z2)
+
+    z1 = attn(x, x, x, key=getkey())
+    z2 = attn(x, x, x, key=getkey())
+    assert jnp.any(z1 != z2)
+
+    attn2 = eqx.nn.MultiheadAttention(
+        num_heads=2, query_size=10, dropout_p=0.5, inference=True, key=getkey()
+    )
+    z1 = attn2(x, x, x, key=getkey())
+    z2 = attn2(x, x, x, key=getkey())
+    assert jnp.all(z1 == z2)
+
+
+def test_multihead_attention_deterministic(getkey):
+    with warnings.catch_warnings():
+        attn = eqx.nn.MultiheadAttention(
+            num_heads=2, query_size=10, dropout_p=0.5, key=getkey()
+        )
+        x = jrandom.normal(getkey(), (3, 10))
+        warnings.simplefilter("ignore")
+        z1 = attn(x, x, x, key=getkey(), deterministic=True)
+        z2 = attn(x, x, x, deterministic=True)
+        assert jnp.all(z1 == z2)
+
+
 def test_embedding(getkey):
     emb = eqx.nn.Embedding(100, 512, key=getkey())
     x = jnp.array([1])


### PR DESCRIPTION
Handled the argument, added a warning and 2 simple test cases, all similar to how Dropout does it

Relates: #287