### PR TITLE
Added support for converting a field

### DIFF
--- a/docs/api/advanced_fields.md
+++ b/docs/api/advanced_fields.md
@@ -1,0 +1,19 @@
+# Advanced features
+
+## Converters and static fields
+
+Equinox modules are [dataclasses](https://docs.python.org/3/library/dataclasses.html). Equinox extends this support with converters and static fields.
+
+::: equinox.field
+
+## Abstract attributes
+
+Equinox modules can be used as [abstract base classes](https://docs.python.org/3/library/abc.html), which means they support [`abc.abstractmethod`](https://docs.python.org/3/library/abc.html#abc.abstractmethod). Equinox extends this with support for abstract instance attributes and abstract class attributes.
+
+::: equinox.AbstractVar
+    selection:
+        members: false
+
+::: equinox.AbstractClassVar
+    selection:
+        members: false

--- a/docs/api/utilities/miscellaneous.md
+++ b/docs/api/utilities/miscellaneous.md
@@ -8,8 +8,4 @@
 
 ---
 
-::: equinox.static_field
-
----
-
 ::: equinox.module_update_wrapper

--- a/equinox/__init__.py
+++ b/equinox/__init__.py
@@ -10,6 +10,10 @@ from ._ad import (
     filter_value_and_grad as filter_value_and_grad,
     filter_vjp as filter_vjp,
 )
+from ._better_abstract import (
+    AbstractClassVar as AbstractClassVar,
+    AbstractVar as AbstractVar,
+)
 from ._callback import filter_pure_callback as filter_pure_callback
 from ._eval_shape import filter_eval_shape as filter_eval_shape
 from ._filters import (
@@ -24,6 +28,7 @@ from ._filters import (
 from ._jit import filter_jit as filter_jit
 from ._make_jaxpr import filter_make_jaxpr as filter_make_jaxpr
 from ._module import (
+    field as field,
     Module as Module,
     module_update_wrapper as module_update_wrapper,
     Partial as Partial,

--- a/equinox/nn/_composed.py
+++ b/equinox/nn/_composed.py
@@ -1,4 +1,3 @@
-import typing
 from collections.abc import Callable, Sequence
 from typing import (
     Any,
@@ -13,21 +12,13 @@ import jax.nn as jnn
 import jax.random as jrandom
 from jaxtyping import Array, PRNGKeyArray
 
+from .._doc_utils import doc_repr
 from .._module import Module, static_field
 from ._linear import Linear
 
 
-def _identity(x):
-    return x
-
-
-if getattr(typing, "GENERATING_DOCUMENTATION", False):
-
-    def relu(_):
-        pass
-
-    jnn.relu = relu
-    _identity.__qualname__ = "identity"  # Renamed for nicer documentation.
+_identity = doc_repr(lambda x: x, "lambda x: x")
+_relu = doc_repr(jnn.relu, "<function relu>")
 
 
 class MLP(Module):
@@ -54,7 +45,7 @@ class MLP(Module):
         out_size: Union[int, Literal["scalar"]],
         width_size: int,
         depth: int,
-        activation: Callable = jnn.relu,
+        activation: Callable = _relu,
         final_activation: Callable = _identity,
         use_bias: bool = True,
         use_final_bias: bool = True,

--- a/examples/bert.ipynb
+++ b/examples/bert.ipynb
@@ -222,7 +222,7 @@
     "    attention: eqx.nn.MultiheadAttention\n",
     "    layernorm: eqx.nn.Embedding\n",
     "    dropout: eqx.nn.Dropout\n",
-    "    num_heads: int = eqx.static_field()\n",
+    "    num_heads: int = eqx.field(static=True)\n",
     "\n",
     "    def __init__(\n",
     "        self,\n",

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -111,7 +111,9 @@ nav:
             - Autoparallelism (e.g. multi-GPU): 'examples/parallelism.ipynb'
             - Serialisation (with hyperparameters): 'examples/serialisation.ipynb'
     - Full API:
-        - 'api/module.md'
+        - Modules:
+            - 'api/module.md'
+            - 'api/advanced_fields.md'
         - Neural network layers:
             - 'api/nn/linear.md'
             - 'api/nn/conv.md'


### PR DESCRIPTION
This adds `eqx.field(converter=...)`, for calling a function on a field at the end of `__init__`.

For consistency `eqx.static_field`, is now deprecated in favour of `eqx.field(static=True)`. (But `static_field` will continue to exist for backward compatibility.)

`equinox.{AbstractVar, AbstractClassVar}` are also added to the public API.