### PR TITLE
error_if now has a breakpoint option

### DIFF
--- a/equinox/_errors.py
+++ b/equinox/_errors.py
@@ -1,18 +1,22 @@
+import os
+import warnings
 from collections.abc import Sequence
-from typing import cast
+from typing import cast, Literal
 
 import jax
+import jax._src.traceback_util as traceback_util
 import jax.core
-import jax.interpreters.ad as ad
-import jax.interpreters.batching as batching
-import jax.interpreters.mlir as mlir
 import jax.lax as lax
 import jax.tree_util as jtu
 import numpy as np
 from jaxtyping import Array, ArrayLike, Bool, Int, PyTree
 
-from ._filters import combine, is_array_like, partition
+from ._ad import filter_custom_jvp
+from ._filters import combine, is_array, partition
 from ._unvmap import unvmap_any, unvmap_max
+
+
+traceback_util.register_exclusion(__file__)
 
 
 def _nan_like(x: np.ndarray) -> np.ndarray:
@@ -40,67 +44,64 @@ You will need to manually kill this job and/or restart the runtime.
 """
 
 
-def _error_impl(pred, index, *x, msgs):
-    def raises(_index):
-        raise RuntimeError(msgs[_index.item()])
+@filter_custom_jvp
+def _error(x, pred, index, *, msgs, on_error):
+    if on_error == "raise":
 
-    def tpu_msg(_out, _index):
-        msg = msgs[_index.item()]
-        # `print` doesn't work; nor does `jax.debug.print`.
-        # But both `input` and `jax.debug.breakpoint` do. The former allows us to
-        # actually display something to the user.
-        input(msg + _tpu_msg)
-        # We do the tree_map inside the pure_callback, not outside, so that `out` has a
-        # data dependency and doesn't get optimised out.
-        return jtu.tree_map(_nan_like, _out)
+        def raises(_index):
+            raise RuntimeError(msgs[_index.item()])
 
-    def callback():
-        out = jax.pure_callback(raises, struct, index)  # pyright: ignore
-        # If we make it this far then we're on the TPU, which squelches runtime errors
-        # and returns dummy values instead.
-        # Fortunately, we're able to outsmart it!
-        return jax.pure_callback(tpu_msg, struct, out, index)  # pyright: ignore
+        def tpu_msg(_out, _index):
+            msg = msgs[_index.item()]
+            # `print` doesn't work; nor does `jax.debug.print`.
+            # But both `input` and `jax.debug.breakpoint` do. The former allows us to
+            # actually display something to the user.
+            input(msg + _tpu_msg)
+            # We do the tree_map inside the pure_callback, not outside, so that `out`
+            # has a data dependency and doesn't get optimised out.
+            return jtu.tree_map(_nan_like, _out)
 
-    struct = jax.eval_shape(lambda: x)
-    return lax.cond(pred, callback, lambda: x)
+        def handle_error():  # pyright: ignore
+            out = jax.pure_callback(raises, struct, index)  # pyright: ignore
+            # If we make it this far then we're on the TPU, which squelches runtime
+            # errors and returns dummy values instead.
+            # Fortunately, we're able to outsmart it!
+            return jax.pure_callback(tpu_msg, struct, out, index)  # pyright: ignore
 
+        struct = jax.eval_shape(lambda: x)
+        return lax.cond(pred, handle_error, lambda: x)
 
-def _error_abstract(pred, index, *x, msgs):
-    return x
+    elif on_error == "breakpoint":
+        # TODO: find a way to have this be DCE'd if `x` is.
 
+        def display_msg(x, _index):
+            print(msgs[_index.item()])
+            return x
 
-def _error_jvp(primals, tangents, *, msgs):
-    _, _, *tx = tangents
-    return branched_error_p.bind(*primals, msgs=msgs), tx
+        def handle_error(x):
+            x = jax.pure_callback(display_msg, x, index)  # pyright: ignore
+            return jax.debug.breakpoint(token=x)
 
-
-def _error_transpose(cts, pred, index, *x, msgs):
-    return [None, None] + cts
-
-
-def _error_batching(inputs, batch_axes, *, msgs):
-    pred_bdim, index_bdim, *xs_bdim = batch_axes
-    assert pred_bdim is batching.not_mapped
-    assert index_bdim is batching.not_mapped
-    return branched_error_p.bind(*inputs, msgs=msgs), tuple(xs_bdim)
+        return lax.cond(pred, handle_error, lambda y: y, x)
+    else:
+        assert False
 
 
-branched_error_p = jax.core.Primitive("branched_error")
-branched_error_p.multiple_results = True
-branched_error_p.def_impl(_error_impl)
-branched_error_p.def_abstract_eval(_error_abstract)
-ad.primitive_jvps[branched_error_p] = _error_jvp
-ad.primitive_transposes[branched_error_p] = _error_transpose
-batching.primitive_batchers[branched_error_p] = _error_batching
-mlir.register_lowering(
-    branched_error_p, mlir.lower_fun(_error_impl, multiple_results=True)
-)
+# Use a custom_jvp to put the lax.cond outside of AD.
+# This is needed as lax.cond will unnecessarily promote symbolic
+# zeros to non-symbolic-zeros, and we'd really like to avoid that.
+@_error.def_jvp
+def _error_jvp(primals, tangents, *, msgs, on_error):
+    x, pred, index = primals
+    tx, _, _ = tangents
+    return _error(x, pred, index, msgs=msgs, on_error=on_error), tx
 
 
 def error_if(
     x: PyTree,
     pred: Bool[ArrayLike, "..."],
     msg: str,
+    on_error: Literal["default", "raise", "breakpoint"] = "default",
 ) -> PyTree:
     """Throws an error based on runtime values. Works even under JIT.
 
@@ -112,6 +113,9 @@ def error_if(
         error will be raised if any of them are `True`. If vmap'd then an error will be
         raised if any batch element has `True`.
     - `msg`: the string to display as an error message.
+    - `on_error`: how to raise the error. Valid values are either `"default"`,
+        `"raise"`, or `"breakpoint"`. The default value of `"default"` defers to the
+        `EQX_ON_ERROR` environment variable, which itself defaults to `"raise"`.
 
     **Returns:**
 
@@ -130,7 +134,7 @@ def error_if(
         f(jax.numpy.array(-1))
         ```
     """
-    return branched_error_if(x, pred, 0, [msg])
+    return branched_error_if(x, pred, 0, [msg], on_error)
 
 
 def branched_error_if(
@@ -138,11 +142,19 @@ def branched_error_if(
     pred: Bool[ArrayLike, "..."],
     index: Int[ArrayLike, "..."],
     msgs: Sequence[str],
+    on_error: Literal["default", "raise", "breakpoint"] = "default",
 ) -> PyTree:
     """As [`equinox.internal.error_if`][], but will raise one of
     several `msgs` depending on the value of `index`.
     """
-
+    if on_error == "default":
+        on_error = os.environ.get("EQX_ON_ERROR", "raise")  # pyright: ignore
+        if on_error not in ("raise", "breakpoint"):
+            raise RuntimeError("Unrecognised value for `EQX_ON_ERROR`.")
+        on_error = cast(Literal["raise", "breakpoint"], on_error)
+    else:
+        if on_error not in ("raise", "breakpoint"):
+            raise RuntimeError("Unrecognised value for `on_error`.")
     with jax.ensure_compile_time_eval():
         pred = unvmap_any(pred)
         index = unvmap_max(index)
@@ -152,18 +164,24 @@ def branched_error_if(
                     if isinstance(index, Array):
                         index = index.item()
                     index = cast(int, index)
-                    raise RuntimeError(msgs[index])
+                    warnings.warn(
+                        "`Error can be resolved statically. Handling at trace-time "
+                        "rather than waiting until runtime."
+                    )
+                    if on_error == "raise":
+                        raise RuntimeError(msgs[index])
+                    elif on_error == "breakpoint":
+                        print(msgs[index])
+                        breakpoint()
+                    else:
+                        assert False
                 # else defer error to runtime, when the index is known.
             else:
                 return x
 
-    dynamic_x, static_x = partition(x, is_array_like)
-    flat, treedef = jtu.tree_flatten(dynamic_x)
+    dynamic_x, static_x = partition(x, is_array)
+    flat = jtu.tree_leaves(dynamic_x)
     if len(flat) == 0:
-        raise ValueError("No array-likes to thread error on to")
-    # Use a primitive to put the lax.cond inside the impl rule.
-    # This is needed as lax.cond will unnecessarily promote symbolic
-    # zeros to non-symbolic-zeros, and we'd really like to avoid that.
-    flat = branched_error_p.bind(pred, index, *flat, msgs=msgs)
-    dynamic_x = jtu.tree_unflatten(treedef, flat)
+        raise ValueError("No arrays to thread error on to.")
+    dynamic_x = _error(dynamic_x, pred, index, msgs=msgs, on_error=on_error)
     return combine(dynamic_x, static_x)

--- a/equinox/_eval_shape.py
+++ b/equinox/_eval_shape.py
@@ -3,10 +3,14 @@ from collections.abc import Callable
 from typing import Any, Union
 
 import jax
+import jax._src.traceback_util as traceback_util
 from jaxtyping import PyTree
 
 from ._filters import combine, is_array, partition
 from ._module import Static
+
+
+traceback_util.register_exclusion(__file__)
 
 
 def _filter(x):

--- a/equinox/_jit.py
+++ b/equinox/_jit.py
@@ -6,6 +6,7 @@ from typing import Any, overload, TypeVar
 from typing_extensions import ParamSpec
 
 import jax
+import jax._src.traceback_util as traceback_util
 from jaxtyping import PyTree
 
 from ._compile_utils import (
@@ -20,6 +21,9 @@ from ._deprecate import deprecated_0_10
 from ._doc_utils import doc_remove_args
 from ._filters import combine, is_array, partition
 from ._module import Module, module_update_wrapper, Partial, Static
+
+
+traceback_util.register_exclusion(__file__)
 
 
 _P = ParamSpec("_P")

--- a/equinox/_make_jaxpr.py
+++ b/equinox/_make_jaxpr.py
@@ -3,12 +3,16 @@ from typing import Any
 from typing_extensions import ParamSpec
 
 import jax
+import jax._src.traceback_util as traceback_util
 import jax.core
 import jax.tree_util as jtu
 from jaxtyping import PyTree
 
 from ._filters import combine, is_array, partition
 from ._module import Module, module_update_wrapper, Static
+
+
+traceback_util.register_exclusion(__file__)
 
 
 _P = ParamSpec("_P")

--- a/equinox/_vmap_pmap.py
+++ b/equinox/_vmap_pmap.py
@@ -6,6 +6,7 @@ from collections.abc import Callable, Hashable
 from typing import Any, Optional, overload, Union
 
 import jax
+import jax._src.traceback_util as traceback_util
 import jax.core
 import jax.interpreters.batching as batching
 import jax.interpreters.pxla as pxla
@@ -25,6 +26,9 @@ from ._deprecate import deprecated_0_10
 from ._doc_utils import doc_remove_args
 from ._filters import combine, filter, is_array, is_array_like, partition
 from ._module import Module, module_update_wrapper, Partial, Static
+
+
+traceback_util.register_exclusion(__file__)
 
 
 ResolvedAxisSpec = Optional[int]

--- a/equinox/internal/__init__.py
+++ b/equinox/internal/__init__.py
@@ -10,7 +10,6 @@ from .._doc_utils import doc_remove_args as doc_remove_args, doc_repr as doc_rep
 from .._enum import Enumeration as Enumeration
 from .._errors import (
     branched_error_if as branched_error_if,
-    branched_error_p as branched_error_p,
     error_if as error_if,
 )
 from .._misc import left_broadcast_to as left_broadcast_to

--- a/equinox/internal/_debug.py
+++ b/equinox/internal/_debug.py
@@ -158,10 +158,13 @@ def _debug_backward_nan_bwd(residuals, grad_x, perturbed, x, name, terminate):
     return grad_x
 
 
-def breakpoint_if(pred: Bool[Array, "..."]):
+def breakpoint_if(pred: Bool[Array, "..."], **kwargs):
     # We can't just write `jax.debug.breakpoint` for the second branch. For some reason
     # it needs as lambda wrapper.
-    lax.cond(unvmap_any(pred), lambda: jax.debug.breakpoint(), lambda: None)
+    token = kwargs.get("token", None)
+    return lax.cond(
+        unvmap_any(pred), lambda: jax.debug.breakpoint(**kwargs), lambda: token
+    )
 
 
 _dce_store = {}

--- a/equinox/internal/_finalise_jaxpr.py
+++ b/equinox/internal/_finalise_jaxpr.py
@@ -180,7 +180,6 @@ def finalise_make_jaxpr(fn, *, return_shape: bool = False):
 
 
 # Register finalisation rules for Equinox's custom primitives.
-from .._errors import branched_error_p
 from .._unvmap import unvmap_all_p, unvmap_any_p, unvmap_max_p
 from ._debug import announce_jaxpr_p
 from ._loop import maybe_set_p, select_if_vmap_p
@@ -201,15 +200,6 @@ for prim in (
     nonbatchable_p,
 ):
     register_impl_finalisation(prim)
-
-
-# Assume no errors are raised after finalisation. Can't use the impl rule as that
-# has a pure_callback.
-def _branched_error_if_finalisation(pred, index, *x, msgs):
-    return x
-
-
-primitive_finalisations[branched_error_p] = _branched_error_if_finalisation
 
 
 # To make this also useful as debugging tool, we also inline some calls.


### PR DESCRIPTION
In particular this is controlled through a new `EQX_ON_ERROR=<raise|breakpoint>` environment variable.

Note that `EQX_ON_ERROR=breakpoint` sometimes runs afoul of this bug in core JAX: https://github.com/google/jax/issues/16732. If so this can be worked around by deleting intermediate `jax.jit`/`eqx.filter_jit` decorators.