### PR TITLE
Support class creation kwargs, e.g. `class A(eqx.Module, foo=bar)`.

### DIFF
--- a/equinox/_module.py
+++ b/equinox/_module.py
@@ -115,12 +115,12 @@ _has_dataclass_init = weakref.WeakKeyDictionary()
 # Inherits from ABCMeta as a convenience for a common use-case.
 # It's not a feature we use ourselves.
 class _ModuleMeta(ABCMeta):  # pyright: ignore
-    def __new__(mcs, name, bases, dict_):  # pyright: ignore
+    def __new__(mcs, name, bases, dict_, **kwargs):  # pyright: ignore
         dict_ = {
             k: _wrap_method(v) if _not_magic(k) and inspect.isfunction(v) else v
             for k, v in dict_.items()
         }
-        cls = super().__new__(mcs, name, bases, dict_)
+        cls = super().__new__(mcs, name, bases, dict_, **kwargs)
         # Do override subclasses' dataclass-__init__-s. (None of which call super, so
         # they must be overriden.)
         # Don't override custom __init__'s, which leads to poor ergonomics:

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -252,3 +252,20 @@ def test_wrapped(getkey):
     y = eqx.filter_vmap(eqx.nn.Linear(2, 2, key=getkey()))
     x, y = eqx.filter((x, y), eqx.is_array)
     jtu.tree_map(lambda x, y: x + y, x, y)
+
+
+def test_class_creation_kwargs():
+    called = False
+
+    class A(eqx.Module):
+        def __init_subclass__(cls, foo, **kwargs) -> None:
+            nonlocal called
+            assert not called
+            called = True
+            assert foo
+            assert len(kwargs) == 0
+
+    class B(A, foo=True):
+        pass
+
+    assert called


### PR DESCRIPTION
Fixes #481.