### PR TITLE
Apply functools.wraps to Module methods to preserve docstrings

### DIFF
--- a/equinox/_module.py
+++ b/equinox/_module.py
@@ -101,7 +101,9 @@ class _wrap_method:
     def __get__(self, instance, owner):
         if instance is None:
             return self.method
-        return jtu.Partial(self.method, instance)
+        _method = ft.wraps(self.method)(jtu.Partial(self.method, instance))
+        delattr(_method, "__wrapped__")
+        return _method
 
 
 def _not_magic(k: str) -> bool:


### PR DESCRIPTION
Methods of `equinox.Module` lose their `__doc__`, `__name__`, `__module__`, etc.

The methods all get wrapped with`jax.treel_util.Partial`, which doesn't use `functools.wraps` likely due to the signature change making the docstring usually inapplicable.  In this case we're just doing instance-binding so these attributes remain relevant.  Simply wrapping `Partial` does not work alone as it sets the `__wrapped__` attribute, which causes inspection of the signature to think a `self` argument is still expected.