### PR TITLE
module_update_wrapper no longer assigns __wrapped__

### DIFF
--- a/equinox/_ad.py
+++ b/equinox/_ad.py
@@ -49,6 +49,10 @@ class _ValueAndGradWrapper(Module):
     _has_aux: bool
     _gradkwargs: Dict[str, Any]
 
+    @property
+    def __wrapped__(self):
+        return self._fun
+
     def __call__(self, x, /, *args, **kwargs):
         @ft.partial(jax.value_and_grad, has_aux=self._has_aux, **self._gradkwargs)
         def fun_value_and_grad(_diff_x, _nondiff_x, *_args, **_kwargs):
@@ -67,6 +71,10 @@ class _ValueAndGradWrapper(Module):
 class _GradWrapper(Module):
     _fun_value_and_grad: _ValueAndGradWrapper
     _has_aux: bool
+
+    @property
+    def __wrapped__(self):
+        return self._fun_value_and_grad
 
     def __call__(self, /, *args, **kwargs):
         value, grad = self._fun_value_and_grad(*args, **kwargs)

--- a/equinox/_jit.py
+++ b/equinox/_jit.py
@@ -72,6 +72,10 @@ class _JitWrapper(Module):
     _cached: Any
     _filter_warning: bool
 
+    @property
+    def __wrapped__(self):
+        return hashable_combine(self._dynamic_fun, self._static_fun)
+
     def _call(self, is_lower, args, kwargs):
         args, kwargs = _bind(self._signature, args, kwargs)
         dynamic_spec, static_spec = hashable_partition((args, kwargs), is_array)

--- a/equinox/_make_jaxpr.py
+++ b/equinox/_make_jaxpr.py
@@ -20,6 +20,10 @@ def _is_struct(x):
 class _MakeJaxpr(Module):
     fn: Callable
 
+    @property
+    def __wrapped__(self):
+        return self.fn
+
     def __call__(self, *args, **kwargs):
         dynamic, static = partition((args, kwargs), _is_struct)
         dynamic_flat, dynamic_treedef = jtu.tree_flatten(dynamic)

--- a/equinox/_vmap_pmap.py
+++ b/equinox/_vmap_pmap.py
@@ -148,6 +148,10 @@ class _VmapWrapper(Module):
     _axis_size: Optional[int]
     _vmapkwargs: Dict[str, Any]
 
+    @property
+    def __wrapped__(self):
+        return self._fun
+
     def __call__(self, /, *args, **kwargs):
         if len(kwargs) != 0:
             raise RuntimeError(
@@ -476,6 +480,10 @@ class _PmapWrapper(Module):
     _axis_size: Optional[int]
     _filter_warning: bool
     _pmapkwargs: Dict[str, Any]
+
+    @property
+    def __wrapped__(self):
+        return self._fun
 
     def _call(self, is_lower, args, kwargs):
         maybe_dummy = _common_preprocess(self._axis_size, kwargs)

--- a/equinox/internal/_noinline.py
+++ b/equinox/internal/_noinline.py
@@ -381,6 +381,10 @@ class _NoInlineWrapper(Module):
     abstract_fn: Callable = static_field()
     dynamic_fn: Any
 
+    @property
+    def __wrapped__(self):
+        return self.abstract_fn
+
     def __call__(self, *args, **kwargs):
         return filter_primitive_bind(
             noinline_p,

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -218,3 +218,11 @@ def test_flatten_with_keys():
     assert isinstance(path1, jtu.GetAttrKey) and path1.name == "foo"
     assert isinstance(path2a, jtu.GetAttrKey) and path2a.name == "qux"
     assert isinstance(path2b, jtu.SequenceKey) and path2b.idx == 0
+
+
+def test_wrapped(getkey):
+    # https://github.com/patrick-kidger/equinox/issues/377
+    x = eqx.filter_vmap(eqx.nn.Linear(2, 2, key=getkey()))
+    y = eqx.filter_vmap(eqx.nn.Linear(2, 2, key=getkey()))
+    x, y = eqx.filter((x, y), eqx.is_array)
+    jtu.tree_map(lambda x, y: x + y, x, y)


### PR DESCRIPTION
Otherwise this places a dynamic node in the static metadata, which wreaks all kind of havoc.

Fixes #377.