### PR TITLE
Enumeration.where(tracer, x, x) is now x.

### DIFF
--- a/equinox/_enum.py
+++ b/equinox/_enum.py
@@ -355,10 +355,13 @@ else:
                 raise ValueError("`where` requires a scalar boolean predicate")
             if isinstance(a, EnumerationItem) and isinstance(b, EnumerationItem):
                 if a._enumeration is cls and b._enumeration is cls:
-                    with jax.ensure_compile_time_eval():
-                        value = jnp.where(pred, a._value, b._value)
-                    cls = cast(type[Enumeration], cls)
-                    return EnumerationItem(value, cls)
+                    if a._value is b._value:
+                        return a
+                    else:
+                        with jax.ensure_compile_time_eval():
+                            value = jnp.where(pred, a._value, b._value)
+                        cls = cast(type[Enumeration], cls)
+                        return EnumerationItem(value, cls)
             name = f"{cls.__module__}.{cls.__qualname__}"
             raise ValueError(
                 f"Arguments to {name}.where(...) must be members of {name}."

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -1,5 +1,6 @@
 import jax
 import jax.numpy as jnp
+import jax.tree_util as jtu
 import pytest
 
 import equinox as eqx
@@ -265,3 +266,18 @@ def test_compile_time_eval():
         assert y
 
     f()
+
+
+def test_where_traced_bool_same_branches():
+    class A(eqxi.Enumeration):
+        a = "hi"
+        b = "bye"
+
+    @jax.jit
+    def f(pred, foo):
+        leaves, treedef = jtu.tree_flatten(foo)
+        bar = jtu.tree_unflatten(treedef, leaves)
+        out = A.where(pred, foo, bar)
+        assert out is foo
+
+    f(True, A.a)


### PR DESCRIPTION
This is useful for keeping things statically resolved for as long as
possible. Even if the predicate is traced, in this scenario we don't
need to promote the output to a tracer.
