### PR TITLE
CWL now compatible with partially nondifferentiable body functions.

### DIFF
--- a/equinox/internal/_loop/common.py
+++ b/equinox/internal/_loop/common.py
@@ -1,4 +1,4 @@
-from typing import Any, Union
+from typing import Any
 
 import jax
 import jax.core
@@ -8,7 +8,7 @@ import jax.interpreters.mlir as mlir
 import jax.lax as lax
 import jax.numpy as jnp
 import jax.tree_util as jtu
-from jaxtyping import Array, Bool, Shaped
+from jaxtyping import Array, Bool
 
 from ..._filters import combine, is_array, partition
 from ..._module import field, Module
@@ -248,7 +248,8 @@ def _maybe_set(pred, xs, x, i, *, kwargs, makes_false_steps):
 
 
 class _Buffer(Module):
-    _array: Union[Shaped[Array, "..."], "_Buffer"]
+    # annotation removed because beartype can't handle the forward reference.
+    _array: Any  # Union[Shaped[Array, "..."], _Buffer]
     _pred: Bool[Array, ""]
     _tag: object = field(static=True)
     _makes_false_steps: bool = field(static=True)

--- a/equinox/nn/_normalisation.py
+++ b/equinox/nn/_normalisation.py
@@ -50,7 +50,7 @@ class LayerNorm(Module):
 
     """
 
-    shape: tuple[int] = field(static=True)
+    shape: tuple[int, ...] = field(static=True)
     eps: float = field(static=True)
     use_weight: bool = field(static=True)
     use_bias: bool = field(static=True)

--- a/tests/test_while_loop.py
+++ b/tests/test_while_loop.py
@@ -712,6 +712,17 @@ def test_symbolic_zero(capfd):
     ) in text
 
 
+def test_disable_jit():
+    def cond_fun(carry):
+        return True
+
+    def body_fun(carry):
+        return 5
+
+    with jax.disable_jit():
+        eqxi.while_loop(cond_fun, body_fun, 3, max_steps=3, kind="checkpointed")
+
+
 def test_buffer_index():
     def cond_fun(carry):
         return True


### PR DESCRIPTION
This is fairly finickity! So, the checkpointed while loop (CWL) needs
to figure out which cotangents to propagate backward. There are two
criteria for this:
(1) only some inputs actually need cotangents at all. Any parts of the
    carry that are unrelated to those inputs can be skipped.
(2) some cotangents might be resolvable as symbolic zeros, and can thus
    be skipped.

Previously, we handled (2) but did not handle (1). In practice this
was mostly fine. We just pretended all (inexact) inputs needed
cotangents, and let anything superfluous get DCE'd at the end.

However, this has one niche problem, which is that it is incompatible
with `eqxi.nondifferentiable` -- which is used to mark an inexact
input as nondifferentiable, and raise a trace-time error if we attempt
to differentiate it.

With this change, we're now a bit more careful: we run an additional
fixed-point iteration to check which inputs need cotangents, and then
skip the rest.

Note that this extra fixed-point iteration is actually done using a
JVP. This is designed to mirror what JAX does internally: perturbations
are tracked using a fixed-point iteration inside the JVP rule for
`lax.{while_loop,scan}`. I considered some other alternatives (using
VJPs or `pe.dce_jaxpr`) but I think those either fail in corner cases
or run into catch-22s.
