### PR TITLE
Added an optional dtype argument to BatchNorm.

### DIFF
--- a/equinox/nn/_batch_norm.py
+++ b/equinox/nn/_batch_norm.py
@@ -3,7 +3,7 @@ from typing import Hashable, Optional, Sequence, Tuple, Union
 import jax
 import jax.lax as lax
 import jax.numpy as jnp
-from jaxtyping import Array, Bool, Float
+from jaxtyping import Array, Bool, Float, Num
 
 from .._module import Module, static_field
 from ._stateful import State, StateIndex
@@ -60,7 +60,7 @@ class BatchNorm(Module):
         channelwise_affine: bool = True,
         momentum: float = 0.99,
         inference: bool = False,
-        dtype: jnp.dtype = jnp.float64,
+        dtype: Num = jnp.float64,
         **kwargs,
     ):
         """**Arguments:**
@@ -79,6 +79,7 @@ class BatchNorm(Module):
             statistics are directly used for normalisation. This may be toggled with
             [`equinox.tree_inference`][] or overridden during
             [`equinox.nn.BatchNorm.__call__`][].
+        - `dtype`: The dtype of the input array.
         """
 
         super().__init__(**kwargs)
@@ -90,7 +91,10 @@ class BatchNorm(Module):
             self.weight = None
             self.bias = None
         self.first_time_index = StateIndex(lambda **_: jnp.array(True))
-        make_buffers = lambda **_: (jnp.empty((input_size,), dtype=dtype), jnp.empty((input_size,), dtype=dtype))
+        make_buffers = lambda **_: (
+            jnp.empty((input_size,), dtype=dtype),
+            jnp.empty((input_size,), dtype=dtype),
+        )
         self.state_index = StateIndex(make_buffers)
         self.inference = inference
         self.axis_name = axis_name

--- a/equinox/nn/_batch_norm.py
+++ b/equinox/nn/_batch_norm.py
@@ -60,7 +60,7 @@ class BatchNorm(Module):
         channelwise_affine: bool = True,
         momentum: float = 0.99,
         inference: bool = False,
-        dtype: jnp.dtype = jnp.float32,
+        dtype: jnp.dtype = jnp.float64,
         **kwargs,
     ):
         """**Arguments:**

--- a/equinox/nn/_batch_norm.py
+++ b/equinox/nn/_batch_norm.py
@@ -144,7 +144,7 @@ class BatchNorm(Module):
             def _stats(y):
                 mean = jnp.mean(y)
                 mean = lax.pmean(mean, self.axis_name)
-                var = jnp.mean((y - mean) ** 2)
+                var = jnp.mean(abs(y - mean) ** 2)
                 var = lax.pmean(var, self.axis_name)
                 var = jnp.maximum(0.0, var)
                 return mean, var

--- a/equinox/nn/_batch_norm.py
+++ b/equinox/nn/_batch_norm.py
@@ -60,6 +60,7 @@ class BatchNorm(Module):
         channelwise_affine: bool = True,
         momentum: float = 0.99,
         inference: bool = False,
+        dtype: jnp.dtype = jnp.float32,
         **kwargs,
     ):
         """**Arguments:**
@@ -89,7 +90,7 @@ class BatchNorm(Module):
             self.weight = None
             self.bias = None
         self.first_time_index = StateIndex(lambda **_: jnp.array(True))
-        make_buffers = lambda **_: (jnp.empty((input_size,)), jnp.empty((input_size,)))
+        make_buffers = lambda **_: (jnp.empty((input_size,), dtype=dtype), jnp.empty((input_size,), dtype=dtype))
         self.state_index = StateIndex(make_buffers)
         self.inference = inference
         self.axis_name = axis_name

--- a/equinox/nn/_batch_norm.py
+++ b/equinox/nn/_batch_norm.py
@@ -60,7 +60,7 @@ class BatchNorm(Module):
         channelwise_affine: bool = True,
         momentum: float = 0.99,
         inference: bool = False,
-        dtype: Num = jnp.float64,
+        dtype: Num = jnp.float32,
         **kwargs,
     ):
         """**Arguments:**


### PR DESCRIPTION
Was encountering the error "Old and new values have different structures." when using BatchNorm with complex valued inputs. Added the ability to specify the dtype of the buffers passed to StateIndex. 

I am slightly unsure on the typing to use for dtype (as using jnp.dtype raises a style error during pyright's pre-commit hook). I have currently opted for Num from jaxtyping. 