### PR TITLE
Make `depth` more explicit

### DIFF
--- a/equinox/nn/_composed.py
+++ b/equinox/nn/_composed.py
@@ -68,7 +68,7 @@ class MLP(Module):
         - `out_size`: The output size. The output from the module will be a vector
             of shape `(out_features,)`.
         - `width_size`: The size of each hidden layer.
-        - `depth`: The number of hidden layers including the output layer. ie. depth=2
+        - `depth`: The number of hidden layers, including the output layer. For Example, `depth=2`
             results in an network with layers [`Linear(in_size, width_size)`,
             `Linear(width_size, width_size)`, `Linear(width_size, out_size)`].
         - `activation`: The activation function after each hidden layer. Defaults to

--- a/equinox/nn/_composed.py
+++ b/equinox/nn/_composed.py
@@ -68,7 +68,7 @@ class MLP(Module):
         - `out_size`: The output size. The output from the module will be a vector
             of shape `(out_features,)`.
         - `width_size`: The size of each hidden layer.
-        - `depth`: The number of hidden layers, including the output layer. For Example, `depth=2`
+        - `depth`: The number of hidden layers, including the output layer. For example, `depth=2`
             results in an network with layers [`Linear(in_size, width_size)`,
             `Linear(width_size, width_size)`, `Linear(width_size, out_size)`].
         - `activation`: The activation function after each hidden layer. Defaults to

--- a/equinox/nn/_composed.py
+++ b/equinox/nn/_composed.py
@@ -68,9 +68,10 @@ class MLP(Module):
         - `out_size`: The output size. The output from the module will be a vector
             of shape `(out_features,)`.
         - `width_size`: The size of each hidden layer.
-        - `depth`: The number of hidden layers, including the output layer. For example, `depth=2`
-            results in an network with layers [`Linear(in_size, width_size)`,
-            `Linear(width_size, width_size)`, `Linear(width_size, out_size)`].
+        - `depth`: The number of hidden layers, including the output layer.
+            For example, `depth=2` results in an network with layers:
+            [`Linear(in_size, width_size)`, `Linear(width_size, width_size)`,
+            `Linear(width_size, out_size)`].
         - `activation`: The activation function after each hidden layer. Defaults to
             ReLU.
         - `final_activation`: The activation function after the output layer. Defaults

--- a/equinox/nn/_composed.py
+++ b/equinox/nn/_composed.py
@@ -68,7 +68,9 @@ class MLP(Module):
         - `out_size`: The output size. The output from the module will be a vector
             of shape `(out_features,)`.
         - `width_size`: The size of each hidden layer.
-        - `depth`: The number of hidden layers.
+        - `depth`: The number of hidden layers including the output layer. ie. depth=2
+            results in an network with layers [`Linear(in_size, width_size)`,
+            `Linear(width_size, width_size)`, `Linear(width_size, out_size)`].
         - `activation`: The activation function after each hidden layer. Defaults to
             ReLU.
         - `final_activation`: The activation function after the output layer. Defaults


### PR DESCRIPTION
It's not immediately clear what convention `depth` is using. For example, a depth two network could either correspond to a network of shape: (in layer, hidden layer 1, hidden layer 2, output layer) or of shape (in layer, hidden layer, output layer). This makes it clear exactly which convention equinox uses.