### PR TITLE
Tweaked ViT example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build/
 dist/
 site/
 examples/data
+examples/CIFAR
 .all_objects.cache
 .pymon
 .idea

--- a/equinox/nn/_normalisation.py
+++ b/equinox/nn/_normalisation.py
@@ -131,6 +131,13 @@ class LayerNorm(Module):
         if x.shape != self.shape:
             raise ValueError(
                 "`LayerNorm(shape)(x)` must satisfy the invariant `shape == x.shape`"
+                f"Received `shape={self.shape} and `x.shape={x.shape}`. You might need "
+                "to replace `layer_norm(x)` with `jax.vmap(layer_norm)(x)`.\n"
+                "\n"
+                "If this is a new error for you, it might be because this became "
+                "stricter in Equinox v0.11.0. Previously all that was required is that "
+                "`x.shape` ended with `shape`. However, this turned out to be a "
+                "frequent source of bugs, so we made the check stricter!"
             )
         mean = jnp.mean(x, keepdims=True)
         variance = jnp.var(x, keepdims=True)

--- a/examples/vision_transformer.ipynb
+++ b/examples/vision_transformer.ipynb
@@ -8,27 +8,33 @@
    "source": [
     "# Vision Transformer (ViT)\n",
     "\n",
-    "This example builds a vision transformer model using Equinox, an implementation based on the paper: An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale.\n",
+    "This example builds a vision transformer model using Equinox, an implementation based on the paper: _An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale_.\n",
     "\n",
-    "This is a tutorial example, if you want to use a vision transformer Equinox model in your project, please refer to this implementation [Eqxvision: Vision Transformer](https://eqxvision.readthedocs.io/en/latest/api/models/classification/vit/).\n",
+    "In addition to this tutorial example, you may also like the ViT implementation [available here in Eqxvision here](https://eqxvision.readthedocs.io/en/latest/api/models/classification/vit/).\n",
+    "\n",
+    "!!! warning\n",
+    "\n",
+    "    This example will take a short while to run on a GPU.\n",
     "\n",
     "!!! cite \"Reference\"\n",
     "\n",
     "    [arXiv link](https://arxiv.org/abs/2010.11929)\n",
     "\n",
     "    ```bibtex\n",
-    "    @article{dosovitskiy2020image,\n",
-    "        title={An image is worth 16x16 words: Transformers for image recognition at scale},\n",
-    "        author={Dosovitskiy, Alexey and Beyer, Lucas and Kolesnikov, Alexander and Weissenborn, Dirk and Zhai, Xiaohua and Unterthiner, Thomas and Dehghani, Mostafa and Minderer, Matthias and Heigold, Georg and Gelly, Sylvain and others},\n",
-    "        journal={arXiv preprint arXiv:2010.11929},\n",
-    "        year={2020}\n",
+    "    @inproceedings{dosovitskiy2021an,\n",
+    "        title={An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale},\n",
+    "        author={Alexey Dosovitskiy and Lucas Beyer and Alexander Kolesnikov and Dirk Weissenborn\n",
+    "                and Xiaohua Zhai and Thomas Unterthiner and Mostafa Dehghani and Matthias Minderer\n",
+    "                and Georg Heigold and Sylvain Gelly and Jakob Uszkoreit and Neil Houlsby},\n",
+    "        booktitle={International Conference on Learning Representations},\n",
+    "        year={2021},\n",
     "    }\n",
     "    ```"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 2,
    "metadata": {
     "id": "3-NddIhhxINj"
    },
@@ -36,16 +42,13 @@
    "source": [
     "import functools\n",
     "\n",
-    "from jaxtyping import PRNGKeyArray, Array, Float\n",
-    "\n",
-    "import numpy as np\n",
-    "\n",
     "import einops  # https://github.com/arogozhnikov/einops\n",
-    "\n",
     "import jax\n",
     "import jax.numpy as jnp\n",
     "import jax.random as jr\n",
+    "import numpy as np\n",
     "import optax  # https://github.com/deepmind/optax\n",
+    "from jaxtyping import PRNGKeyArray, Array, Float\n",
     "\n",
     "# We'll use PyTorch to load the dataset.\n",
     "import torch\n",
@@ -57,7 +60,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 3,
    "metadata": {
     "id": "bYi-XlXRxINl"
    },
@@ -92,7 +95,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -100,7 +103,16 @@
     "id": "Vcwi4un6CMu_",
     "outputId": "fad94424-789b-46b2-f3df-41f004ddfaf7"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Files already downloaded and verified\n",
+      "Files already downloaded and verified\n"
+     ]
+    }
+   ],
    "source": [
     "transform_train = transforms.Compose(\n",
     "    [\n",
@@ -154,7 +166,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 5,
    "metadata": {
     "id": "SFo1GzZvxINl"
    },
@@ -204,18 +216,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 6,
    "metadata": {
     "id": "mDg-L_9ixINm"
    },
    "outputs": [],
    "source": [
     "class AttentionBlock(eqx.Module):\n",
-    "    layer_norm: eqx.nn.LayerNorm\n",
+    "    layer_norm1: eqx.nn.LayerNorm\n",
+    "    layer_norm2: eqx.nn.LayerNorm\n",
     "    attention: eqx.nn.MultiheadAttention\n",
     "    linear1: eqx.nn.Linear\n",
     "    linear2: eqx.nn.Linear\n",
-    "    dropout: eqx.nn.Dropout\n",
+    "    dropout1: eqx.nn.Dropout\n",
+    "    dropout2: eqx.nn.Dropout\n",
     "\n",
     "    def __init__(\n",
     "        self,\n",
@@ -227,12 +241,14 @@
     "    ):\n",
     "        key1, key2, key3 = jr.split(key, 3)\n",
     "\n",
-    "        self.layer_norm = eqx.nn.LayerNorm(input_shape)\n",
+    "        self.layer_norm1 = eqx.nn.LayerNorm(input_shape)\n",
+    "        self.layer_norm2 = eqx.nn.LayerNorm(input_shape)\n",
     "        self.attention = eqx.nn.MultiheadAttention(num_heads, input_shape, key=key1)\n",
     "\n",
     "        self.linear1 = eqx.nn.Linear(input_shape, hidden_dim, key=key2)\n",
-    "        self.dropout = eqx.nn.Dropout(dropout_rate)\n",
     "        self.linear2 = eqx.nn.Linear(hidden_dim, input_shape, key=key3)\n",
+    "        self.dropout1 = eqx.nn.Dropout(dropout_rate)\n",
+    "        self.dropout2 = eqx.nn.Dropout(dropout_rate)\n",
     "\n",
     "    def __call__(\n",
     "        self,\n",
@@ -240,18 +256,18 @@
     "        enable_dropout: bool,\n",
     "        key: PRNGKeyArray,\n",
     "    ) -> Float[Array, \"num_patches embedding_dim\"]:\n",
-    "        input_x = self.layer_norm(x)\n",
+    "        input_x = jax.vmap(self.layer_norm1)(x)\n",
     "        x = x + self.attention(input_x, input_x, input_x)\n",
     "\n",
-    "        input_x = self.layer_norm(x)\n",
+    "        input_x = jax.vmap(self.layer_norm2)(x)\n",
     "        input_x = jax.vmap(self.linear1)(input_x)\n",
     "        input_x = jax.nn.gelu(input_x)\n",
     "\n",
     "        key1, key2 = jr.split(key, num=2)\n",
     "\n",
-    "        input_x = self.dropout(input_x, inference=not enable_dropout, key=key1)\n",
+    "        input_x = self.dropout1(input_x, inference=not enable_dropout, key=key1)\n",
     "        input_x = jax.vmap(self.linear2)(input_x)\n",
-    "        input_x = self.dropout(input_x, inference=not enable_dropout, key=key2)\n",
+    "        input_x = self.dropout2(input_x, inference=not enable_dropout, key=key2)\n",
     "\n",
     "        x = x + input_x\n",
     "\n",
@@ -269,7 +285,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 7,
    "metadata": {
     "id": "nG6fLPhyQEBx"
    },
@@ -349,7 +365,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 8,
    "metadata": {
     "id": "agBSRsXVxINn"
    },
@@ -420,11 +436,119 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {
     "id": "y3Bm_Xln-rSp"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Step: 0/100000, Loss: 2.5608019828796387.\n",
+      "Step: 1000/100000, Loss: 1.711548089981079.\n",
+      "Step: 2000/100000, Loss: 1.4029508829116821.\n",
+      "Step: 3000/100000, Loss: 1.405516505241394.\n",
+      "Step: 4000/100000, Loss: 1.1661641597747803.\n",
+      "Step: 5000/100000, Loss: 1.1351711750030518.\n",
+      "Step: 6000/100000, Loss: 1.11599600315094.\n",
+      "Step: 7000/100000, Loss: 0.796968936920166.\n",
+      "Step: 8000/100000, Loss: 0.6870157718658447.\n",
+      "Step: 9000/100000, Loss: 1.0474591255187988.\n",
+      "Step: 10000/100000, Loss: 0.9413787722587585.\n",
+      "Step: 11000/100000, Loss: 0.8514565229415894.\n",
+      "Step: 12000/100000, Loss: 0.6746965646743774.\n",
+      "Step: 13000/100000, Loss: 0.7895829677581787.\n",
+      "Step: 14000/100000, Loss: 0.6844460964202881.\n",
+      "Step: 15000/100000, Loss: 0.6571178436279297.\n",
+      "Step: 16000/100000, Loss: 0.5611618757247925.\n",
+      "Step: 17000/100000, Loss: 0.610838770866394.\n",
+      "Step: 18000/100000, Loss: 0.7180566787719727.\n",
+      "Step: 19000/100000, Loss: 0.6528561115264893.\n",
+      "Step: 20000/100000, Loss: 0.5517654418945312.\n",
+      "Step: 21000/100000, Loss: 0.6301887035369873.\n",
+      "Step: 22000/100000, Loss: 0.5667067766189575.\n",
+      "Step: 23000/100000, Loss: 0.43517759442329407.\n",
+      "Step: 24000/100000, Loss: 0.5348870754241943.\n",
+      "Step: 25000/100000, Loss: 0.44732385873794556.\n",
+      "Step: 26000/100000, Loss: 0.49118855595588684.\n",
+      "Step: 27000/100000, Loss: 0.5242345929145813.\n",
+      "Step: 28000/100000, Loss: 0.44588926434516907.\n",
+      "Step: 29000/100000, Loss: 0.23619337379932404.\n",
+      "Step: 30000/100000, Loss: 0.4560542702674866.\n",
+      "Step: 31000/100000, Loss: 0.3148268163204193.\n",
+      "Step: 32000/100000, Loss: 0.4813237488269806.\n",
+      "Step: 33000/100000, Loss: 0.40532559156417847.\n",
+      "Step: 34000/100000, Loss: 0.2517223358154297.\n",
+      "Step: 35000/100000, Loss: 0.322698712348938.\n",
+      "Step: 36000/100000, Loss: 0.3052283525466919.\n",
+      "Step: 37000/100000, Loss: 0.37322986125946045.\n",
+      "Step: 38000/100000, Loss: 0.27499520778656006.\n",
+      "Step: 39000/100000, Loss: 0.2547920346260071.\n",
+      "Step: 40000/100000, Loss: 0.27322614192962646.\n",
+      "Step: 41000/100000, Loss: 0.6049947738647461.\n",
+      "Step: 42000/100000, Loss: 0.28800976276397705.\n",
+      "Step: 43000/100000, Loss: 0.2901820242404938.\n",
+      "Step: 44000/100000, Loss: 0.3800655007362366.\n",
+      "Step: 45000/100000, Loss: 0.15261484682559967.\n",
+      "Step: 46000/100000, Loss: 0.17970965802669525.\n",
+      "Step: 47000/100000, Loss: 0.23651015758514404.\n",
+      "Step: 48000/100000, Loss: 0.3813527822494507.\n",
+      "Step: 49000/100000, Loss: 0.35252541303634644.\n",
+      "Step: 50000/100000, Loss: 0.16249465942382812.\n",
+      "Step: 51000/100000, Loss: 0.10218428075313568.\n",
+      "Step: 52000/100000, Loss: 0.2192973792552948.\n",
+      "Step: 53000/100000, Loss: 0.1880446970462799.\n",
+      "Step: 54000/100000, Loss: 0.14270251989364624.\n",
+      "Step: 55000/100000, Loss: 0.1278090476989746.\n",
+      "Step: 56000/100000, Loss: 0.0856819674372673.\n",
+      "Step: 57000/100000, Loss: 0.16201086342334747.\n",
+      "Step: 58000/100000, Loss: 0.20575015246868134.\n",
+      "Step: 59000/100000, Loss: 0.20935538411140442.\n",
+      "Step: 60000/100000, Loss: 0.09025183320045471.\n",
+      "Step: 61000/100000, Loss: 0.21367806196212769.\n",
+      "Step: 62000/100000, Loss: 0.06895419955253601.\n",
+      "Step: 63000/100000, Loss: 0.14567255973815918.\n",
+      "Step: 64000/100000, Loss: 0.18438486754894257.\n",
+      "Step: 65000/100000, Loss: 0.11639232933521271.\n",
+      "Step: 66000/100000, Loss: 0.06631053984165192.\n",
+      "Step: 67000/100000, Loss: 0.11763929575681686.\n",
+      "Step: 68000/100000, Loss: 0.046494871377944946.\n",
+      "Step: 69000/100000, Loss: 0.14044761657714844.\n",
+      "Step: 70000/100000, Loss: 0.1277393102645874.\n",
+      "Step: 71000/100000, Loss: 0.154437854886055.\n",
+      "Step: 72000/100000, Loss: 0.15087449550628662.\n",
+      "Step: 73000/100000, Loss: 0.05043340474367142.\n",
+      "Step: 74000/100000, Loss: 0.3183276355266571.\n",
+      "Step: 75000/100000, Loss: 0.15685151517391205.\n",
+      "Step: 76000/100000, Loss: 0.13796621561050415.\n",
+      "Step: 77000/100000, Loss: 0.1036764532327652.\n",
+      "Step: 78000/100000, Loss: 0.08222786337137222.\n",
+      "Step: 79000/100000, Loss: 0.1525675356388092.\n",
+      "Step: 80000/100000, Loss: 0.06328584253787994.\n",
+      "Step: 81000/100000, Loss: 0.1235610619187355.\n",
+      "Step: 82000/100000, Loss: 0.03093503788113594.\n",
+      "Step: 83000/100000, Loss: 0.07480041682720184.\n",
+      "Step: 84000/100000, Loss: 0.016707731410861015.\n",
+      "Step: 85000/100000, Loss: 0.0491723008453846.\n",
+      "Step: 86000/100000, Loss: 0.0650872215628624.\n",
+      "Step: 87000/100000, Loss: 0.08738622069358826.\n",
+      "Step: 88000/100000, Loss: 0.10671466588973999.\n",
+      "Step: 89000/100000, Loss: 0.11922930181026459.\n",
+      "Step: 90000/100000, Loss: 0.1234014481306076.\n",
+      "Step: 91000/100000, Loss: 0.08588997274637222.\n",
+      "Step: 92000/100000, Loss: 0.036773063242435455.\n",
+      "Step: 93000/100000, Loss: 0.03425668179988861.\n",
+      "Step: 94000/100000, Loss: 0.21202465891838074.\n",
+      "Step: 95000/100000, Loss: 0.26020047068595886.\n",
+      "Step: 96000/100000, Loss: 0.154791459441185.\n",
+      "Step: 97000/100000, Loss: 0.1340092271566391.\n",
+      "Step: 98000/100000, Loss: 0.11398129910230637.\n",
+      "Step: 99000/100000, Loss: 0.16246598958969116.\n",
+      "Step: 99999/100000, Loss: 0.04668630287051201.\n"
+     ]
+    }
+   ],
    "source": [
     "key = jr.PRNGKey(2003)\n",
     "\n",
@@ -446,7 +570,7 @@
     "    b2=beta2,\n",
     ")\n",
     "\n",
-    "state = optimizer.init(eqx.filter(model, eqx.is_array))\n",
+    "state = optimizer.init(eqx.filter(model, eqx.is_inexact_array))\n",
     "\n",
     "model, state, losses = train(model, optimizer, state, trainloader, num_steps, key=key)"
    ]
@@ -462,7 +586,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {
     "colab": {
      "base_uri": "https://localhost:8080/"
@@ -476,7 +600,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Accuracy: 76.2%\n"
+      "Accuracy: 79.13661858974359%\n"
      ]
     }
    ],
@@ -516,9 +640,9 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "jax",
    "language": "python",
-   "name": "python3"
+   "name": "jax"
   },
   "language_info": {
    "codemirror_mode": {
@@ -530,9 +654,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.6"
+   "version": "3.11.4"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 4
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -104,6 +104,7 @@ nav:
             - Generative score-based diffusion: 'examples/score_based_diffusion.ipynb'
             - BERT language model: 'examples/bert.ipynb'
             - U-Net implementation: 'examples/unet.ipynb'
+            - Vision transformer: 'examples/vision_transformer.ipynb'
             - Image GAN: 'examples/deep_convolutional_gan.ipynb'
         - Features:
             - Freezing parameters: 'examples/frozen_layer.ipynb'


### PR DESCRIPTION
This builds on #483. The main changes here are to:
- Have two separate `LayerNorm` layers, rather than sharing weights between the two.
- Compute layer normalisation separately for each patch, rather than across every channel simultaneously.

These improve test accuracy from 76% to 79%.

Other than that:
- Added the example to `mkdocs.yml` so that it appears in the rendered docs.
- Tweaked the new LayerNorm error message to be readable. (I was hitting it when running the original implementation. Likely a bug of the form that this new error was designed to catch!)

(CC @ahmed-alllam)