### PR TITLE
Added Module.__check_init__ for after-initialisation checking of invariants. See #472.

### DIFF
--- a/docs/api/module/advanced_fields.md
+++ b/docs/api/module/advanced_fields.md
@@ -18,6 +18,69 @@ Equinox modules can be used as [abstract base classes](https://docs.python.org/3
     selection:
         members: false
 
+## Checking invariants
+
+Equinox extends dataclasses with a `__check_init__` method, which is automatically ran after initialisation. This can be used to check invariants like so:
+
+```python
+class Positive(eqx.Module):
+    x: int
+
+    def __check_init__(self):
+        if self.x <= 0:
+            raise ValueError("Oh no!")
+```
+
+This method has three key differences compared to the `__post_init__` provided by dataclasses:
+
+- It is not overridden by an `__init__` method of a subclass. In contrast, the following code has a silent bug:
+    
+    ```python
+    class Parent(eqx.Module):
+        x: int
+
+        def __check_init__(self):
+            if self.x <= 0:
+                raise ValueError("Oh no!")
+
+    class Child(Parent):
+        x_as_str: str
+
+        def __init__(self, x):
+            self.x = x
+            self.x_as_str = str(x)
+
+    Child(-1)  # No error!
+    ```
+
+- It is automatically called for parent classes; `super().__check_init__()` is not required:
+
+    ```python
+    class Parent(eqx.Module):
+        def __check_init__(self):
+            print("Parent")
+
+    class Child(Parent):
+        def __check_init__(self):
+            print("Child")
+
+    Child()  # prints out both Child and Parent
+    ```
+
+    As with the previous bullet point, this is to prevent child classes accidentally failing to check that the invariants of their parent hold.
+
+- Assignment is not allowed:
+    
+    ```python
+    class MyModule(eqx.Module):
+        foo: int
+
+        def __check_init__(self):
+            self.foo = 1  # will raise an error
+    ```
+
+    This is to prevent `__check_init__` from doing anything too surprising: as the name suggests, it's meant to be used for checking invariants.
+
 ## Creating wrapper modules
 
 ::: equinox.module_update_wrapper

--- a/equinox/_module.py
+++ b/equinox/_module.py
@@ -201,6 +201,13 @@ class _ModuleMeta(ABCMeta):  # pyright: ignore
             else:
                 setattr(self, field.name, converter(getattr(self, field.name)))
         object.__setattr__(self, "__class__", cls)
+        for kls in cls.__mro__:
+            try:
+                check = kls.__dict__["__check_init__"]
+            except KeyError:
+                pass
+            else:
+                check(self)
         return self
 
 


### PR DESCRIPTION
As discussed in #472, it would be nice to have a way to check invariants after a class has been instantiated. Typical use cases are something like:

```python
class A(eqx.Module):
    x: int

    def __check_init__(self):
        if x < 0:
            raise ValueError("x must be non-negative")
```

This PR adds `__check_init__`, which is automatically called after initialisation.

---

Now you may wonder, why not use `__post_init__`, as provided by dataclasses? It turns out that this use-case isn't well-served by `__post_init__`. The reason is that `__post_init__` is not called if a subclass defines an `__init__` or `__post_init__` method of its own, and forgets to call `super().__post_init__()`. Any checks placed in `__post_init__` are silently never run!

Indeed, it turns out exactly this issue has existed in Diffrax for some time: https://github.com/patrick-kidger/diffrax/pull/308.

The advantage of `__check_init__` is that all instances across the whole MRO are automatically ran. That is, all superclass `__check_init__` are automatically ran, without needing to call `super()`. This makes it impossible for a downstream class to silently avoid checking the invariants of its parent class.

---

Note that `__check_init__` is ran *after* the class is completely initialised. That is, it is no longer possible to assign `self.foo = bar` inside of `__check_init__`.

This is a deliberate constraint, to prevent parent classes from silently performing any behaviour that may be surprising for its child class. This is particularly important, as a child class has no way to override the `__check_init__` of its parent.

As the name suggests, this method is intended for checking invariants, not arbitrary postprocessing. (Use `__post_init__` for that.)
