### PR TITLE
Add support for pjit

### DIFF
--- a/equinox/__init__.py
+++ b/equinox/__init__.py
@@ -21,7 +21,7 @@ from ._filters import (
     is_inexact_array_like as is_inexact_array_like,
     partition as partition,
 )
-from ._jit import filter_jit as filter_jit
+from ._jit import filter_jit as filter_jit, filter_pjit as filter_pjit
 from ._make_jaxpr import filter_make_jaxpr as filter_make_jaxpr
 from ._module import (
     Module as Module,


### PR DESCRIPTION
This PR addresses #289 by patching `filter_jit` with a switch to call `jax.experimental.pjit.pjit` instead of `jax.jit`. I've been using this patch extensively and seems to be completely seamless. 

Also @patrick-kidger, I'm just wondering what the practice of  importing everything with the `thing as thing` convention does? I've seen this in a few places elsewhere.