### PR TITLE
Change LayerNorm to allow weights or biases

### DIFF
--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -662,7 +662,7 @@ def test_layer_norm(getkey):
     x = jrandom.uniform(getkey(), (128,))
     assert ln(x).shape == (128,)
 
-    ln = eqx.nn.LayerNorm(shape=(128, 128), elementwise_affine=False)
+    ln = eqx.nn.LayerNorm(shape=(128, 128), use_weight=False, use_bias=False)
     x = jrandom.uniform(getkey(), (128, 128))
     assert ln(x).shape == (128, 128)
 


### PR DESCRIPTION
Addresses https://github.com/patrick-kidger/equinox/issues/310. I handled the deprecation of `elementwise_affine` in as similar a manner as I could to `dropout` which also has a deprecated argument. 