### PR TITLE
Fix scan-over-layers example in docs

### DIFF
--- a/docs/tricks.md
+++ b/docs/tricks.md
@@ -213,7 +213,7 @@ class TenMLPs(eqx.Module):
     
         def f(_x, _dynamic_mlp):
             mlp = eqx.combine(_dynamic_mlp, static_mlps)
-            return mlp(x), None
+            return mlp(_x), None
     
         out, _ = lax.scan(f, x, dynamic_mlps)
         return out


### PR DESCRIPTION
The [scan-over-layers example](https://docs.kidger.site/equinox/tricks/#improve-compilation-speed-with-scan-over-layers) in the tricks section of the docs currently outputs just the result of the final MLP acting on the input. Changing `mlp(x)` to `mlp(_x)` inside the scan function `f` leads to the intended behavior.