### PR TITLE
Updated the abstract/final design pattern.

### DIFF
--- a/docs/api/module/advanced_fields.md
+++ b/docs/api/module/advanced_fields.md
@@ -94,12 +94,12 @@ When enabled via
 class Foo(eqx.Module, strict=True):
     ...
 ```
-then the following things are checked when you define your class (an error raised if they fail).
+then the following things are checked when you define your class (an error is raised if they fail).
 
-- That all base classes also inherit from `eqx.Module`.
-- That abstract classes have names beginning with `Abstract`.
-- That abstract classes do not implement an `__init__` method.
-- That abstract classes do not have any fields.
+- That all base classes are also strict `eqx.Module`s.
+- That concrete classes are final.
+- The `__init__` method and all fields are all defined on a single class.
+- That abstract classes have names beginning with `"Abstract"`.
 - That no concrete method is overridden. For example, this will raise an error:
     ```python
     class Foo(eqx.Module):
@@ -117,6 +117,5 @@ then the following things are checked when you define your class (an error raise
     class Concrete(Abstract, strict=True):
         def f(self): ...
     ```
-    This check essentially also ensures that concrete classes are final.
 
-Just the strict module is checked. It does not matter whether any of the superclasses are strict, and subclasses will not become strict unless they also opt-in. This makes it possible to safely enable strict modules in a library, without affecting any downstream users.
+Just the strict `Module` is checked. Subclasses will not become strict unless they also opt-in. This makes it possible to safely enable strict modules in a library, without affecting any downstream users.

--- a/docs/api/module/advanced_fields.md
+++ b/docs/api/module/advanced_fields.md
@@ -85,6 +85,7 @@ This method has three key differences compared to the `__post_init__` provided b
 
 ::: equinox.module_update_wrapper
 
+<!--
 ## Strict modules
 
 Equinox supports an entirely optional "strict mode", for validating that you follow the abstract/final design pattern as discussed in [this style guide](../../../pattern/).
@@ -118,4 +119,4 @@ then the following things are checked when you define your class (an error is ra
         def f(self): ...
     ```
 
-Just the strict `Module` is checked. Subclasses will not become strict unless they also opt-in. This makes it possible to safely enable strict modules in a library, without affecting any downstream users.
+Just the strict `Module` is checked. Subclasses will not become strict unless they also opt-in. This makes it possible to safely enable strict modules in a library, without affecting any downstream users.-->

--- a/docs/pattern.md
+++ b/docs/pattern.md
@@ -1,23 +1,55 @@
-# The abstract/final design pattern
+# The abstract/final pattern
 
-The following is a very useful design pattern. It's not mandatory, but it comes very strongly recommended, as it's designed to produce very readable code. This is also the pattern used throughout the Equinox ecosystem -- [Lineax](https://github.com/google/lineax), [Diffrax](https://github.com/patrick-kidger/diffrax) etc. -- and as such Equinox offers a lot of tools to make this approach feel particularly powerful.
+The following is a useful design pattern. It's not mandatory, but it does come recommended, as it's designed to produce very readable code. This is also the pattern used throughout the Equinox ecosystem -- [Lineax](https://github.com/google/lineax), [Diffrax](https://github.com/patrick-kidger/diffrax) etc.
 
 !!! Tip "The abstract/final design pattern"
 
-    Due to `eqx.Module`, we tend to create a lot of classes. We're going to enforce the restriction that every class be precisely one of:  
+    Every subclass of `eqx.Module` must be either
 
-    (a) abstract -- that is, it can be subclassed, but not instantiated;  
-    (b) final -- that is, it can be instantiated, but not subclassed.
+    (a) abstract (it can be subclassed, but not instantiated); or  
+    (b) final (it can be instantiated, but not subclassed).
 
-    Moreover, abstract classes shouldn't define `__init__` methods, nor should they define attributes (other than those marked with [`equinox.AbstractVar`][] or [`equinox.AbstractClassVar`][]).
-    
-    Finally, we should never re-override a method. Once a subclass implements a method, that's it.
+    Unless they're abstract, then methods and attributes must never be overridden. Once they've been implemented, that's it.
 
-This idea is very simple. Now, let's take a deep dive on why this is such a neat pattern, and how Equinox offers special tools to support this.
+    The `__init__` method, and all dataclass fields, must all be defined in one class. No defining fields in multiple parts of a class hierarchy.
+
+Collectively, these rules serve to avoid all the worst ways in which you might spaghetti your code. Abstract classes are used to define interfaces or partial implementations. Final classes are what get passed around at runtime. No overriding (of methods or of non-abstract classes) means there are no surprises with exactly what is being called. Keeping all fields together means that initialisation is readable.
+
+Equinox will enforce these rules when subclassing with `strict=True`, e.g.
+```python
+class Foo(eqx.Module, strict=True):
+    x: int
+# ...so far so good...
+
+class Bar(Foo, strict=True):
+    y: int
+# ...error raised here: can't define fields in two different classes.
+```
+(In addition, `strict=True` checks two other things: that all abstract classes have a name that starts with `"Abstract"`, and that modules aren't mixed with non-module classes.)
+
+!!! faq "FAQ"
+
+    Some quick FAQs:
+
+    - If we want to subclass to override just one method, just to tweak it a little bit -- this can be done by wrapping the original class, not subclassing it.
+    - In practice we typically define all fields, and the `__init__` method, on the final class that we instantiate. Every so often we could do them on an abstract class though, in which case the final subclasses will only be implementing methods.
+    - You should never use the `hasattr` builtin. You probably meant to declare this attribute/method on an abstract base class.
+    - To access an attribute on an abstract class, it can be declared using [`equinox.AbstractVar`][]; the eventual final subclass must provide this as a field or property.
+
+    And for the CS nerds:
+
+    - This is going all-in on nominal subtyping, not structural/duck subtyping.
+    - Yes, this design pattern looks a lot like Rust/Julia/something. For example the abstract-or-final rule is inspired by Julia's type system, and the no-overriding is inspired by how many languages (including Rust) approach the orphan problem.
+    - This has nothing to do with object-oriented (OO) programming, and everything to do with type theory. OO is about mutating classes through their methods, and as Equinox modules are immutable then we never do that here. (It is true that a lot of OO codebases could benefit from rules like these, though.)
+
+---
+
+The above is the really important bit. For those who are curious to know more, here's how we arrive at the above design pattern.
 
 ## Level 1: Abstract base classes (ABCs) as interfaces
 
-When following the above, we tend to write code that looks like the following:
+Let's start off with something very standard: using ABCs to define interfaces. Here's an example.
+
 ```python
 class AbstractOptimiser(eqx.Module):
     @abc.abstractmethod
@@ -59,15 +91,17 @@ optimiser = Adam(learning_rate=3e-4)
 train(params, dataloader, optimiser)
 ```
 
-Hopefully the above is indeed easy to read! The `AbstractOptimiser` defines an interface using `init` and `update`. Subsequently, we can write our `train` and `make_step` functions without needing to worry exactly which optimiser we have been passed.
+Hopefully the above is indeed easy to read. The `AbstractOptimiser` defines an interface using `init(params)` and `update(params, grad, state)`. (And we should also add type annotations to their arguments, actually.)
+
+Subsequently, the `train` and `make_step` functions can be written without needing to know exactly which optimiser has been passed. (We can later implement some other optimiser and use that in the same place.)
 
 For readability, it's worth following the convention that all abstract classes begin with the word "Abstract".
 
-This idea is very common. Indeed Python has a whole module, [abc](https://docs.python.org/3/library/abc.html), for declaring such `abc.abstractmethod`s. And here we see our first example of Equinox making this approach easy for you: Equinox modules automatically inherit from `abc.ABC`, so you don't need to do that yourself.
+The above is very common. Indeed Python has a whole module, [abc](https://docs.python.org/3/library/abc.html), for declaring such `abc.abstractmethod`s. This is also our first example of Equinox making this approach easy: Equinox modules automatically inherit from `abc.ABC`, so you don't need to do that yourself.
 
-## Level 2: intermediate ABCS, abstract attributes, and concrete-`__init__`-only
+## Level 2: intermediate ABCS, abstract attributes, and `__init__`-only-once
 
-Now here's a natural extension to the above: intermediate ABCs, that introduce partial implementations.
+Now let's move on to a natural extension to the above: intermediate ABCs, that introduce partial implementations.
 
 ```python
 class AbstractInterpolation(eqx.Module):
@@ -94,9 +128,9 @@ class CubicInterpolation(AbstractPolynomialInterpolation):
 ```
 in this case, the intermediate ABC `AbstractPolynomialInterpolation` implements the `__call__` method. However, it isn't yet a concrete (non-abstract) class, as it introduces a new abstract variable `coeffs` -- we need to wait until `CubicInterpolation` for that to be defined.
 
-We also see the use of [`equinox.AbstractVar`][] -- this is an Equinox-specific extension to the `abc` module, making it possible to define abstract attributes. (There is also [`equinox.AbstractClassVar`][], to define abstract class attributes.) This is another example of Equinox being designed to make this design pattern easy.
+Using an abstract attribute ([`equinox.AbstractVar`][]) here means that we can write `self.coeffs` inside `degree` and `__call__`, and know that this is safe. Unless all abstract attributes are defined then Equinox won't allow us to instantiate the class.
 
-As a final more subtle point, note that `AbstractPolynomialInterpolation` did **not** provide an `__init__` method! We could have written this instead:
+Why didn't we just define `AbstractPolynomialInterpolation.coeffs` as a concrete field? (Just `coeffs: Array`.) Indeed we could have written this:
 ```python
 class AbstractPolynomialInterpolation(AbstractInterpolation)
     coeffs: Array
@@ -116,22 +150,22 @@ class CubicInterpolation(AbstractPolynomialInterpolation):
         coeffs = ...  # some implementation
         super().__init__(coeffs)
 ```
-but once you have multiple classes involved, then splitting up your initialisation like this very quickly becomes far less readable. (And a reliable source of bugs.) Overall, we recommend that `__init__` methods and (non-abstract) fields may only be defined on concrete classes. Equinox will enforce this when defined via `class Foo(eqx.Module, strict=True)`.
+but this is now much less readable: we've split up initialisation across two different classes. This is a reliable source of bugs. Thus we arrive at the rule that all fields, and the `__init__` method, should all be defined together. Using `strict=True` when subclassing (e.g. `class CubicInterpolation(AbstractPolynomialInterpolation, strict=True)`) will mean that Equinox checks for this, and raises an error if need be.
 
 ## Level 3: implement methods precisely once, and concrete-means-final
 
-Our "concrete `__init__` only" rule means that `__init__` is defined precisely once, is never overridden, and we never call `super().__init__`. Why stop there -- perhaps we should enforce that we never override *any* method?
+Our "`__init__` only once" rule means that `__init__` is defined precisely once, is never overridden, and we never call `super().__init__`. Why stop there: perhaps we should enforce that we never override *any* method?
 
 In practice, we argue that's a good idea! This rule means that when you see code like:
 ```python
 def foo(interp: AbstractPolynomialInterpolation)
-    ... = interp(...)
+    ... = interp.degree()
 ```
-you know that it is calling `AbstractPolynomialInterpolation.__call__`, and not anything else. This is great for code readability. Once again, this may be checked via a `strict=True` flag, passed as `class Foo(eqx.Module, strict=True)`.
+you know that it is calling precisely `AbstractPolynomialInterpolation.degree`, and not an override in some subclass. This is excellent for code readability. Thus we get the rule that no method should be overriden. (And this rule will also be checked via the `strict=True` flag.)
 
-If we assume this, then we now find ourselves arriving at a conclusion: concrete means final. That is, once we have a concrete class (every abstract method/attribute defined in our ABCs is now overriden with an implementation, so we can instantiate this class), then it is now final (we're not allowed to re-override things, so subclassing is pointless).
+If we assume this, then we now find ourselves arriving at a conclusion: concrete means final. That is, once we have a concrete class (every abstract method/attribute defined in our ABCs is now overriden with an implementation, so we can instantiate this class), then it is now final (we're not allowed to re-override things, so subclassing is pointless). This is how we arrive at the abstract-or-final rule itself!
 
-What about when you have an existing concrete class that you want to tweak just-a-little-bit? In this case, prefer composition over inheritance. Write a wrapper that forwards each method as appropriate.
+What about when you have an existing concrete class that you want to tweak just-a-little-bit? In this case, prefer composition over inheritance. Write a wrapper that forwards each method as appropriate. This is just as expressive, and means we keep these readable type-safe rules.
 
 ## Level 4: `__check_init__`
 
@@ -146,63 +180,94 @@ class AbstractPolynomialInterpolation(AbstractInterpolation)
 
     ...
 ```
-This method is something that Equinox will look for, and if present it will be ran after initialisation. This is again an Equinox-specific extension designed to support this design pattern.
+This method is something that Equinox will look for, and if present it will be ran after initialisation. This is an Equinox-specific extension designed to support this design pattern.
 
 See [checking invariants](../api/module/advanced_fields/#checking-invariants) for more details.
 
 ## Extensions and FAQ
 
-**Does `super()` ever get used at all?**
-
-Ideally, no! This design pattern means that you should never need to write `super()` at all.
-
 **Does this pattern work with multiple inheritance?**
 
-Yup. Nothing changes on that front. Take a look at [Diffrax](https://github.com/patrick-kidger/diffrax), for example. Simplifying a little, this happily has diamond inheritance patterns that look like:
+Yes. For example, here's a diamond inheritance pattern (for building a differential equation solver):
 ```python
 class AbstractSolver(eqx.Module):
     @abc.abstractmethod
-    def step(...): ...
+    def step(...):
+        raise NotImplementedError
 
 class AbstractAdaptiveSolver(AbstractSolver):
-    ...
+    tolerance: eqx.AbstractVar[float]
 
 class AbstractImplicitSolver(AbstractSolver):
     root_finder: eqx.AbstractVar[AbstractRootFinder]
 
 class ImplicitEuler(AbstractAdaptiveSolver, AbstractImplicitSolver):
+    tolerance: float
     root_finder: AbstractRootFinder = Newton()
 
-    def step(...): ...
+    def step(...):
+        ...  # some implementation
+
+solver = ImplicitEuler(tolerance=1e-3)  # this can be instantiated
 ```
 
 **That's a lot of `Abstract`s**
 
 Yes.
 
+**Does `super()` ever get used at all?**
+
+No. This design pattern means that you should never need to write `super()` at all.
+
 **What about co-operative multiple inheritance?**
 
-If you're a Python nerd, you'll now be wondering about co-operative multiple inheritance, and the ubiquitous use of `super()`.
+If you're a Python nerd, you'll now be wondering about co-operative multiple inheritance, which specifies using `super()` ubiquitously.
 
 The TL;DR of this is that almost no-one ever uses this properly, and the abstract+final pattern is intended as a direct alternative. One sees a lot of code that looks like this:
 ```python
 class A:
     def __init__(self, x):
         self.x = x
-        # Not calling super().__init__, because the superclass is just `object`, right??
+        # Not calling super().__init__, because the superclass is just `object`, right?
 
 class AA:
-    def __init__(...): ...
+    def __init__(...):
+        super().__init__(...)  # Being a good citizen.
+        ...  # Do anything else that needs to happen.
 
 class B(A, AA):
     pass
 
-B() # bug!
+B()  # AA.__init__ is not called.
 ```
-And in this case `B()` calls `A.__init__` which then fails to call `AA.__init__`. Co-operative multiple inheritance only works if everyone, well, co-operates.
+In this case `B()` calls `A.__init__` and this then fails to call `AA.__init__`. Co-operative multiple inheritance only works if everyone, well, co-operates.
 
-Besides that, when you call `super().__init__`, then you don't actually know what method you're calling -- because `super()` could be pointing at almost any class at all. This means that it's not possible to know what arguments to pass to `super().__init__`! "Only use keyword arguments" is the closest to a resolution that this issue has, and it's still fragile.
+Even if everyone wants to do their best, there is another issue. When writing `super().__init__`, it isn't actually know what method is being called -- as above, `super()` could be pointing at almost any class at all. This actually means that it's not possible to know what arguments to pass to `super().__init__`! "Only use keyword arguments" is the closest to a resolution that this issue has, and it's still fragile.
+
+In contrast, our no-overriding and abstract-or-final rules means that we never come across this scenario. We always know precisely what is being called.
+
+**Hang on, I don't buy the abstract-or-concrete part. Can't a concrete subclass add a new method to a concrete superclass?**
+
+You're thinking of something like this this:
+```python
+# This is clearly something we can instantiate: it has no abstract methods/attributes.
+class ConcreteArray(eqx.Module):
+    def some_method(self):
+        pass
+
+# This is clearly also without abstract methods/attributes, and also doesn't break the
+# rule about overriding methods.
+class ConcreteArrayTwo(ConcreteArray):
+    def another_method(self):
+        pass
+```
+We didn't discuss it above, but we do ban things like this as well. (And `strict=True` will prevent this.) The reason is to simplify things when writing something like:
+```python
+def add(x: ConcreteArray, y: ConcreteArray) -> ConcreteArray:
+    ...
+```
+so that there are never any questions about what the return type should be. (If we passed in `ConcreteArrayTwo` in to `x` or `y`, maybe we should try to return a `ConcreteArrayTwo` instead? What if `x = ConcreteArrayTwo()` but `y = ConcreteArrayThree()`, and these two types don't know about each other? Better to avoid the question in the first place.)
 
 **These ideas have appeared in &lt;XYZ language&gt;?**
 
-Yup! Variants of this design pattern are very common, especially in modern languages like Julia/Rust/etc.etc.
+Yup! Variants of this design pattern are very common, especially in modern languages like Julia/Rust/etc., or in older languages with a strong emphasis on typing.

--- a/equinox/_module.py
+++ b/equinox/_module.py
@@ -696,10 +696,14 @@ class Module(metaclass=_ModuleMeta):
         [`abc.abstractmethod`](https://docs.python.org/3/library/abc.html#abc.abstractmethod).
         You can also create abstract instance attributes or abstract class
         attributes, see [`equinox.AbstractVar`][] and
-        [`equinox.AbstractClassVar`][]. Finally, some optional strict type-checking
-        may be enabled by passing `strict=True`, e.g.
-        `class Foo(eqx.Module, strict=True)`; see [strict modules](../advanced_fields/#strict-modules) for details.
+        [`equinox.AbstractClassVar`][].
     """  # noqa: E501
+
+    #     [`equinox.AbstractClassVar`][]. Finally, some optional strict type-checking
+    #     may be enabled by passing `strict=True`, e.g.
+    #     `class Foo(eqx.Module, strict=True)`; see
+    #     [strict modules](../advanced_fields/#strict-modules) for details.
+    # """  # noqa: E501
 
     def __hash__(self):
         return hash(tuple(jtu.tree_leaves(self)))

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -144,5 +144,5 @@ nav:
     - Misc:
         - 'faq.md'
         - 'tricks.md'
-        - 'pattern.md'
+        # - 'pattern.md'
         - 'citation.md'


### PR DESCRIPTION
- Updated the text to be easier to read.
- Loosened the requirements on the pattern a little bit -- in particular
    to allow abstract classes to have __init__ methods and attributes,
    as long as they're the only class in the hierarchy to have them.
- Now explicitly checking that you don't subclass a concrete class, as
    otherwise you could still do so, just without overriding any
    methods / only adding new methods.
