### PR TITLE
Fixed spurious error when accessing methods during __init__.

### DIFF
--- a/equinox/_pretty_print.py
+++ b/equinox/_pretty_print.py
@@ -10,6 +10,8 @@ import jax.tree_util as jtu
 import numpy as np
 from jaxtyping import PyTree
 
+from ._doc_utils import WithRepr
+
 
 Dataclass = Any
 NamedTuple = Any  # workaround typeguard bug
@@ -140,7 +142,7 @@ def _pformat_dataclass(obj, **kwargs) -> pp.Doc:
     # values to the module so the repr fails.
     objs = named_objs(
         [
-            (field.name, getattr(obj, field.name, "<uninitialised>"))
+            (field.name, getattr(obj, field.name, WithRepr(None, "<uninitialised>")))
             for field in dataclasses.fields(obj)
             if field.repr
         ],

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -150,8 +150,9 @@ def test_method_assignment():
         x: jax.Array
 
         def __init__(self, x):
-            # foo is assigned before x! Therefore
-            # self.bar.instance.x` doesn't exist yet.
+            # foo is assigned before x! We have that `self.bar.__self__` is a copy of
+            # `self`, but for which self.bar.__self__.x` doesn't exist yet. Then later
+            # calling `self.foo()` would raise an error.
             self.foo = self.bar
             self.x = x
 
@@ -188,6 +189,17 @@ def test_method_assignment2():
 
     with pytest.raises(ValueError, match="Cannot assign methods in __init__"):
         SubComponent()
+
+
+def test_method_access_during_init():
+    class Foo(eqx.Module):
+        def __init__(self):
+            self.method()
+
+        def method(self):
+            pass
+
+    Foo()
 
 
 @pytest.mark.parametrize("new", (False, True))


### PR DESCRIPTION
Drive-by: improved pretty-printing of dataclasses with unintialised fields.
