### PR TITLE
first draft for BN support in nn.Sequential

### DIFF
--- a/docs/api/nn/stateful.md
+++ b/docs/api/nn/stateful.md
@@ -15,3 +15,10 @@ See the [stateful example](../../examples/stateful.ipynb) for an example of work
     selection:
         members:
             - __init__
+
+---
+
+::: equinox.nn.StatefulLayer
+    selection:
+        members:
+            - __call__

--- a/equinox/nn/__init__.py
+++ b/equinox/nn/__init__.py
@@ -34,4 +34,8 @@ from ._pool import (
 )
 from ._rnn import GRUCell as GRUCell, LSTMCell as LSTMCell
 from ._spectral_norm import SpectralNorm as SpectralNorm
-from ._stateful import State as State, StateIndex as StateIndex
+from ._stateful import (
+    State as State,
+    StatefulLayer as StatefulLayer,
+    StateIndex as StateIndex,
+)

--- a/equinox/nn/_batch_norm.py
+++ b/equinox/nn/_batch_norm.py
@@ -6,11 +6,11 @@ import jax.lax as lax
 import jax.numpy as jnp
 from jaxtyping import Array, Bool, Float
 
-from .._module import field, Module
-from ._stateful import State, StateIndex
+from .._module import field
+from ._stateful import State, StatefulLayer, StateIndex
 
 
-class BatchNorm(Module):
+class BatchNorm(StatefulLayer):
     r"""Computes a mean and standard deviation over the batch and spatial
     dimensions of an array, and uses these to normalise the whole array. Optionally
     applies a channelwise affine transformation afterwards.

--- a/equinox/nn/_spectral_norm.py
+++ b/equinox/nn/_spectral_norm.py
@@ -6,9 +6,9 @@ import jax.numpy as jnp
 import jax.random as jr
 from jaxtyping import Array, Float, PRNGKeyArray
 
-from .._module import field, Module
+from .._module import field
 from .._tree import tree_at
-from ._stateful import State, StateIndex
+from ._stateful import State, StatefulLayer, StateIndex
 
 
 def _power_iteration(weight, u, v, eps):
@@ -26,7 +26,7 @@ def _power_iteration(weight, u, v, eps):
 _Layer = TypeVar("_Layer")
 
 
-class SpectralNorm(Module, Generic[_Layer]):
+class SpectralNorm(StatefulLayer, Generic[_Layer]):
     """Applies spectral normalisation to a given parameter.
 
     Given a weight matrix $W$, and letting $σ(W)$ denote (an approximation to) its

--- a/equinox/nn/_stateful.py
+++ b/equinox/nn/_stateful.py
@@ -1,11 +1,12 @@
+import abc
 import types
 from collections.abc import Callable
-from typing import Any, Generic, TypeVar
+from typing import Any, Generic, Optional, TypeVar
 
 import jax
 import jax.numpy as jnp
 import jax.tree_util as jtu
-from jaxtyping import PyTree
+from jaxtyping import Array, PRNGKeyArray, PyTree
 
 from .._module import Module
 from .._pretty_print import bracketed, named_objs, text, tree_pformat
@@ -145,3 +146,30 @@ class State:
             state[key] = value
         self._state = state
         return self
+
+
+class StatefulLayer(Module):
+    """An abstract base class representing a stateful layer within a neural network.
+
+    Stateful layers maintain internal state across calls, which can be useful for tasks
+    such as BatchNormalisation.
+
+    Subclasses must implement the `__call__` method that takes input data and the
+    current state as arguments and returns the output data and updated state.
+
+    !!! info
+
+        This declaration is currently intended for defining the
+        API for use with `nn.Sequential`.
+
+    """
+
+    @abc.abstractmethod
+    def __call__(
+        self,
+        x,
+        state: State,
+        *,
+        key: Optional[PRNGKeyArray],
+    ) -> tuple[Array, State]:
+        raise NotImplementedError("Subclasses must implement the __call__ method.")


### PR DESCRIPTION
Added the StatefulLayer as per discussion https://github.com/patrick-kidger/equinox/issues/448

One doubt I have is the `inference` parameter, it is not utilised by other norms. 
If BN needs to be easily interchangable with other norms, we might want to either remove `inference` parameter from BN and only rely on the self.inference flag or
add `inference` params to other normalisation layers as well. 

Also, do all Stateful layers utilise the `inference` flag? 