### PR TITLE
EQX_ON_ERROR=breakpoint improvements.

### DIFF
--- a/equinox/_config.py
+++ b/equinox/_config.py
@@ -16,3 +16,8 @@ if EQX_ON_ERROR == "breakpoint":
         "The environment variable `EQX_ON_ERROR=breakpoint` is currently set. Note "
         "that this should only be used for debugging, as it slows down runtime speed."
     )
+
+
+EQX_ON_ERROR_BREAKPOINT_FRAMES = os.environ.get("EQX_ON_ERROR_BREAKPOINT_FRAMES", None)
+if EQX_ON_ERROR_BREAKPOINT_FRAMES is not None:
+    EQX_ON_ERROR_BREAKPOINT_FRAMES = int(EQX_ON_ERROR_BREAKPOINT_FRAMES)

--- a/equinox/_errors.py
+++ b/equinox/_errors.py
@@ -14,7 +14,7 @@ import numpy as np
 from jaxtyping import Array, ArrayLike, Bool, Int, PyTree
 
 from ._ad import filter_custom_jvp
-from ._config import EQX_ON_ERROR
+from ._config import EQX_ON_ERROR, EQX_ON_ERROR_BREAKPOINT_FRAMES
 from ._doc_utils import doc_remove_args
 from ._filters import combine, is_array, partition
 from ._jit import filter_jit
@@ -113,6 +113,8 @@ def _error(x, pred, index, *, msgs, on_error):
                 breakpoint_kwargs["token"] = _index
             if "vectorized" in breakpoint_params:
                 breakpoint_kwargs["vectorized"] = True
+            if EQX_ON_ERROR_BREAKPOINT_FRAMES is not None:
+                breakpoint_kwargs["num_frames"] = EQX_ON_ERROR_BREAKPOINT_FRAMES
             _index = jax.debug.breakpoint(**breakpoint_kwargs)
             return jax.pure_callback(  # pyright: ignore
                 to_nan, struct, _index, vectorized=True

--- a/equinox/_module.py
+++ b/equinox/_module.py
@@ -14,6 +14,7 @@ from collections.abc import Callable
 from typing import Any, cast, Optional, Protocol, TYPE_CHECKING, TypeVar, Union
 from typing_extensions import dataclass_transform, ParamSpec
 
+import jax._src.traceback_util as traceback_util
 import jax.tree_util as jtu
 import numpy as np
 from jaxtyping import Array, Bool, PyTreeDef
@@ -23,6 +24,9 @@ from ._caches import internal_lru_caches
 from ._doc_utils import doc_repr
 from ._pretty_print import tree_pformat
 from ._tree import tree_equal
+
+
+traceback_util.register_exclusion(__file__)
 
 
 _P = ParamSpec("_P")


### PR DESCRIPTION
- Now has a customisable number of frames, according to the
  `EQX_ON_ERROR_BREAKPOINT_FRAMES` environment variable. This is useful
  as JAX has a bug when combining certain operations with many frames
  (https://github.com/google/jax/issues/16732).
- `_module.py` is now excluded tracebacks.
