### PR TITLE
filter_value_and_grad: preserve return type of wrapped function

### DIFF
--- a/equinox/_ad.py
+++ b/equinox/_ad.py
@@ -100,19 +100,20 @@ class _GradWrapper(Module):
 
 
 _Scalar = Union[float, complex, Float[ArrayLike, ""], Complex[ArrayLike, ""]]
+_ScalarTy = TypeVar("_ScalarTy", bound=_Scalar)
 
 
 @overload
 def filter_value_and_grad(
     *, has_aux: Literal[False] = False
-) -> Callable[[Callable[_P, _Scalar]], Callable[_P, tuple[_Scalar, PyTree]]]:
+) -> Callable[[Callable[_P, _ScalarTy]], Callable[_P, tuple[_ScalarTy, PyTree]]]:
     ...
 
 
 @overload
 def filter_value_and_grad(
-    fun: Callable[_P, _Scalar], *, has_aux: Literal[False] = False
-) -> Callable[_P, tuple[_Scalar, PyTree]]:
+    fun: Callable[_P, _ScalarTy], *, has_aux: Literal[False] = False
+) -> Callable[_P, tuple[_ScalarTy, PyTree]]:
     ...
 
 
@@ -120,15 +121,16 @@ def filter_value_and_grad(
 def filter_value_and_grad(
     *, has_aux: Literal[True] = True
 ) -> Callable[
-    [Callable[_P, tuple[_Scalar, _T]]], Callable[_P, tuple[tuple[_Scalar, _T], PyTree]]
+    [Callable[_P, tuple[_ScalarTy, _T]]],
+    Callable[_P, tuple[tuple[_ScalarTy, _T], PyTree]],
 ]:
     ...
 
 
 @overload
 def filter_value_and_grad(
-    fun: Callable[_P, tuple[_Scalar, _T]], *, has_aux: Literal[True] = True
-) -> Callable[_P, tuple[tuple[_Scalar, _T], PyTree]]:
+    fun: Callable[_P, tuple[_ScalarTy, _T]], *, has_aux: Literal[True] = True
+) -> Callable[_P, tuple[tuple[_ScalarTy, _T], PyTree]]:
     ...
 
 


### PR DESCRIPTION
I ran into this while trying to update the RNN tutorial to use `jaxtyping`.

Using a bounded type variable conveys to the type checker that wrapping a function with `filter_value_and_grad` will not change the type of value returned by the original function.

As an example:

Suppose `f` returns a `float`. Let `wrapped = filter_value_and_grad(f)`. Then the return type of `wrapped` is `tuple[_Scalar, PyTree]`, not `tuple[float, PyTree]`, where `_Scalar` is defined here: https://github.com/patrick-kidger/equinox/blob/56bafcb17bbced52974cf8fe0ee84d20cf778e38/equinox/_ad.py#L102

The wrapped function can return a value of a different type so long as it is also a `_Scalar` (like `complex`).

Using the type variable communicates this invariant to the type checker.

I opted not to replace `_Scalar` with `_ScalarTy` throughout the entire file because it doesn't make sense to use a type variable which occurs exclusively arguments or the return value, and there were a few other use sites which do that with `_Scalar`.