### PR TITLE
Enumerations now use a fully-stringified type annotation.

### DIFF
--- a/equinox/_enum.py
+++ b/equinox/_enum.py
@@ -138,7 +138,9 @@ following entries:
 
 class EnumerationItem(Module):
     _value: Int[Union[Array, np.ndarray], ""]
-    _enumeration: type["Enumeration"] = field(static=True)
+    # Should have annotation `"type[Enumeration]"`, but this fails due to beartype bug
+    # #289.
+    _enumeration: Any = field(static=True)
 
     def __eq__(self, other) -> Bool[Array, ""]:  # pyright: ignore
         if isinstance(other, EnumerationItem):

--- a/equinox/_module.py
+++ b/equinox/_module.py
@@ -622,6 +622,8 @@ went uncaught, possibly leading to silently wrong behaviour.
     # Appears in AbstractVar error messages
     _InitableModule.__name__ = cls.__name__
     _InitableModule.__qualname__ = cls.__qualname__
+    # I don't have a specific use-case for this but it's probably good practice.
+    _InitableModule.__module__ = cls.__module__
 
     return _InitableModule
 

--- a/equinox/nn/_attention.py
+++ b/equinox/nn/_attention.py
@@ -30,7 +30,7 @@ def dot_product_attention_weights(
             )
         logits = jnp.where(mask, logits, jnp.finfo(logits.dtype).min)
 
-    return jax.nn.softmax(logits, axis=-1)
+    return jax.nn.softmax(logits, axis=-1)  # pyright: ignore
 
 
 def dot_product_attention(


### PR DESCRIPTION
This is mostly for simplicitly/compatibility with other libraries later down the line -- partially-stringified type annotations are a bit of a nightmare to parse.