### PR TITLE
Minor help comment fix

### DIFF
--- a/equinox/_tree.py
+++ b/equinox/_tree.py
@@ -387,7 +387,7 @@ def tree_flatten_one_level(
                 # tree_subnodes(x)
                 # ```
                 # as `x` is not an immediate subnode of itself.
-                # If you want to check for that then use `tree_check_acyclic`.
+                # If you want to check for that then use `tree_check`.
                 try:
                     type_string = type(pytree).__name__
                 except AttributeError:


### PR DESCRIPTION
Fix the name of the function in the comment, from the one that was (probably) used in older versions, to the currently existing one.

I was having an issue related to the incorrect construction of PyTree, thus was reading the source code of the implementation. Noticed that the name in the comment was incorrect.