### PR TITLE
better custom autodiff

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ _In other words, why should you care? Because Equinox is really simple to learn,
 pip install equinox
 ```
 
-Requires Python 3.9+ and JAX 0.4.11+.
+Requires Python 3.9+ and JAX 0.4.13+.
 
 ## Documentation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,7 +19,7 @@ _In other words, why should you care? Because Equinox is really simple to learn,
 pip install equinox
 ```
 
-Requires Python 3.9+ and JAX 0.4.11+.
+Requires Python 3.9+ and JAX 0.4.13+.
 
 ## Quick example
 

--- a/equinox/internal/__init__.py
+++ b/equinox/internal/__init__.py
@@ -39,7 +39,11 @@ from ._finalise_jaxpr import (
     primitive_finalisations as primitive_finalisations,
     register_impl_finalisation as register_impl_finalisation,
 )
-from ._loop import scan as scan, while_loop as while_loop
+from ._loop import (
+    scan as scan,
+    select_if_vmap_p as select_if_vmap_p,
+    while_loop as while_loop,
+)
 from ._misc import (
     ContainerMeta as ContainerMeta,
     eval_empty as eval_empty,

--- a/equinox/internal/__init__.py
+++ b/equinox/internal/__init__.py
@@ -40,6 +40,7 @@ from ._finalise_jaxpr import (
     register_impl_finalisation as register_impl_finalisation,
 )
 from ._loop import (
+    maybe_set_p as maybe_set_p,
     scan as scan,
     select_if_vmap_p as select_if_vmap_p,
     while_loop as while_loop,

--- a/equinox/internal/_debug.py
+++ b/equinox/internal/_debug.py
@@ -124,7 +124,9 @@ def _debug_backward_nan(x, name, terminate):
     return x
 
 
-def _debug_backward_nan_fwd(x, name, terminate):
+@_debug_backward_nan.def_fwd
+def _debug_backward_nan_fwd(perturbed, x, name, terminate):
+    del perturbed
     return debug_backward_nan(x, name, terminate), None
 
 
@@ -135,7 +137,9 @@ class _LongRepr(Module):
         return tree_pformat(self.obj, short_arrays=False)
 
 
-def _debug_backward_nan_bwd(_, grad_x, x, name, terminate):
+@_debug_backward_nan.def_bwd
+def _debug_backward_nan_bwd(residuals, grad_x, perturbed, x, name, terminate):
+    del residuals, perturbed
     msg = "   primals={x}\ncotangents={grad_x}"
     if name is not None:
         msg = f"{name}:\n" + msg
@@ -148,6 +152,3 @@ def _debug_backward_nan_bwd(_, grad_x, x, name, terminate):
         ]
         grad_x = error_if(grad_x, jnp.any(jnp.stack(nans)), "Encountered NaN")
     return grad_x
-
-
-_debug_backward_nan.defvjp(_debug_backward_nan_fwd, _debug_backward_nan_bwd)

--- a/equinox/internal/_finalise_jaxpr.py
+++ b/equinox/internal/_finalise_jaxpr.py
@@ -183,7 +183,7 @@ def finalise_make_jaxpr(fn, *, return_shape: bool = False):
 from .._errors import branched_error_p
 from .._unvmap import unvmap_all_p, unvmap_any_p, unvmap_max_p
 from ._debug import announce_jaxpr_p
-from ._loop.common import select_if_vmap_p
+from ._loop import maybe_set_p, select_if_vmap_p
 from ._noinline import noinline_p
 from ._nontraceable import nonbatchable_p, nondifferentiable_backward_p, nontraceable_p
 
@@ -195,6 +195,7 @@ for prim in (
     nondifferentiable_backward_p,
     announce_jaxpr_p,
     select_if_vmap_p,
+    maybe_set_p,
     noinline_p,
     nontraceable_p,
     nonbatchable_p,

--- a/equinox/internal/_finalise_jaxpr.py
+++ b/equinox/internal/_finalise_jaxpr.py
@@ -183,6 +183,7 @@ def finalise_make_jaxpr(fn, *, return_shape: bool = False):
 from .._errors import branched_error_p
 from .._unvmap import unvmap_all_p, unvmap_any_p, unvmap_max_p
 from ._debug import announce_jaxpr_p
+from ._loop.common import select_if_vmap_p
 from ._noinline import noinline_p
 from ._nontraceable import nonbatchable_p, nondifferentiable_backward_p, nontraceable_p
 
@@ -193,6 +194,7 @@ for prim in (
     unvmap_max_p,
     nondifferentiable_backward_p,
     announce_jaxpr_p,
+    select_if_vmap_p,
     noinline_p,
     nontraceable_p,
     nonbatchable_p,

--- a/equinox/internal/_loop/__init__.py
+++ b/equinox/internal/_loop/__init__.py
@@ -1,1 +1,2 @@
+from .common import select_if_vmap_p as select_if_vmap_p
 from .loop import scan as scan, while_loop as while_loop

--- a/equinox/internal/_loop/__init__.py
+++ b/equinox/internal/_loop/__init__.py
@@ -1,2 +1,2 @@
-from .common import select_if_vmap_p as select_if_vmap_p
+from .common import maybe_set_p as maybe_set_p, select_if_vmap_p as select_if_vmap_p
 from .loop import scan as scan, while_loop as while_loop

--- a/equinox/internal/_loop/bounded.py
+++ b/equinox/internal/_loop/bounded.py
@@ -4,11 +4,10 @@ from typing import Any, Optional, TypeVar, Union
 
 import jax
 import jax.lax as lax
-import jax.numpy as jnp
 import jax.tree_util as jtu
 from jaxtyping import Array, Bool
 
-from .common import common_rewrite
+from .common import common_rewrite, fixed_asarray
 
 
 _T = TypeVar("_T")
@@ -49,7 +48,7 @@ def bounded_while_loop(
 
     if not isinstance(max_steps, int) or max_steps < 0:
         raise ValueError("max_steps must be a non-negative integer")
-    init_val = jtu.tree_map(jnp.asarray, init_val)
+    init_val = jtu.tree_map(fixed_asarray, init_val)
     if max_steps == 0:
         return init_val
 

--- a/equinox/internal/_loop/common.py
+++ b/equinox/internal/_loop/common.py
@@ -14,29 +14,11 @@ from ..._filters import is_array
 from ..._module import field, Module
 from ..._tree import tree_at, tree_equal
 from ..._unvmap import unvmap_any
+from .._primitive import create_vprim
 
 
 def _select_if_vmap_impl(pred, x, y):
     return x
-
-
-def _select_if_vmap_batch(axis_size, axis_name, trace, inputs, batch_axes):
-    del axis_name, trace
-    pred, x, y = inputs
-    bp, bx, by = batch_axes
-    if bp is batching.not_mapped:
-        if bx is batching.not_mapped:
-            x = jnp.broadcast_to(x, (axis_size,) + x.shape)
-        else:
-            x = jnp.moveaxis(x, bx, 0)
-        if by is batching.not_mapped:
-            y = jnp.broadcast_to(y, (axis_size,) + y.shape)
-        else:
-            y = jnp.moveaxis(y, by, 0)
-        out = _select_if_vmap(pred, x, y)
-    else:
-        out = jax.vmap(lax.select, in_axes=(bp, bx, by))(pred, x, y)
-    return out, 0
 
 
 def _select_if_vmap_jvp(primals, tangents):
@@ -65,34 +47,38 @@ def _select_if_vmap_transpose(ct, pred, x, y):
     assert ct.shape == y.aval.shape
     assert ct.dtype == y.aval.dtype
     if type(ct) is ad.Zero:
-        out = [None]
-        if ad.is_undefined_primal(x):
-            out.append(ct)  # pyright: ignore
-        else:
-            out.append(None)
-        if ad.is_undefined_primal(y):
-            out.append(ct)  # pyright: ignore
-        else:
-            out.append(None)
-        return out
+        ct_x = None
+        ct_y = None
     else:
         zero = jnp.zeros(ct.shape, ct.dtype)
-        ct_x = _select_if_vmap(pred, ct, zero)
-        ct_y = _select_if_vmap(pred, zero, ct)
-        return [None, ct_x, ct_y]
+        if ad.is_undefined_primal(x):
+            ct_x = _select_if_vmap(pred, ct, zero)
+        else:
+            ct_x = None
+        if ad.is_undefined_primal(y):
+            ct_y = _select_if_vmap(pred, zero, ct)
+        else:
+            ct_y = None
+    return [None, ct_x, ct_y]
 
 
-# We want to insert `lax.select`s to avoid updating any batch elements in the loop that
-# have a False predicate. (But the loop is still going whilst other batch elements have
-# a True predicate). However, if we have no vmap at all, then we can be slightly more
-# efficient: don't introduce a select at all.
-def _select_if_vmap(pred, x, y):
-    pred = fixed_asarray(pred)
-    x = fixed_asarray(x)
-    y = fixed_asarray(y)
-    assert x.shape == y.shape
-    assert x.dtype == y.dtype
-    return select_if_vmap_p.bind(pred, x, y)
+def _select_if_vmap_batch(axis_size, axis_name, trace, inputs, batch_axes):
+    del axis_name, trace
+    pred, x, y = inputs
+    bp, bx, by = batch_axes
+    if bp is batching.not_mapped:
+        if bx is batching.not_mapped:
+            x = jnp.broadcast_to(x, (axis_size,) + x.shape)
+        else:
+            x = jnp.moveaxis(x, bx, 0)
+        if by is batching.not_mapped:
+            y = jnp.broadcast_to(y, (axis_size,) + y.shape)
+        else:
+            y = jnp.moveaxis(y, by, 0)
+        out = _select_if_vmap(pred, x, y)
+    else:
+        out = jax.vmap(lax.select, in_axes=(bp, bx, by))(pred, x, y)
+    return out, 0
 
 
 select_if_vmap_p = jax.core.Primitive("select_if_vmap")
@@ -106,6 +92,107 @@ mlir.register_lowering(
 )
 
 
+# We want to insert `lax.select`s to avoid updating any batch elements in the loop that
+# have a False predicate. (But the loop is still going whilst other batch elements have
+# a True predicate). However, if we have no vmap at all, then we can be slightly more
+# efficient: don't introduce a select at all.
+def _select_if_vmap(pred, x, y):
+    """As `lax.select(pred, x, y)` if `pred` is vmap'd. Unvmap'd `pred` are assumed to
+    be `True`, so that in this case `x` is returned unconditionally.
+    """
+    pred = fixed_asarray(pred)
+    assert pred.shape == ()
+    assert pred.dtype == jnp.bool_
+    x = fixed_asarray(x)
+    y = fixed_asarray(y)
+    assert x.shape == y.shape
+    assert x.dtype == y.dtype
+    return select_if_vmap_p.bind(pred, x, y)
+
+
+def _maybe_set_impl(pred, xs, i, x, *, kwargs):
+    x = _select_if_vmap(pred, x, xs.at[i].get(**kwargs))
+    return [xs.at[i].set(x, **kwargs)]
+
+
+def _maybe_set_abstract(pred, xs, i, x, *, kwargs):
+    return [xs]
+
+
+def _maybe_set_jvp(primals, tangents, *, kwargs):
+    pred, xs, i, x = primals
+    _, t_xs, _, t_x = tangents
+    out = _maybe_set(pred, xs, i, x, kwargs)
+    if type(t_x) is ad.Zero and type(t_xs) is ad.Zero:
+        t_out = t_xs
+    else:
+        if type(t_x) is ad.Zero:
+            t_x = jnp.zeros(t_x.aval.shape, t_x.aval.dtype)  # pyright: ignore
+        if type(t_xs) is ad.Zero:
+            t_xs = jnp.zeros(t_xs.aval.shape, t_xs.aval.dtype)  # pyright: ignore
+        t_out = _maybe_set(pred, t_xs, i, t_x, kwargs)
+    return [out], [t_out]
+
+
+def _maybe_set_transpose(ct_out, pred, xs, i, x, *, kwargs):
+    assert not ad.is_undefined_primal(pred)
+    assert not ad.is_undefined_primal(i)
+    [ct_out] = ct_out
+    if ad.is_undefined_primal(xs):
+        # Not updating a zero! `_Buffer`s are write-once to each location, so when
+        # transposed they are read-once from each location, meaning if we read from `i`
+        # now then we will never do so again, so we can skip placing a zero there.
+        #
+        # Besides just being a nice efficiency gain: this is actually important for
+        # working around b/288798733, in which having extra dynamic_update_slices causes
+        # operations to happen out-of-place.
+        ct_xs = ct_out
+    else:
+        ct_xs = None
+    if ad.is_undefined_primal(x):
+        if type(ct_out) is ad.Zero:
+            ct_x = None
+        else:
+            ct_x = ct_out.at[i].get(**kwargs)
+            ct_x = _select_if_vmap(pred, ct_x, jnp.zeros_like(ct_x))
+    else:
+        ct_x = None
+    return [None, ct_xs, None, ct_x]
+
+
+maybe_set_p = create_vprim(
+    "maybe_set",
+    _maybe_set_impl,
+    _maybe_set_abstract,
+    _maybe_set_jvp,
+    _maybe_set_transpose,
+)
+
+
+# This is a carefully optimised routine, that relies on the special behaviour exhibited
+# by `_Buffer`.
+# The main one is fact that `_Buffer`s are write-once to each location, so they
+# are read-once to each location when transposed. This means we can skip placing zeros
+# in the cotangent of `xs`. This reduces the number of in-place updates on the backward
+# pass from 2 to 0. This ends up being really important for efficiency, due to
+# b/288798733.
+# Second, the fact that unbatched `pred` are necessarily always True (due to being
+# used inside a while loop) means that we use `_select_if_vmap` over simply
+# `lax.select`.
+def _maybe_set(pred, xs, i, x, kwargs):
+    """As `lax.select(pred, xs.at[i].set(x, **kwargs), xs)`, under the assumption that
+    `xs.at[i]` is written to at most once, so that we can have a more efficient
+    transpose rule. Also assumes unvmap'd `pred` is unconditionally `True`.
+    """
+    assert pred.shape == ()
+    assert pred.dtype == jnp.bool_
+    dtype = jnp.result_type(xs, x)
+    xs = xs.astype(dtype)
+    x = fixed_asarray(x).astype(dtype)
+    [out] = maybe_set_p.bind(pred, xs, i, x, kwargs=kwargs)
+    return out
+
+
 class _Buffer(Module):
     _array: Union[Shaped[Array, "..."], "_Buffer"]
     _pred: Bool[Array, ""]
@@ -114,16 +201,12 @@ class _Buffer(Module):
     def __getitem__(self, item):
         return self._array[item]
 
-    def _op(self, pred, item, x, op):
+    def _op(self, pred, item, x, op, kwargs):
         pred = pred & self._pred
         if isinstance(self._array, _Buffer):
-            array = self._array._op(pred, item, x, op)
+            array = self._array._op(pred, item, x, op, kwargs)
         else:
-            old_x = self._array[item]
-            dtype = jnp.result_type(x, old_x)
-            x = jnp.broadcast_to(x, old_x.shape).astype(dtype)
-            x = _select_if_vmap(pred, x, old_x)
-            array = getattr(self._array.at[item], op)(x)
+            array = op(pred, self._array, item, x, kwargs)
         return _Buffer(array, self._pred, self._tag)
 
     @property
@@ -154,20 +237,8 @@ class _BufferItem(Module):
     _buffer: _Buffer
     _item: Any
 
-    def set(self, x, *, pred=True):
-        return self._buffer._op(pred, self._item, x, "set")
-
-    def add(self, x, *, pred=True):
-        return self._buffer._op(pred, self._item, x, "add")
-
-    def multiply(self, x, *, pred=True):
-        return self._buffer._op(pred, self._item, x, "multiply")
-
-    def divide(self, x, *, pred=True):
-        return self._buffer._op(pred, self._item, x, "divide")
-
-    def power(self, x, *, pred=True):
-        return self._buffer._op(pred, self._item, x, "power")
+    def set(self, x, *, pred=True, **kwargs):
+        return self._buffer._op(pred, self._item, x, _maybe_set, kwargs)
 
 
 def _is_buffer(x):

--- a/equinox/internal/_loop/loop.py
+++ b/equinox/internal/_loop/loop.py
@@ -76,9 +76,15 @@ def while_loop(
 
         Note that `buffers` is subject to the following restrictions:
 
-        - You should never write to the same location twice.
+        - You should never write to the same location twice. (Even before it is passed
+            into the loop: e.g.
+            ```python
+            xs = xs.at[0].set(x).at[0].set(y)
+            while_loop(cond, body, xs, buffers=lambda xs: xs)
+            ```
+            is not allowed.)
         - You should only read from it (`buf[i]`) at locations (`i`) that you have
-          written to previously.
+          written to previously (`buf.at[i].set(...)`).
 
         These assumptions are *completely unchecked* and you will get incorrect
         gradients if you violate these assumptions.
@@ -158,6 +164,11 @@ def scan(
     - `checkpoints`: Only used if `kind="checkpointed"`. Specifies the number of
         checkpoints to use; if `None` then this is set proportional to `sqrt(length)`.
         Can also be a string `"all"`, representing checkpointing every step.
+
+    !!! Danger
+
+        Note that `buffers` is subject to the same restrictions as
+        `equinox.internal.while_loop`.
 
     Returns:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "equinox"
-version = "0.10.6"
+version = "0.10.7"
 description = "Elegant easy-to-use neural networks in JAX."
 readme = "README.md"
 requires-python ="~=3.9"
@@ -23,7 +23,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Mathematics",
 ]
 urls = {repository = "https://github.com/patrick-kidger/equinox" }
-dependencies = ["jax>=0.4.11", "jaxtyping>=0.2.20", "typing_extensions>=4.5.0"]
+dependencies = ["jax>=0.4.13", "jaxtyping>=0.2.20", "typing_extensions>=4.5.0"]
 
 [build-system]
 requires = ["hatchling"]

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -11,13 +11,15 @@ def test_backward_nan(capfd):
     def backward_nan(x):
         return x
 
-    def backward_nan_fwd(x):
+    @backward_nan.def_fwd
+    def backward_nan_fwd(perturbed, x):
+        del perturbed
         return backward_nan(x), None
 
-    def backward_nan_bwd(_, x, grad_x):
+    @backward_nan.def_bwd
+    def backward_nan_bwd(residual, grad_x, perturbed, x):
+        del residual, grad_x, perturbed, x
         return jnp.nan
-
-    backward_nan.defvjp(backward_nan_fwd, backward_nan_bwd)
 
     @eqx.filter_jit
     @jax.grad

--- a/tests/test_while_loop.py
+++ b/tests/test_while_loop.py
@@ -198,7 +198,7 @@ def test_backward_checkpointed(
     )
     assert shaped_allclose(value, true_value, rtol=1e-4, atol=1e-4)
     assert shaped_allclose(grad, true_grad, rtol=1e-4, atol=1e-4)
-    assert text.strip() == true_text
+    assert true_text in text.strip()
 
 
 @pytest.mark.parametrize("buffer", (False, True))


### PR DESCRIPTION
- Now using symbolic zeros in `filter_custom_{jvp,vjp}`. This also brings with it an API tweak for backward compatibility. (E.g. `filter_custom_jvp.defjvp -> filter_custom_jvp.def_jvp` for the new behaviour.)
- Removed unnecessary `lax.select` in `eqxi.while_loop` when not vmap'ing. This should improve speed slightly when not vmap'ing.
- Improved speed of backprop through `eqxi.while_loop` buffers, in particular avoiding https://github.com/google/jax/issues/10197. In particular this can be used to reduce some programs with quadratic runtime down to just linear runtime. 
