### PR TITLE
AbstractVar+pyright should now work

### DIFF
--- a/equinox/_better_abstract.py
+++ b/equinox/_better_abstract.py
@@ -8,7 +8,6 @@ is the public API. But the two pieces aren't directly related under-the-hood.)
 import abc
 import dataclasses
 from typing import (
-    Annotated,
     ClassVar,
     Generic,
     get_args,
@@ -23,7 +22,9 @@ _T = TypeVar("_T")
 
 
 if TYPE_CHECKING:
-    AbstractVar: TypeAlias = Annotated[_T, "AbstractVar"]
+    # Deliberately confuse pyright into treating this as `Unknown`.
+    # Then it won't complain when folks override with a concrete variable in a subclass.
+    AbstractVar: TypeAlias = getattr(abc, "foo" + "bar")  # pyright: ignore
     from typing import ClassVar as AbstractClassVar
 else:
 


### PR DESCRIPTION
This is a silly hack. Our AbstractVars are basically an extension to the type system that pyright doesn't know about. So in order to stop it complaining about being overriden by concrete types later, we just make it uncheckable whilst still abstract.

(jaxtyping.PyTree uses the same hack.)