### PR TITLE
Allow Abstract vars to be static

### DIFF
--- a/tests/test_abstract.py
+++ b/tests/test_abstract.py
@@ -1,4 +1,5 @@
 import abc
+from dataclasses import fields
 from typing import ClassVar, TYPE_CHECKING
 
 import pytest
@@ -102,6 +103,20 @@ def test_abstract_attribute():
 
     class M2(A):
         x = True
+
+    class A2(A):
+        x: AbstractVar[bool] = eqx.field(static=True)
+
+    class N1(A2):
+        x: bool = False
+
+    n1 = N1()
+    assert fields(n1)[0].metadata["static"]
+
+    with pytest.raises(ValueError, match="is allowed for abstract attributes"):
+
+        class A3(A):
+            x: AbstractVar[bool] = eqx.field(static=False)
 
 
 def test_abstract_class_attribute():

--- a/tests/test_abstract.py
+++ b/tests/test_abstract.py
@@ -107,11 +107,14 @@ def test_abstract_attribute():
     class A2(A):
         x: AbstractVar[bool] = eqx.field(static=True)
 
+    with pytest.raises(TypeError, match="abstract attributes"):
+
+        A2()
+
     class N1(A2):
         x: bool = False
 
-    n1 = N1()
-    assert fields(n1)[0].metadata["static"]
+    assert fields(N1())[0].metadata["static"]
 
     with pytest.raises(ValueError, match="is allowed for abstract attributes"):
 


### PR DESCRIPTION
A draft on how to support abstract attributes that are static as discussed in #472 .

Please don't mind the comments which were just there to keep me sane.

I am not quite sure of the  impact of two specific changes:

1. Moving the parent classes `super().__new__` call to the end of the the new `__new__`
2. This required using `if name not in namespace` instead of  `if name not in cls.__dict__` on line 290.

Added some tests. Everything seems to run fine so far.

