### PR TITLE
Added RMSNorm

### DIFF
--- a/docs/api/nn/normalisation.md
+++ b/docs/api/nn/normalisation.md
@@ -29,3 +29,11 @@
         members:
             - __init__
             - __call__
+
+---
+
+::: equinox.nn.RMSNorm
+    selection:
+        members:
+            - __init__
+            - __call__

--- a/equinox/nn/__init__.py
+++ b/equinox/nn/__init__.py
@@ -16,7 +16,11 @@ from ._embedding import Embedding as Embedding
 from ._inference import inference_mode as inference_mode
 from ._linear import Identity as Identity, Linear as Linear
 from ._mlp import MLP as MLP
-from ._normalisation import GroupNorm as GroupNorm, LayerNorm as LayerNorm
+from ._normalisation import (
+    GroupNorm as GroupNorm,
+    LayerNorm as LayerNorm,
+    RMSNorm as RMSNorm,
+)
 from ._pool import (
     AdaptiveAvgPool1d as AdaptiveAvgPool1d,
     AdaptiveAvgPool2d as AdaptiveAvgPool2d,

--- a/equinox/nn/_normalisation.py
+++ b/equinox/nn/_normalisation.py
@@ -372,18 +372,11 @@ class RMSNorm(Module):
                 "`RMSNorm(shape)(x)` must satisfy the invariant `shape == x.shape`"
                 f"Received `shape={self.shape} and `x.shape={x.shape}`. You might need "
                 "to replace `rms_norm(x)` with `jax.vmap(rms_norm)(x)`.\n"
-                "\n"
-                "If this is a new error for you, it might be because this became "
-                "stricter in Equinox v0.11.0. Previously all that was required is that "
-                "`x.shape` ended with `shape`. However, this turned out to be a "
-                "frequent source of bugs, so we made the check stricter!"
             )
         inv_rms = jax.lax.rsqrt(jnp.sum(x**2) + self.eps)
-        out = inv_rms * x
+        out = jnp.sqrt(self.dim) * inv_rms * x
         if self.use_weight:
             out = self.weight * out
-        else:
-            out = jnp.sqrt(self.dim) * out
         if self.use_bias:
             out = out + self.bias
         if state is sentinel:


### PR DESCRIPTION
Added RMS normalisation, a simplified variant of layer norm which computes

$$ \frac{x}{\sqrt{\varepsilon + \frac{1}{n}\Vert x \Vert^2_2}} \gamma + \beta$$

where $n = \dim(x)$ and $\gamma$ is a learnable array if `use_weight=True`, or $\sqrt{n}$ if `use_weight=False`. $\beta$ is an optional bias term. This has become somewhat popular in transformers for being simpler than layer norm but having similar/better performance.

Originally proposed in [this paper](https://arxiv.org/abs/1910.07467), see [Lucidrain's dicussion](https://github.com/lucidrains/x-transformers#root-mean-square-layer-normalization) about this for more details.

The defaults `use_weight=False` and `use_bias=False` are intentional. This is meant to be a faster and simpler version of layer norm, so leaving these off by default made the most sense to me.