### PR TITLE
Calling equinox.filter_{grad, value_and_grad} without a positional first argument now raises a better error message.

### DIFF
--- a/equinox/_ad.py
+++ b/equinox/_ad.py
@@ -55,12 +55,19 @@ class _ValueAndGradWrapper(Module):
     def __wrapped__(self):
         return self._fun
 
-    def __call__(self, x, /, *args, **kwargs):
+    def __call__(self, *args, **kwargs):
         @ft.partial(jax.value_and_grad, has_aux=self._has_aux, **self._gradkwargs)
         def fun_value_and_grad(_diff_x, _nondiff_x, *_args, **_kwargs):
             _x = combine(_diff_x, _nondiff_x)
             return self._fun(_x, *_args, **_kwargs)
 
+        if len(args) == 0:
+            raise TypeError(
+                "Functions wrapped with `equinox.filter_{grad, value_and_grad}` must "
+                "have their first argument passed by position, not keyword. (This is "
+                "the argument that is differentiated.)"
+            )
+        x, *args = args
         diff_x, nondiff_x = partition(x, is_inexact_array)
         return fun_value_and_grad(diff_x, nondiff_x, *args, **kwargs)
 

--- a/tests/test_ad.py
+++ b/tests/test_ad.py
@@ -584,3 +584,11 @@ def test_filter_custom_vjp_nonarray_residual():
         return 2 * ct
 
     jax.grad(f)(1.0)
+
+
+def test_positional_first_argument():
+    x = jnp.array(1.0)
+    with pytest.raises(TypeError, match="Functions wrapped with"):
+        eqx.filter_grad(lambda x: x + 1)(x=x)
+    with pytest.raises(TypeError, match="Functions wrapped with"):
+        eqx.filter_value_and_grad(lambda x, y: x + y)(x=x, y=x)

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -848,7 +848,7 @@ def test_spectral_norm(getkey):
     def λ1():
         u, v = state.get(spectral.uv_index)
         σ = jnp.einsum("i,ij,j->", u, spectral.layer.weight, v)
-        _, s, _ = jnp.linalg.svd(spectral.layer.weight / σ)
+        _, s, _ = jnp.linalg.svd(spectral.layer.weight / σ)  # pyright: ignore
         return s[0]
 
     x = jrandom.normal(getkey(), (5,))


### PR DESCRIPTION
Fixes #502.