### PR TITLE
Allow omega to take prefixing PyTree to handle buffer edge case

### DIFF
--- a/equinox/internal/_loop/common.py
+++ b/equinox/internal/_loop/common.py
@@ -20,16 +20,6 @@ class _Buffer(Module):
     def __getitem__(self, item):
         return self._array[item]
 
-    # def _set(self, pred, item, x):
-    #     pred = pred & self._pred
-    #     if isinstance(self._array, _Buffer):
-    #         array = self._array._set(pred, item, x)
-    #     else:
-    #         old_x = self._array[item]
-    #         x = jnp.where(pred, x, old_x)
-    #         array = self._array.at[item].set(x)
-    #     return _Buffer(array, self._pred, self._tag)
-
     def _op(self, pred, item, x, op):
         pred = pred & self._pred
         if isinstance(self._array, _Buffer):

--- a/equinox/internal/_loop/common.py
+++ b/equinox/internal/_loop/common.py
@@ -61,6 +61,17 @@ class _BufferItem(Module):
     def set(self, x, *, pred=True):
         return self._buffer._set(pred, self._item, x)
 
+    def add(self, x, *, pred=True):
+        return self._buffer._set(pred, self._item, self._buffer[self._item] + x)
+
+    def multiply(self, x, *, pred=True):
+        return self._buffer._set(pred, self._item, self._buffer[self._item] * x)
+
+    def divide(self, x, *, pred=True):
+        return self._buffer._set(pred, self._item, self._buffer[self._item] / x)
+
+    def power(self, x, *, pred=True):
+        return self._buffer._set(pred, self._item, self._buffer[self._item] ** x)
 
 def _is_buffer(x):
     return isinstance(x, _Buffer)

--- a/equinox/internal/_loop/common.py
+++ b/equinox/internal/_loop/common.py
@@ -20,14 +20,24 @@ class _Buffer(Module):
     def __getitem__(self, item):
         return self._array[item]
 
-    def _set(self, pred, item, x):
+    # def _set(self, pred, item, x):
+    #     pred = pred & self._pred
+    #     if isinstance(self._array, _Buffer):
+    #         array = self._array._set(pred, item, x)
+    #     else:
+    #         old_x = self._array[item]
+    #         x = jnp.where(pred, x, old_x)
+    #         array = self._array.at[item].set(x)
+    #     return _Buffer(array, self._pred, self._tag)
+
+    def _op(self, pred, item, x, op):
         pred = pred & self._pred
         if isinstance(self._array, _Buffer):
-            array = self._array._set(pred, item, x)
+            array = self._array._op(pred, item, x, op)
         else:
             old_x = self._array[item]
             x = jnp.where(pred, x, old_x)
-            array = self._array.at[item].set(x)
+            array = getattr(self._array.at[item], op)(x)
         return _Buffer(array, self._pred, self._tag)
 
     @property
@@ -59,19 +69,20 @@ class _BufferItem(Module):
     _item: Any
 
     def set(self, x, *, pred=True):
-        return self._buffer._set(pred, self._item, x)
+        return self._buffer._op(pred, self._item, x, "set")
 
     def add(self, x, *, pred=True):
-        return self._buffer._set(pred, self._item, self._buffer[self._item] + x)
+        return self._buffer._op(pred, self._item, x, "add")
 
     def multiply(self, x, *, pred=True):
-        return self._buffer._set(pred, self._item, self._buffer[self._item] * x)
+        return self._buffer._op(pred, self._item, x, "multiply")
 
     def divide(self, x, *, pred=True):
-        return self._buffer._set(pred, self._item, self._buffer[self._item] / x)
+        return self._buffer._op(pred, self._item, x, "divide")
 
     def power(self, x, *, pred=True):
-        return self._buffer._set(pred, self._item, self._buffer[self._item] ** x)
+        return self._buffer._op(pred, self._item, x, "power")
+
 
 def _is_buffer(x):
     return isinstance(x, _Buffer)

--- a/equinox/internal/_omega.py
+++ b/equinox/internal/_omega.py
@@ -34,7 +34,7 @@ class _ω(metaclass=_Metaω):
 
         If `structure` is passed then
         ```
-        ω(a, structure=b).call(fn) = jax.tree_util.tree_map(lambda x, y: fn(y), b, a)
+        ω(a, structure=b).call(fn) = jax.tree_util.tree_map(lambda _, y: fn(y), b, a)
         ```
         where `b` is a prefix PyTree of `a`. This evaluates `a` at the nodes corresponding
         to the leaves of `b`.

--- a/equinox/internal/_omega.py
+++ b/equinox/internal/_omega.py
@@ -33,7 +33,7 @@ class _ω(metaclass=_Metaω):
         This is entirely equivalent to the above.
 
 
-        If if a tuple `(a, b)` is passed then
+        If `structure` is passed then
         ```
         ω(a,structure=b).call(fn) = jax.tree_util.tree_map(lambda x,y: fn(y), b, a)
         ```
@@ -79,7 +79,7 @@ class _ω(metaclass=_Metaω):
     def call(self, fn):
         return ω(
             jtu.tree_map(
-                lambda _x, y: fn(y[...]), self.struct, self.ω, is_leaf=self.is_leaf
+                lambda _x, y: fn(y), self.struct, self.ω, is_leaf=self.is_leaf
             ),
             structure=self.struct,
             is_leaf=self.is_leaf,

--- a/equinox/internal/_omega.py
+++ b/equinox/internal/_omega.py
@@ -77,7 +77,7 @@ class _ω(metaclass=_Metaω):
 
     def call(self, fn):
         return ω(
-            jtu.tree_map(lambda x, y: fn(y), self.struct, self.ω, is_leaf=self.is_leaf),
+            jtu.tree_map(lambda x, y: fn(y[...]), self.struct, self.ω, is_leaf=self.is_leaf),
             self.struct,
             is_leaf=self.is_leaf,
         )
@@ -117,14 +117,14 @@ def _set_binary(base, name: str, op: Callable[[Any, Any], Any]) -> None:
                 raise ValueError("`is_leaf` must match.")
             return ω(
                 jtu.tree_map(
-                    lambda x, y, z: op(y, z), self.struct, self.ω, other.ω, is_leaf=self.is_leaf
+                    lambda x, y, z: op(y[...], z[...]), self.struct, self.ω, other.ω, is_leaf=self.is_leaf
                 ),
                 self.struct,
                 is_leaf=self.is_leaf,
             )
         elif isinstance(other, (bool, complex, float, int, jax.Array)):
             return ω(
-                jtu.tree_map(lambda x, y: op(y, other), self.struct, self.ω, is_leaf=self.is_leaf),
+                jtu.tree_map(lambda x, y: op(y[...], other), self.struct, self.ω, is_leaf=self.is_leaf),
                 self.struct,
                 is_leaf=self.is_leaf,
             )
@@ -228,25 +228,25 @@ def _set_binary_at(base, name: str, op: Callable[[Any, Any, Any], Any]) -> None:
             if not _equal_code(self.is_leaf, other.is_leaf):
                 raise ValueError("is_leaf specifications must match.")
             return ω(
-                self.struct,
                 jtu.tree_map(
-                    lambda x, y, z: op(y, self.item, z),
-                    self.value,
+                    lambda x, y, z: op(y, self.item, z[...]),
                     self.struct,
+                    self.value,
                     other.ω,
                     is_leaf=self.is_leaf,
                 ),
+                self.struct,
                 is_leaf=self.is_leaf,
             )
         elif isinstance(other, (bool, complex, float, int, jax.Array)):
             return ω(
-                self.struct,
                 jtu.tree_map(
                     lambda x, y: op(y, self.item, other),
-                    self.value,
                     self.struct,
+                    self.value,
                     is_leaf=self.is_leaf
                 ),
+                self.struct,
                 is_leaf=self.is_leaf,
             )
         else:
@@ -260,6 +260,7 @@ def _set_binary_at(base, name: str, op: Callable[[Any, Any, Any], Any]) -> None:
 for (name, op) in [
     ("set", lambda x, y, z, **kwargs: x.at[y].set(z, **kwargs)),
     ("add", lambda x, y, z, **kwargs: x.at[y].add(z, **kwargs)),
+    ("sub", lambda x, y, z, **kwargs: x.at[y].add(-z, **kwargs)),
     ("multiply", lambda x, y, z, **kwargs: x.at[y].multiply(z, **kwargs)),
     ("divide", lambda x, y, z, **kwargs: x.at[y].divide(z, **kwargs)),
     ("power", lambda x, y, z, **kwargs: x.at[y].power(z, **kwargs)),

--- a/equinox/internal/_omega.py
+++ b/equinox/internal/_omega.py
@@ -70,7 +70,7 @@ class _ω(metaclass=_Metaω):
     def __getitem__(self, item):
         return ω(
             jtu.tree_map(
-                lambda x, y: y[item], self.struct, self.ω, is_leaf=self.is_leaf
+                lambda _x, y: y[item], self.struct, self.ω, is_leaf=self.is_leaf
             ),
             structure=self.struct,
             is_leaf=self.is_leaf,
@@ -79,7 +79,7 @@ class _ω(metaclass=_Metaω):
     def call(self, fn):
         return ω(
             jtu.tree_map(
-                lambda x, y: fn(y[...]), self.struct, self.ω, is_leaf=self.is_leaf
+                lambda _x, y: fn(y[...]), self.struct, self.ω, is_leaf=self.is_leaf
             ),
             structure=self.struct,
             is_leaf=self.is_leaf,
@@ -120,7 +120,7 @@ def _set_binary(base, name: str, op: Callable[[Any, Any], Any]) -> None:
                 raise ValueError("`is_leaf` must match.")
             return ω(
                 jtu.tree_map(
-                    lambda x, y, z: op(y[...], z[...]),
+                    lambda _x, y, z: op(y[...], z[...]),
                     self.struct,
                     self.ω,
                     other.ω,
@@ -132,7 +132,7 @@ def _set_binary(base, name: str, op: Callable[[Any, Any], Any]) -> None:
         elif isinstance(other, (bool, complex, float, int, jax.Array)):
             return ω(
                 jtu.tree_map(
-                    lambda x, y: op(y[...], other),
+                    lambda _x, y: op(y[...], other),
                     self.struct,
                     self.ω,
                     is_leaf=self.is_leaf,
@@ -151,7 +151,7 @@ def _set_binary(base, name: str, op: Callable[[Any, Any], Any]) -> None:
 def _set_unary(base, name: str, op: Callable[[Any], Any]) -> None:
     def fn(self):
         return ω(
-            jtu.tree_map(lambda x, y: op(y), self.struct, self.ω, is_leaf=self.is_leaf),
+            jtu.tree_map(lambda _x, y: op(y), self.struct, self.ω, is_leaf=self.is_leaf),
             structure=self.struct,
             is_leaf=self.is_leaf,
         )
@@ -241,7 +241,7 @@ def _set_binary_at(base, name: str, op: Callable[[Any, Any, Any], Any]) -> None:
                 raise ValueError("is_leaf specifications must match.")
             return ω(
                 jtu.tree_map(
-                    lambda x, y, z: op(y, self.item, z[...]),
+                    lambda _x, y, z: op(y, self.item, z[...]),
                     self.struct,
                     self.value,
                     other.ω,
@@ -253,7 +253,7 @@ def _set_binary_at(base, name: str, op: Callable[[Any, Any, Any], Any]) -> None:
         elif isinstance(other, (bool, complex, float, int, jax.Array)):
             return ω(
                 jtu.tree_map(
-                    lambda x, y: op(y, self.item, other),
+                    lambda _x, y: op(y, self.item, other),
                     self.struct,
                     self.value,
                     is_leaf=self.is_leaf,


### PR DESCRIPTION
`jtu.tree_map(fn, tree, *rest)` uses `tree` to determine where to evaluate
`f(tree, *rest)`. `tree` must be a prefixing PyTree to
every PyTree in  `*rest`.

This adds support for prefixing trees. in particular:
```
ω(a, b).call(fn) = jax.tree_util(lambda x, y: fn(y), b, a)
```
and
```
ω(a).call(fn) = ω(a, a).call(fn)
```

This was included to handle buffers in the equinox internal while loop,
where we may wish to use ω to index into buffers, rather than into the PyTrees
resulting from wrapping subtrees in buffers.