### PR TITLE
Remove implicit promotion in Conv

### DIFF
--- a/equinox/nn/_conv.py
+++ b/equinox/nn/_conv.py
@@ -188,9 +188,9 @@ class Conv(Module):
             rhs_dilation=self.dilation,
             feature_group_count=self.groups,
         )
+        x = jnp.squeeze(x, axis=0)
         if self.use_bias:
             x = x + self.bias
-        x = jnp.squeeze(x, axis=0)
         return x
 
 


### PR DESCRIPTION
Simple change to address https://github.com/patrick-kidger/equinox/issues/308. Previously the code in the issue would result in 
```
ValueError: Operands could not be broadcast together for add on shapes (1, 4, 8) (4, 1) and with the config option jax_numpy_rank_promotion='raise'. For more information, see https://jax.readthedocs.io/en/latest/rank_promotion_warning.html.
```

Now it results in 

```
Array([[ 0.7041937 ,  0.7041937 ,  0.7041937 ,  0.7041937 ,  0.7041937 ,
         0.7041937 ,  0.7041937 ,  0.7041937 ],
       [-0.42025453, -0.42025453, -0.42025453, -0.42025453, -0.42025453,
        -0.42025453, -0.42025453, -0.42025453],
       [ 0.25013918,  0.25013918,  0.25013918,  0.25013918,  0.25013918,
         0.25013918,  0.25013918,  0.25013918],
       [ 0.36006033,  0.36006033,  0.36006033,  0.36006033,  0.36006033,
         0.36006033,  0.36006033,  0.36006033]], dtype=float32)
```