### PR TITLE
Assertions for eqx.nn.Embedding: Sizes must not be negative

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ examples/data
 .idea
 examples/MNIST
 examples/multipart_serialised.eqx
+.python-version

--- a/equinox/nn/_embedding.py
+++ b/equinox/nn/_embedding.py
@@ -24,8 +24,8 @@ class Embedding(Module):
     ):
         """**Arguments:**
 
-        - `num_embeddings`: Size of embedding dictionary.
-        - `embedding_size`: Size of each embedding vector.
+        - `num_embeddings`: Size of embedding dictionary. Must be non-negative.
+        - `embedding_size`: Size of each embedding vector. Must be non-negative.
         - `weight`: If given, the embedding lookup table. Will be generated randomly
             if not provided.
         - `key`: A `jax.random.PRNGKey` used to provide randomness for parameter

--- a/equinox/nn/_embedding.py
+++ b/equinox/nn/_embedding.py
@@ -33,6 +33,8 @@ class Embedding(Module):
         """
         super().__init__(**kwargs)
         if weight is None:
+            assert num_embeddings >= 0, "num_embeddings must not be negative."
+            assert embedding_size >= 0, "embedding_size must not be negative."
             self.weight = jrandom.normal(key, (num_embeddings, embedding_size))
         else:
             if weight.shape != (num_embeddings, embedding_size):


### PR DESCRIPTION
Hi Patrick, 

I've noticed that you could do:

```python
import equinox as eqx
import jax
key = jax.random.PRNGKey(32)
emb = eqx.nn.Embedding(4, -1, key=key)
```

Normally, you wouldn't do this, because it makes not much sense, but sometimes you use some struct which holds the params for your model, and those might have negative numbers in them because - as is the case in LLaMA2 - those are set later (e.g. by the tokenizer). 

If you pass negative numbers in there, you get this error:

```
The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/artur/workspace/equinox-llama2/.venv/lib/python3.10/site-packages/equinox/_module.py", line 186, in __call__
    self = super(_ModuleMeta, initable_cls).__call__(*args, **kwargs)
  File "/home/artur/workspace/equinox-llama2/.venv/lib/python3.10/site-packages/equinox/_better_abstract.py", line 280, in __call__
    self = super().__call__(*args, **kwargs)
  File "/home/artur/workspace/equinox-llama2/.venv/lib/python3.10/site-packages/equinox/nn/_embedding.py", line 36, in __init__
    self.weight = jrandom.normal(key, (num_embeddings, embedding_size))
  File "/home/artur/workspace/equinox-llama2/.venv/lib/python3.10/site-packages/jax/_src/random.py", line 649, in normal
    return _normal(key, shape, dtype)  # type: ignore
jaxlib.mlir._mlir_libs._site_initialize.<locals>.MLIRError: Invalid type:
error: unknown: invalid tensor dimension size
```

which simply states that the dimension size is invalid. This can be prevented with a much nicer error message, like this:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/arturgalstyan/Workspace/equinox/equinox/_module.py", line 185, in __call__
    self = super(_ModuleMeta, initable_cls).__call__(*args, **kwargs)
  File "/Users/arturgalstyan/Workspace/equinox/equinox/_better_abstract.py", line 279, in __call__
    self = super().__call__(*args, **kwargs)
  File "/Users/arturgalstyan/Workspace/equinox/equinox/nn/_embedding.py", line 37, in __init__
    assert embedding_size >= 0, "embedding_size must not be negative."
AssertionError: embedding_size must not be negative.
```

---

Lastly: for pyenv users, a file called `.python-version` is automatically created, which needn't be committed, so I've added it to the `.gitignore` file. 