### PR TITLE
filter_eval_shape now alwasys has a .out_struct property

### DIFF
--- a/equinox/_eval_shape.py
+++ b/equinox/_eval_shape.py
@@ -4,8 +4,10 @@ from typing import Any, Union
 
 import jax
 import jax._src.traceback_util as traceback_util
+import jax.tree_util as jtu
 from jaxtyping import PyTree
 
+from ._caches import internal_lru_caches
 from ._filters import combine, is_array, partition
 from ._module import Static
 
@@ -35,3 +37,26 @@ def filter_eval_shape(
     dynamic, static = partition((fun, args, kwargs), _filter)
     dynamic_out, static_out = jax.eval_shape(ft.partial(_fn, static), dynamic)
     return combine(dynamic_out, static_out.value)
+
+
+def _to_struct(x):
+    if is_array(x):
+        return jax.ShapeDtypeStruct(x.shape, x.dtype)
+    else:
+        return x
+
+
+@ft.lru_cache(maxsize=None)
+def _cached_filter_eval_shape(leaves, treedef):
+    fn, args, kwargs = jtu.tree_unflatten(treedef, leaves)
+    return filter_eval_shape(fn, *args, **kwargs)
+
+
+internal_lru_caches.append(_cached_filter_eval_shape)
+
+
+def cached_filter_eval_shape(fn, *args, **kwargs):
+    tree = jtu.tree_map(_to_struct, (fn, args, kwargs))
+    leaves, treedef = jtu.tree_flatten(tree)
+    leaves = tuple(leaves)
+    return _cached_filter_eval_shape(leaves, treedef)

--- a/equinox/internal/__init__.py
+++ b/equinox/internal/__init__.py
@@ -18,6 +18,7 @@ from .._errors import (
     branched_error_if as branched_error_if,
     error_if as error_if,
 )
+from .._eval_shape import cached_filter_eval_shape as cached_filter_eval_shape
 from .._misc import left_broadcast_to as left_broadcast_to
 from .._module import Static as Static
 from .._pretty_print import tree_pp as tree_pp

--- a/tests/test_ad.py
+++ b/tests/test_ad.py
@@ -340,6 +340,15 @@ def test_closure_convert_basic():
     f(1.0, 1.0)
 
 
+def test_closure_convert_trivial():
+    def f(a):
+        return a + 1
+
+    f2 = eqx.filter_closure_convert(f, 1)
+    f2.out_struct
+    assert type(f2).__name__ == "_TrivialClosureConvert"
+
+
 def test_closure_convert_custom_jvp():
     @eqx.filter_custom_jvp
     def call(f, x):


### PR DESCRIPTION
Previously, this was erroneously skipped when the function lacked any closed-over variables.
In addition, this commit adds eqxi.cached_filter_eval_shape, as that is needed for the above.
