### PR TITLE
Clip variance in normalization

### DIFF
--- a/equinox/experimental/_batch_norm.py
+++ b/equinox/experimental/_batch_norm.py
@@ -145,6 +145,7 @@ class BatchNorm(Module):
             mean = lax.pmean(mean, self.axis_name)
             var = jnp.mean((y - mean) ** 2)
             var = lax.pmean(var, self.axis_name)
+            var = jnp.maximum(0.0, var)
             return mean, var
 
         batch_state = jax.vmap(_stats)(x)

--- a/equinox/nn/_normalisation.py
+++ b/equinox/nn/_normalisation.py
@@ -87,6 +87,7 @@ class LayerNorm(Module):
         """
         mean = jnp.mean(x, keepdims=True)
         variance = jnp.var(x, keepdims=True)
+        variance = jnp.maximum(0.0, variance)
         inv = jax.lax.rsqrt(variance + self.eps)
         out = (x - mean) * inv
         if self.elementwise_affine:
@@ -176,6 +177,7 @@ class GroupNorm(Module):
         y = x.reshape(self.groups, channels // self.groups, *x.shape[1:])
         mean = jax.vmap(ft.partial(jnp.mean, keepdims=True))(y)
         variance = jax.vmap(ft.partial(jnp.var, keepdims=True))(y)
+        variance = jnp.maximum(0.0, variance)
         inv = jax.lax.rsqrt(variance + self.eps)
         out = (y - mean) * inv
         out = out.reshape(x.shape)


### PR DESCRIPTION
Hi Patrick,

I encountered some numerical instability in training with `LayerNorm` as losses return `NaN`. When turning on `jax_debug_nans`, it showed that `LayerNorm` failed to compute `jax.lax.rsqrt`.

I refer to Flax about this issue. That is, it is better to clip variance (this [line](https://github.com/google/flax/blob/660fd6c16df3a5fa2b5b0c2eaf9e2ca4de40bea4/flax/linen/normalization.py#L101)) to enable numerical stability for float32.

I don't have a certain test case for this.