### PR TITLE
dev

### DIFF
--- a/docs/api/debug.md
+++ b/docs/api/debug.md
@@ -36,6 +36,12 @@ JAX itself provides the following tools:
 
 ::: equinox.debug.inspect_dce
 
+---
+
+::: equinox.debug.assert_max_traces
+
+::: equinox.debug.get_num_traces
+
 ## Runtime errors
 
 If you are getting a runtime error from [`equinox.error_if`][], then you can control the on-error behaviour via the environment variable `EQX_ON_ERROR`. If ran from `jax.jit` then this will be a long error message starting `jaxlib.xla_extension.XlaRuntimeError: INTERNAL: Generated function failed: CpuCallback error: RuntimeError: ...`; if ran from `eqx.filter_jit` then some of the extra boilerplate will be removed from the error message, and it will simply start with `jaxlib.xla_extension.XlaRuntimeError: ...`.

--- a/docs/api/debug.md
+++ b/docs/api/debug.md
@@ -8,6 +8,12 @@ A common source of NaNs on the forward pass is calling `jnp.log` or `jnp.sqrt` o
 
 A common source of NaNs when backpropagating is when using one of the above operations with a `jnp.where`, for example `y = jnp.where(x > 0, jnp.log(x), 0)`. In this case the NaN is created on the forward pass, but is then masked by the `jnp.where`. Unfortunately, when backpropagating, the order of the `log` and the `where` is flipped -- and the NaN is no longer masked! The solution is to use the "double where" trick: bracket your computation by a `where` on both sides. For this example, `safe_x = jnp.where(x > 0, x, 1); y = jnp.where(x > 0, jnp.log(safe_x), 0)`. This ensures that the NaN is never created in the first place at all.
 
+## Debugging runtime errors
+
+If you are getting a runtime error from [`equinox.error_if`][], then you can control the on-error behaviour via the environment variable `EQX_ON_ERROR`. In particular, setting `EQX_ON_ERROR=breakpoint` will open a `jax.debug.breakpoint` where the error arises. See the [runtime errors](./errors.md) for more information and for other values of this environment variable.
+
+If ran from `jax.jit`, then the [`equinox.error_if`][] error will be a long error message starting `INTERNAL: Generated function failed: CpuCallback error: RuntimeError: ...`. You may prefer to use `eqx.filter_jit`, which will remove some of the extra boilerplate from the error message.
+
 ## JAX tools
 
 JAX itself provides the following tools:
@@ -41,9 +47,3 @@ JAX itself provides the following tools:
 ::: equinox.debug.assert_max_traces
 
 ::: equinox.debug.get_num_traces
-
-## Runtime errors
-
-If you are getting a runtime error from [`equinox.error_if`][], then you can control the on-error behaviour via the environment variable `EQX_ON_ERROR`. If ran from `jax.jit` then this will be a long error message starting `jaxlib.xla_extension.XlaRuntimeError: INTERNAL: Generated function failed: CpuCallback error: RuntimeError: ...`; if ran from `eqx.filter_jit` then some of the extra boilerplate will be removed from the error message, and it will simply start with `jaxlib.xla_extension.XlaRuntimeError: ...`.
-
-In particular, setting `EQX_ON_ERROR=breakpoint` will open a `jax.debug.breakpoint` where the error arises. See the [runtime errors](./errors.md) for more information and for other values of this environment variable.

--- a/equinox/_ad.py
+++ b/equinox/_ad.py
@@ -633,7 +633,8 @@ class filter_custom_jvp:
             "previously passed to indicate a symbolic zero tangent for all objects "
             "that weren't inexact arrays, but all inexact arrays always had an "
             "array-valued tangent. Now, `None` may also be passed to indicate that an "
-            "inexact array has a symbolic zero tangent."
+            "inexact array has a symbolic zero tangent.",
+            stacklevel=2,
         )
 
         def _fn_jvp(args, t_args, **kwargs):
@@ -813,6 +814,7 @@ class filter_custom_vjp:
             "    all objects that weren't inexact arrays, but all inexact arrays "
             "    always had an array-valued gradient. Now, `None` may also be passed "
             "    to indicate that an inexact array has a symbolic zero gradient.",
+            stacklevel=2,
         )
 
         def _fn_fwd(perturbed, vjp_arg, *args, **kwargs):

--- a/equinox/_ad.py
+++ b/equinox/_ad.py
@@ -812,7 +812,7 @@ class filter_custom_vjp:
             "- `None` was previously passed to indicate a symbolic zero gradient for "
             "    all objects that weren't inexact arrays, but all inexact arrays "
             "    always had an array-valued gradient. Now, `None` may also be passed "
-            "    to indicate that an inexact array has a symbolic zero gradient."
+            "    to indicate that an inexact array has a symbolic zero gradient.",
         )
 
         def _fn_fwd(perturbed, vjp_arg, *args, **kwargs):

--- a/equinox/_better_abstract.py
+++ b/equinox/_better_abstract.py
@@ -216,6 +216,7 @@ class ABCMeta(abc.ABCMeta):
         return cls
 
     def __call__(cls, *args, **kwargs):
+        __tracebackhide__ = True
         if len(cls.__abstractclassvars__) > 0:  # pyright: ignore
             abstract_class_vars = set(cls.__abstractclassvars__)  # pyright: ignore
             raise TypeError(

--- a/equinox/_enum.py
+++ b/equinox/_enum.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Any, cast, TYPE_CHECKING, Union
 
 import jax._src.traceback_util as traceback_util
@@ -36,9 +37,11 @@ def _store(
         our_index = our_item._value.item()
         existing_message = index_to_message[our_index]
         if message != existing_message:
-            raise ValueError(
-                f"Enumeration has duplicate incompatible values for {name}"
+            warnings.warn(
+                f"Enumeration has duplicate incompatible values for {name}. Using the "
+                f"latest, which is '{message}'."
             )
+        index_to_message[our_index] = message
         return our_index
 
 

--- a/equinox/_errors.py
+++ b/equinox/_errors.py
@@ -192,12 +192,21 @@ def error_if(
     errors should be handled. Possible values are:
 
     - `EQX_ON_ERROR=raise` will raise a runtime error.
-    - `EQX_ON_ERROR=breakpoint` will open a debugger. Note that this option may prevent
-        certain compiler optimisations, so permanently fixing this value is not
-        recommended. You will need to also pass the `-s` flag to `pytest`, if you are
-        also using that.
     - `EQX_ON_ERROR=nan` will return `NaN` instead of `x`, and then continue the
         computation.
+    - `EQX_ON_ERROR=breakpoint` will open a debugger.
+        - Note that this option may prevent certain compiler optimisations, so
+            permanently fixing this value is not recommended.
+        - You will need to also pass the `-s` flag to `pytest`, if you are
+            also using that.
+        - This will sometimes raise a trace-time error due to JAX bug
+            [#16732](https://github.com/google/jax/issues/16732). (Bugs whilst debugging
+            bugs, eek!) If this happens, then it can be worked around by additionally
+            setting the `EQX_ON_ERROR_BREAKPOINT_FRAMES` variable to a small integer,
+            which specifies how many frames upwards the debugger should capture. The
+            JAX bug is triggered when taking too many frames.
+
+    After changing an environment variable, the Python process must be restarted.
 
     **Returns:**
 

--- a/equinox/_jit.py
+++ b/equinox/_jit.py
@@ -12,6 +12,7 @@ from jaxtyping import PyTree
 
 from ._compile_utils import (
     compile_cache,
+    get_fn_names,
     hashable_combine,
     hashable_filter,
     hashable_partition,
@@ -21,7 +22,7 @@ from ._custom_types import sentinel
 from ._deprecate import deprecated_0_10
 from ._doc_utils import doc_remove_args
 from ._filters import combine, is_array, partition
-from ._module import Module, module_update_wrapper, Partial, Static
+from ._module import field, Module, module_update_wrapper, Partial, Static
 
 
 traceback_util.register_exclusion(__file__)
@@ -33,11 +34,18 @@ _T = TypeVar("_T")
 
 @compile_cache
 def _filter_jit_cache(fun_names, jitkwargs):
-    def fun_wrapped(dynamic, static):
-        dynamic_fun, dynamic_spec = dynamic
-        static_fun, static_spec = static
+    def fun_wrapped(dynamic_donate, dynamic_nodonate, static):
+        dynamic_dict = dict(**dynamic_donate, **dynamic_nodonate)
+        dynamic_fun = dynamic_dict.pop("fun")
+        dynamic_first = dynamic_dict.pop("first")
+        dynamic_rest = dynamic_dict.pop("rest")
+        static_fun, static_first, static_rest = static
         fun = hashable_combine(dynamic_fun, static_fun)
-        args, kwargs = hashable_combine(dynamic_spec, static_spec)
+        first_arg = hashable_combine(dynamic_first, static_first)
+        rest_args, kwargs = hashable_combine(dynamic_rest, static_rest)
+        assert type(rest_args) is tuple
+        *args, dummy_arg = (first_arg,) + rest_args
+        assert dummy_arg is None
         out = fun(*args, **kwargs)
         dynamic_out, static_out = partition(out, is_array)
         return dynamic_out, Static(static_out)
@@ -45,7 +53,7 @@ def _filter_jit_cache(fun_names, jitkwargs):
     fun_name, fun_qualname = fun_names
     fun_wrapped.__name__ = fun_name
     fun_wrapped.__qualname__ = fun_qualname
-    return jax.jit(fun_wrapped, static_argnums=1, **jitkwargs)
+    return jax.jit(fun_wrapped, donate_argnums=0, static_argnums=2, **jitkwargs)
 
 
 def _bind(signature, args, kwargs):
@@ -56,12 +64,37 @@ def _bind(signature, args, kwargs):
     return args, kwargs
 
 
-def _preprocess(info, args, kwargs):
-    signature, dynamic_fun, static_fun = info
+def _preprocess(info, args, kwargs, return_static: bool = False):
+    signature, dynamic_fun, static_fun, donate_first, donate_rest = info
     args, kwargs = _bind(signature, args, kwargs)
-    dynamic_spec = hashable_filter((args, kwargs), is_array)
-    dynamic = (dynamic_fun, dynamic_spec)
-    return dynamic
+    # add dummy to avoid special casing `len(args) == 0`.
+    args = args + (None,)
+    first_arg = args[0]
+    rest_args = args[1:]
+    if return_static:
+        dynamic_first, static_first = hashable_partition(first_arg, is_array)
+        dynamic_rest, static_rest = hashable_partition((rest_args, kwargs), is_array)
+    else:
+        dynamic_first = hashable_filter(first_arg, is_array)
+        dynamic_rest = hashable_filter(rest_args, is_array)
+    dynamic_donate = dict()
+    dynamic_nodonate = dict()
+    if donate_first:
+        dynamic_donate["first"] = dynamic_first
+    else:
+        dynamic_nodonate["first"] = dynamic_first
+    if donate_rest:
+        dynamic_donate["fun"] = dynamic_fun
+        dynamic_donate["rest"] = dynamic_rest
+    else:
+        dynamic_nodonate["fun"] = dynamic_fun
+        dynamic_nodonate["rest"] = dynamic_rest
+
+    if return_static:
+        static = (static_fun, static_first, static_rest)  # pyright: ignore
+        return dynamic_donate, dynamic_nodonate, static
+    else:
+        return dynamic_donate, dynamic_nodonate
 
 
 def _postprocess(out):
@@ -124,37 +157,46 @@ def _modify_traceback(e: Exception):
 
 
 class _JitWrapper(Module):
-    _signature: inspect.Signature
-    _dynamic_fun: PyTree
-    _static_fun: Any
-    _cached: Any
-    _filter_warning: bool
+    fn: str  # this attribute exists solely to give a nice repr
+    _signature: inspect.Signature = field(static=True, repr=False)
+    _dynamic_fun: PyTree = field(repr=False)
+    _static_fun: Any = field(static=True, repr=False)
+    _cached: Any = field(static=True, repr=False)
+    filter_warning: bool = field(static=True)
+    donate_first: bool = field(static=True)
+    donate_rest: bool = field(static=True)
 
     @property
     def __wrapped__(self):
         return hashable_combine(self._dynamic_fun, self._static_fun)
 
     def _call(self, is_lower, args, kwargs):
-        args, kwargs = _bind(self._signature, args, kwargs)
-        dynamic_spec, static_spec = hashable_partition((args, kwargs), is_array)
-        dynamic = (self._dynamic_fun, dynamic_spec)
-        static = (self._static_fun, static_spec)
+        info = (
+            self._signature,
+            self._dynamic_fun,
+            self._static_fun,
+            self.donate_first,
+            self.donate_rest,
+        )
+        dynamic_donate, dynamic_nodonate, static = _preprocess(  # pyright: ignore
+            info, args, kwargs, return_static=True
+        )
         if is_lower:
             return Lowered(
-                self._cached.lower(dynamic, static),
-                (self._signature, self._dynamic_fun, self._static_fun),
+                self._cached.lower(dynamic_donate, dynamic_nodonate, static),
+                info,
                 _preprocess,  # pyright: ignore
                 _postprocess,  # pyright: ignore
             )
         else:
-            if self._filter_warning is True:
+            if self.filter_warning:
                 with warnings.catch_warnings():
                     warnings.filterwarnings(
                         "ignore", message="Some donated buffers were not usable*"
                     )
-                    out = self._cached(dynamic, static)
+                    out = self._cached(dynamic_donate, dynamic_nodonate, static)
             else:
-                out = self._cached(dynamic, static)
+                out = self._cached(dynamic_donate, dynamic_nodonate, static)
             return _postprocess(out)
 
     def __call__(self, /, *args, **kwargs):
@@ -197,21 +239,33 @@ class _JitWrapper(Module):
 
 @overload
 def filter_jit(
-    *, donate: Literal["all", "warn", "none"] = "none"
+    *,
+    donate: Literal[
+        "all", "all-except-first", "warn", "warn-except-first", "none"
+    ] = "none",
 ) -> Callable[[Callable[_P, _T]], Callable[_P, _T]]:
     ...
 
 
 @overload
 def filter_jit(
-    fun: Callable[_P, _T], *, donate: Literal["all", "warn", "none"] = "none"
+    fun: Callable[_P, _T],
+    *,
+    donate: Literal[
+        "all", "all-except-first", "warn", "warn-except-first", "none"
+    ] = "none",
 ) -> Callable[_P, _T]:
     ...
 
 
 @doc_remove_args("jitkwargs")
 def filter_jit(
-    fun=sentinel, *, donate: Literal["all", "warn", "none"] = "none", **jitkwargs
+    fun=sentinel,
+    *,
+    donate: Literal[
+        "all", "all-except-first", "warn", "warn-except-first", "none"
+    ] = "none",
+    **jitkwargs,
 ):
     """An easier-to-use version of `jax.jit`. All JAX and NumPy arrays are traced, and
     all other types are held static.
@@ -222,7 +276,10 @@ def filter_jit(
     - `donate` indicates whether the buffers of JAX arrays are donated or not. It
         should either be:
         - `'all'`: donate all arrays and suppress all warnings about unused buffers;
+        - `'all-except-first'`: donate all arrays except for those in the first
+            argument, and suppress all warnings about unused buffers;
         - `'warn'`: as above, but don't suppress unused buffer warnings;
+        - `'warn-except-first'`: as above, but don't suppress unused buffer warnings;
         - `'none'`: no buffer donation. (This the default.)
 
     **Returns:**
@@ -255,8 +312,9 @@ def filter_jit(
         can do this by wrapping them into a JAX array: `jnp.asarray(x)`.
 
         If you want to donate only some arguments then this can be done by setting
-        `filter_jit(donate="all")` and then  `jnp.copy`ing any arguments you do not want
-        to donate before passing them in.
+        `filter_jit(donate="all-except-first")` and then passing all arguments that you
+        don't want to donate through the first argument. (Packing multiple values into
+        a tuple if necessary.)
     """
 
     if fun is sentinel:
@@ -276,22 +334,44 @@ def filter_jit(
         )
     signature = inspect.signature(fun)
 
-    if donate not in {"all", "warn", "none"}:
+    if donate == "all":
+        filter_warning = True
+        donate_first = True
+        donate_rest = True
+    elif donate == "all-except-first":
+        filter_warning = True
+        donate_first = False
+        donate_rest = True
+    elif donate == "warn":
+        filter_warning = False
+        donate_first = True
+        donate_rest = True
+    elif donate == "warn-except-first":
+        filter_warning = False
+        donate_first = False
+        donate_rest = True
+    elif donate == "none":
+        filter_warning = False
+        donate_first = False
+        donate_rest = False
+    else:
         raise ValueError(
-            "`filter_jit(..., donate=...)` must be one of 'all', 'warn', or 'none'"
+            "`filter_jit(..., donate=...)` must be one of 'all', 'all-except-first', "
+            "'warn', 'warn-except-first', or 'none'."
         )
-    filter_warning = True if donate == "all" else False
-    if donate != "none":
-        jitkwargs["donate_argnums"] = (0,)
 
+    _, name = get_fn_names(fun)
     dynamic_fun, static_fun = hashable_partition(fun, is_array)
     cached = _filter_jit_cache(fun, jitkwargs)
 
     jit_wrapper = _JitWrapper(
+        fn=name,
         _signature=signature,
         _dynamic_fun=dynamic_fun,
         _static_fun=static_fun,
         _cached=cached,
-        _filter_warning=filter_warning,
+        filter_warning=filter_warning,
+        donate_first=donate_first,
+        donate_rest=donate_rest,
     )
     return module_update_wrapper(jit_wrapper)

--- a/equinox/_jit.py
+++ b/equinox/_jit.py
@@ -171,6 +171,7 @@ class _JitWrapper(Module):
         return hashable_combine(self._dynamic_fun, self._static_fun)
 
     def _call(self, is_lower, args, kwargs):
+        __tracebackhide__ = True
         info = (
             self._signature,
             self._dynamic_fun,
@@ -200,6 +201,7 @@ class _JitWrapper(Module):
             return _postprocess(out)
 
     def __call__(self, /, *args, **kwargs):
+        __tracebackhide__ = True
         try:
             return self._call(False, args, kwargs)
         except XlaRuntimeError as e:

--- a/equinox/_module.py
+++ b/equinox/_module.py
@@ -292,6 +292,7 @@ class _ModuleMeta(ABCMeta):  # pyright: ignore
 
             @ft.wraps(init)  # pyright: ignore
             def __init__(self, *args, **kwargs):
+                __tracebackhide__ = True
                 init(self, *args, **kwargs)
                 # Same `if` trick as with `__post_init__`.
                 if self.__class__.__init__ is cls.__init__:
@@ -865,6 +866,7 @@ class BoundMethod(Module):
     __self__: Module
 
     def __call__(self, *args, **kwargs):
+        __tracebackhide__ = True
         return self.__func__(self.__self__, *args, **kwargs)
 
     @property

--- a/equinox/_module.py
+++ b/equinox/_module.py
@@ -493,6 +493,11 @@ class _ModuleMeta(ABCMeta):  # pyright: ignore
         else:
             return value
 
+    def __setattr__(cls, item, value):
+        if _not_magic(item) and inspect.isfunction(value):
+            value = _wrap_method(value)
+        super().__setattr__(item, value)
+
 
 if TYPE_CHECKING:
 

--- a/equinox/_vmap_pmap.py
+++ b/equinox/_vmap_pmap.py
@@ -487,7 +487,7 @@ def _preprocess(info, args, kwargs):
     maybe_dummy = _common_preprocess(axis_size, kwargs)
     del kwargs
     dynamic = filter((fun, args, maybe_dummy, out_axes), is_array)
-    return dynamic
+    return (dynamic,)
 
 
 def _postprocess(out):
@@ -601,7 +601,15 @@ def filter_pmap(
     donate: Literal["all", "warn", "none"] = "none",
     **pmapkwargs,
 ):
-    """Parallelises a function. By default, all JAX/NumPy arrays are parallelised down
+    """
+    !!! warning
+
+        JAX has now added more powerful parallelism APIs directly to the JIT interface.
+        As such, using [`equinox.filter_jit`][] with sharded inputs is now recommended
+        over `filter_pmap`. See also the
+        [parallelism example](../../../examples/parallelism/).
+
+    Parallelises a function. By default, all JAX/NumPy arrays are parallelised down
     their leading axis (i.e. axis index 0), and all other types are broadcast.
 
     `jax.pmap`, and thus `equinox.filter_pmap`, also compiles their function in the same

--- a/equinox/debug/__init__.py
+++ b/equinox/debug/__init__.py
@@ -2,3 +2,7 @@ from ._announce_transform import announce_transform as announce_transform
 from ._backward_nan import backward_nan as backward_nan
 from ._breakpoint_if import breakpoint_if as breakpoint_if
 from ._dce import inspect_dce as inspect_dce, store_dce as store_dce
+from ._max_traces import (
+    assert_max_traces as assert_max_traces,
+    get_num_traces as get_num_traces,
+)

--- a/equinox/debug/_max_traces.py
+++ b/equinox/debug/_max_traces.py
@@ -1,0 +1,144 @@
+import functools as ft
+import weakref
+from collections.abc import Callable
+from typing import Optional, overload, TypeVar
+from typing_extensions import ParamSpec
+
+from .._custom_types import sentinel
+from .._module import field, Module, module_update_wrapper
+
+
+_T = TypeVar("_T")
+_P = ParamSpec("_P")
+
+
+# If we wanted we could actually store this directly on the `_AssertMaxTraces` object.
+# Replace `tag` with a list of a single integer, `[0]`, and propagate the list as static
+# metadata so that even after flattening and unflattening they share a single counter.
+#
+# In practice we do it this way to make it abundantly clear that this counter is shared
+# across cloned (flattened+unflattened) instances.
+_traces = weakref.WeakKeyDictionary()
+
+
+class _Weakrefable:
+    __slots__ = ("__weakref__",)
+
+
+class _AssertMaxTraces(Module):
+    fn: Callable
+    max_traces: Optional[int] = field(static=True)
+    tag: _Weakrefable = field(static=True)
+
+    def __init__(self, fn, max_traces):
+        self.fn = fn
+        self.max_traces = max_traces
+        self.tag = _Weakrefable()
+        _traces[self.tag] = 0
+
+    @property
+    def __wrapped__(self):
+        return self.fn
+
+    def __call__(self, *args, **kwargs):
+        num_traces = _traces[self.tag] = _traces[self.tag] + 1
+        if self.max_traces is not None and num_traces > self.max_traces:
+            raise RuntimeError(
+                f"{self.fn} can only be traced {self.max_traces} times. However, "
+                f"it is has now been traced {num_traces} times."
+            )
+        return self.fn(*args, **kwargs)
+
+
+@overload
+def assert_max_traces(
+    fn: Callable[_P, _T], *, max_traces: Optional[int]
+) -> Callable[_P, _T]:
+    ...
+
+
+@overload
+def assert_max_traces(
+    *, max_traces: Optional[int]
+) -> Callable[[Callable[_P, _T]], Callable[_P, _T]]:
+    ...
+
+
+def assert_max_traces(fn: Callable = sentinel, *, max_traces: Optional[int]):
+    """Asserts that the wrapped callable is not called more than `max_traces` times.
+
+    The typical use-case for this is to check that a JIT-compiled function is not
+    compiled more than `max_traces` times. (I.e. this function can be used to guard
+    against bugs.) In this case it should be placed within the JIT wrapper.
+
+    !!! Example
+
+        ```python
+        @eqx.filter_jit
+        @eqx.debug.assert_max_traces(max_traces=1)
+        def f(x, y):
+            return x + y
+        ```
+
+    **Arguments:**
+
+    - `fn`: The callable to wrap.
+    - `max_traces`: keyword only argument. The maximum number of calls that are
+        allowed. Can be `None` to allow arbitrarily many calls; in this case the number
+        of calls can still can be found via [`equinox.debug.get_num_traces`][].
+
+    **Returns:**
+
+    A wrapped version of `fn` that tracks the number of times it is called. This will
+    raise a `RuntimeError` if is called more than `max_traces` many times.
+
+    !!! info
+
+        See also
+        [`chex.assert_max_traces`](https://github.com/google-deepmind/chex#jax-tracing-assertions)
+        which provides similar functionality.
+
+        The differences are that (a) Chex's implementation is a bit stricter, as the
+        following will raise:
+        ```python
+        import chex
+        import jax
+
+        def f(x):
+            pass
+
+        f2 = jax.jit(chex.assert_max_traces(f, 1))
+        f3 = jax.jit(chex.assert_max_traces(f, 1))
+
+        f2(1)
+        f3(1)  # will raise, despite the fact that f2 and f3 are different.
+        ```
+        and (b) Equinox's implementation supports non-function callables.
+
+        You may prefer the Chex version if you prefer the stricter raising behaviour of
+        the above code.
+    """
+    if fn is sentinel:
+        return ft.partial(assert_max_traces, max_traces=max_traces)  # pyright: ignore
+    return module_update_wrapper(_AssertMaxTraces(fn, max_traces))
+
+
+def get_num_traces(fn) -> int:
+    """Given a function wrapped in [`equinox.debug.assert_max_traces`][], return the
+    number of times which it has been traced so far.
+    """
+    num_traces = _get_num_traces(fn)
+    if num_traces is None:
+        raise ValueError(
+            f"{fn} does not appear to wrapped with `eqx.debug.assert_max_traces`"
+        )
+    return num_traces
+
+
+def _get_num_traces(fn) -> Optional[int]:
+    if isinstance(fn, _AssertMaxTraces):
+        return _traces[fn.tag]
+    elif hasattr(fn, "__wrapped__"):
+        return _get_num_traces(fn.__wrapped__)
+    else:
+        return None

--- a/equinox/debug/_max_traces.py
+++ b/equinox/debug/_max_traces.py
@@ -47,6 +47,7 @@ class _AssertMaxTraces(Module):
         return self.fn
 
     def __call__(self, *args, **kwargs):
+        __tracebackhide__ = True
         num_traces = _traces[self.tag] = _traces[self.tag] + 1
         arguments = inspect.signature(self.fn).bind(*args, **kwargs).arguments
         if self.max_traces is not None and num_traces > self.max_traces:

--- a/equinox/internal/__init__.py
+++ b/equinox/internal/__init__.py
@@ -52,6 +52,7 @@ from ._finalise_jaxpr import (
     primitive_finalisations as primitive_finalisations,
     register_impl_finalisation as register_impl_finalisation,
 )
+from ._getkey import GetKey as GetKey
 from ._loop import (
     buffer_at_set as buffer_at_set,
     maybe_set_p as maybe_set_p,

--- a/equinox/internal/_getkey.py
+++ b/equinox/internal/_getkey.py
@@ -1,0 +1,44 @@
+import dataclasses
+import random
+from typing import Optional
+
+import jax.random as jr
+from jaxtyping import PRNGKeyArray
+
+
+# This offers reproducability -- the initial seed is printed in the repr so we can see
+# it when a test fails.
+# Note the `eq=False`, which means that `GetKey `objects have `__eq__` and `__hash__`
+# based on object identity.
+@dataclasses.dataclass(eq=False)
+class GetKey:
+    """Designed for use as a fixture in tests.
+
+    !!! Example
+
+        ```python
+        # tests/conftest.py
+
+        @pytest.fixture
+        def getkey():
+            return eqxi.GetKey()
+        ```
+
+    Do not use this in any other context; the random seed generation gives deliberate
+    non-determinism.
+    """
+
+    seed: int
+    call: int
+    key: PRNGKeyArray
+
+    def __init__(self, seed: Optional[int] = None):
+        if seed is None:
+            seed = random.randint(0, 2**31 - 1)
+        self.seed = seed
+        self.call = 0
+        self.key = jr.PRNGKey(seed)
+
+    def __call__(self):
+        self.call += 1
+        return jr.fold_in(self.key, self.call)

--- a/equinox/internal/_loop/common.py
+++ b/equinox/internal/_loop/common.py
@@ -248,7 +248,11 @@ def _maybe_set(pred, xs, x, i, *, kwargs, makes_false_steps):
 
 
 if TYPE_CHECKING:
-    from typing_extensions import Annotated as MaybeBuffer
+    from typing import Annotated, TypeVar
+    from typing_extensions import TypeAlias
+
+    _T = TypeVar("_T")
+    MayberBuffer: TypeAlias = Annotated[_T, "AbstractVar"]
 else:
 
     class _MetaBufferItem(type):

--- a/equinox/internal/_loop/common.py
+++ b/equinox/internal/_loop/common.py
@@ -252,7 +252,7 @@ if TYPE_CHECKING:
     from typing_extensions import TypeAlias
 
     _T = TypeVar("_T")
-    MayberBuffer: TypeAlias = Annotated[_T, "AbstractVar"]
+    MaybeBuffer: TypeAlias = Annotated[_T, "MaybeBuffer"]
 else:
 
     class _MetaBufferItem(type):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "equinox"
-version = "0.11.1"
+version = "0.11.2"
 description = "Elegant easy-to-use neural networks in JAX."
 readme = "README.md"
 requires-python ="~=3.9"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,35 +1,15 @@
-import dataclasses
-import random
 import typing
 
-import jax.random as jr
 import pytest
-from jaxtyping import PRNGKeyArray
 
 
 typing.TESTING = True  # pyright: ignore
 
 
-# This offers reproducability -- the initial seed is printed in the repr so we can see
-# it when a test fails.
-# Note the `eq=False`, which means that `_GetKey `objects have `__eq__` and `__hash__`
-# based on object identity.
-@dataclasses.dataclass(eq=False)
-class _GetKey:
-    seed: int
-    call: int
-    key: PRNGKeyArray
-
-    def __init__(self, seed: int):
-        self.seed = seed
-        self.call = 0
-        self.key = jr.PRNGKey(seed)
-
-    def __call__(self):
-        self.call += 1
-        return jr.fold_in(self.key, self.call)
-
-
 @pytest.fixture
 def getkey():
-    return _GetKey(random.randint(0, 2**31 - 1))
+    # Delayed import so that jaxtyping can transform the AST of Equinox before it is
+    # imported, but conftest.py is ran before then.
+    import equinox.internal as eqxi
+
+    return eqxi.GetKey()

--- a/tests/test_ad.py
+++ b/tests/test_ad.py
@@ -550,7 +550,8 @@ def test_filter_custom_vjp_defvjp():
         g0, g1, g2 = g
         return g0 + g1, g2
 
-    f.defvjp(f_fwd, f_bwd)
+    with pytest.warns():
+        f.defvjp(f_fwd, f_bwd)
     jax.grad(lambda x: sum(f(x)))((jnp.array(1.0), jnp.array(1.0)))
 
 

--- a/tests/test_ad.py
+++ b/tests/test_ad.py
@@ -10,7 +10,7 @@ import pytest
 
 import equinox as eqx
 
-from .helpers import shaped_allclose
+from .helpers import tree_allclose
 
 
 def test_filter_grad(getkey):
@@ -26,14 +26,14 @@ def test_filter_grad(getkey):
         return sum
 
     ga, gb = f([a, b])
-    assert shaped_allclose(ga, jnp.ones((2, 3)))
-    assert shaped_allclose(gb, jnp.ones((2, 3)))
+    assert tree_allclose(ga, jnp.ones((2, 3)))
+    assert tree_allclose(gb, jnp.ones((2, 3)))
 
     gtrue, ghi, gobject, ga = f([True, "hi", object(), a])
     assert gtrue is None
     assert ghi is None
     assert gobject is None
-    assert shaped_allclose(ga, jnp.ones((2, 3)))
+    assert tree_allclose(ga, jnp.ones((2, 3)))
 
     gtrue, gdict, (g5, g1), gnp = f(
         [
@@ -46,11 +46,11 @@ def test_filter_grad(getkey):
     assert gtrue is None
     assert list(gdict.keys()) == ["hi"]
     assert isinstance(gdict["hi"], eqx.nn.Linear)
-    assert shaped_allclose(gdict["hi"].weight, jnp.ones((1, 1)))
-    assert shaped_allclose(gdict["hi"].bias, jnp.ones(1))
+    assert tree_allclose(gdict["hi"].weight, jnp.ones((1, 1)))
+    assert tree_allclose(gdict["hi"].bias, jnp.ones(1))
     assert g5 is None
     assert g1 is None
-    assert shaped_allclose(gnp, jnp.ones(2))
+    assert tree_allclose(gnp, jnp.ones(2))
 
 
 # TODO: more comprehensive tests on this.
@@ -62,8 +62,8 @@ def test_filter_value_and_grad(getkey):
         return jnp.sum(x)
 
     val, grad = f(a)
-    assert shaped_allclose(val, jnp.sum(a))
-    assert shaped_allclose(grad, jnp.ones((2, 3)))
+    assert tree_allclose(val, jnp.sum(a))
+    assert tree_allclose(grad, jnp.ones((2, 3)))
 
 
 def test_aux(getkey):
@@ -217,8 +217,8 @@ def test_filter_jvp():
                 return x + 1
 
             primals, tangents = after_jit(eqx.filter_jvp)(f, (1.0,), (1.0,))
-            assert shaped_allclose(primals, jnp.array(2.0))
-            assert shaped_allclose(tangents, jnp.array(1.0))
+            assert tree_allclose(primals, jnp.array(2.0))
+            assert tree_allclose(tangents, jnp.array(1.0))
 
             another_object = object()
 
@@ -281,7 +281,7 @@ def test_filter_jvp():
                     g, primals_in, tangents_in
                 )
                 assert primals_out == true_primals_out
-                assert shaped_allclose(tangents_out, true_tangents_out)
+                assert tree_allclose(tangents_out, true_tangents_out)
 
             bad_tangents_in1 = (jnp.array(5), None, None, None, None, None)
             bad_tangents_in2 = (None, None, None, None, None, object())
@@ -316,7 +316,7 @@ def test_filter_vjp(getkey):
         out_array, out_float, out_sentinel = out
         assert out_array.shape == (3,)
         assert out_array.dtype == jnp.float32
-        assert shaped_allclose(out_float, 2.0)
+        assert tree_allclose(out_float, 2.0)
         assert out_sentinel is sentinel2
         ct_mlp, ct_x, ct_y, ct_sentinel = vjpfun(
             (jnp.array([1.0, 2.0, 3.0]), None, None)
@@ -370,7 +370,7 @@ def test_closure_convert_custom_jvp():
         f = eqx.filter_closure_convert(f, 3.0)
         return call(f, 3.0)
 
-    assert shaped_allclose(run((2.0, 4.0)), (jnp.array(1.0), jnp.array(1.0)))
+    assert tree_allclose(run((2.0, 4.0)), (jnp.array(1.0), jnp.array(1.0)))
 
 
 def test_filter_custom_jvp_no_kwargs():
@@ -392,10 +392,10 @@ def test_filter_custom_jvp_no_kwargs():
         return primal_out, tangent_out
 
     f = lambda a: a**2 + 1
-    assert shaped_allclose(call(f, 1), 2)
-    assert shaped_allclose(call(f, 1.0), 2.0)
-    assert shaped_allclose(call(f, jnp.array(1)), jnp.array(2))
-    assert shaped_allclose(call(f, jnp.array(1.0)), jnp.array(2.0))
+    assert tree_allclose(call(f, 1), 2)
+    assert tree_allclose(call(f, 1.0), 2.0)
+    assert tree_allclose(call(f, jnp.array(1)), jnp.array(2))
+    assert tree_allclose(call(f, jnp.array(1.0)), jnp.array(2.0))
 
     def jvpcall(x, tx):
         def _jvpcall(_x):
@@ -405,8 +405,8 @@ def test_filter_custom_jvp_no_kwargs():
 
     primal_out, tangent_out = jvpcall(2.0, 3.0)
     assert was_called
-    assert shaped_allclose(primal_out, 5.0)
-    assert shaped_allclose(tangent_out, 9.0)
+    assert tree_allclose(primal_out, 5.0)
+    assert tree_allclose(tangent_out, 9.0)
 
 
 def test_filter_custom_jvp_kwargs():
@@ -427,10 +427,10 @@ def test_filter_custom_jvp_kwargs():
         return primal_out, tangent_out
 
     f = lambda a, b: a**2 + b
-    assert shaped_allclose(call(1, 2, fn=f), 3)
-    assert shaped_allclose(call(1.0, 2.0, fn=f), 3.0)
-    assert shaped_allclose(call(jnp.array(1), 2, fn=f), jnp.array(3))
-    assert shaped_allclose(call(jnp.array(1.0), 2, fn=f), jnp.array(3.0))
+    assert tree_allclose(call(1, 2, fn=f), 3)
+    assert tree_allclose(call(1.0, 2.0, fn=f), 3.0)
+    assert tree_allclose(call(jnp.array(1), 2, fn=f), jnp.array(3))
+    assert tree_allclose(call(jnp.array(1.0), 2, fn=f), jnp.array(3.0))
 
     def jvpcall(x, y, tx, ty):
         def _jvpcall(_x, _y):
@@ -440,8 +440,8 @@ def test_filter_custom_jvp_kwargs():
 
     primal_out, tangent_out = jvpcall(2.0, 1.5, 3.0, 4.0)
     assert was_called
-    assert shaped_allclose(primal_out, 5.5)
-    assert shaped_allclose(tangent_out, 13.0)
+    assert tree_allclose(primal_out, 5.5)
+    assert tree_allclose(tangent_out, 13.0)
 
 
 # Checks that we don't get a leaked tracer error from passing an array through

--- a/tests/test_callback.py
+++ b/tests/test_callback.py
@@ -5,7 +5,7 @@ import pytest
 
 import equinox as eqx
 
-from .helpers import shaped_allclose
+from .helpers import tree_allclose
 
 
 def test_callback():
@@ -21,14 +21,14 @@ def test_callback():
     out = eqx.filter_pure_callback(
         f, jnp.array(1.0), sentinel1, result_shape_dtypes=out_struct
     )
-    assert shaped_allclose(out, (jnp.array(2.0), sentinel2))
+    assert tree_allclose(out, (jnp.array(2.0), sentinel2))
 
     @eqx.filter_jit
     def g(x):
         return eqx.filter_pure_callback(f, x, sentinel1, result_shape_dtypes=out_struct)
 
     out = g(jnp.array(2.0))
-    assert shaped_allclose(out, (jnp.array(3.0), sentinel2))
+    assert tree_allclose(out, (jnp.array(3.0), sentinel2))
 
 
 def test_wrong():

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -1,5 +1,6 @@
 import jax
 import jax.numpy as jnp
+import jax.tree_util as jtu
 import pytest
 
 import equinox as eqx
@@ -50,3 +51,33 @@ def test_check_dce(capfd):
     eqx.debug.inspect_dce()
     text, _ = capfd.readouterr()
     assert "(i32[], <DCE'd>)" in text
+
+
+def test_max_traces():
+    @jax.jit
+    @eqx.debug.assert_max_traces(max_traces=1)
+    def f(x):
+        return x + 1
+
+    f(1)
+    f(2)
+
+    with pytest.raises(RuntimeError, match="can only be traced 1 times"):
+        f(3.0)
+
+
+def test_max_traces_clone(getkey):
+    lin = eqx.nn.Linear(3, 4, key=getkey())
+    lin = eqx.filter_jit(eqx.debug.assert_max_traces(lin, max_traces=2))
+    leaves, treedef = jtu.tree_flatten(lin)
+    lin2 = jtu.tree_unflatten(treedef, leaves)
+
+    lin(jnp.array([1.0, 2.0, 3.0]))
+    assert eqx.debug.get_num_traces(lin) == 1
+    assert eqx.debug.get_num_traces(lin2) == 1
+    lin2(jnp.array([1, 2, 3]))
+    assert eqx.debug.get_num_traces(lin) == 2
+    assert eqx.debug.get_num_traces(lin2) == 2
+
+    with pytest.raises(RuntimeError, match="can only be traced 2 times"):
+        lin(jnp.array([False, False, False]))

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -43,14 +43,14 @@ def test_backward_nan(capfd):
 def test_check_dce(capfd):
     @jax.jit
     def f(x):
-        a, _ = eqx.debug.store_dce((x**2, x + 1))
+        a, _, _ = eqx.debug.store_dce((x**2, x + 1, "foobar"))
         return a
 
     f(1)
     capfd.readouterr()
     eqx.debug.inspect_dce()
     text, _ = capfd.readouterr()
-    assert "(i32[], <DCE'd>)" in text
+    assert "(i32[], <DCE'd>, 'foobar')" in text
 
 
 def test_max_traces():

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -232,15 +232,19 @@ def test_duplicate_fields():
     class D(A):  # pyright: ignore
         a = "hi"
 
-    with pytest.raises(ValueError):
+    with pytest.warns():
 
         class E(A):  # pyright: ignore
             a = "not hi"
 
-    with pytest.raises(ValueError):
+        assert E[E.a] == "not hi"
+
+    with pytest.warns():
 
         class F(A, B):  # pyright: ignore
             a = "not hi"
+
+        assert F[F.a] == "not hi"
 
 
 def test_error_if():

--- a/tests/test_enum.py
+++ b/tests/test_enum.py
@@ -6,7 +6,7 @@ import pytest
 import equinox as eqx
 import equinox.internal as eqxi
 
-from .helpers import shaped_allclose
+from .helpers import tree_allclose
 
 
 def test_equality():
@@ -38,10 +38,10 @@ def test_equality():
         assert a.is_traced()
         return a == A.x
 
-    assert shaped_allclose(run1(), jnp.array(False))
-    assert shaped_allclose(run2(), jnp.array(True))
-    assert shaped_allclose(run3(A.x), jnp.array(True))
-    assert shaped_allclose(run3(A.y), jnp.array(False))
+    assert tree_allclose(run1(), jnp.array(False))
+    assert tree_allclose(run2(), jnp.array(True))
+    assert tree_allclose(run3(A.x), jnp.array(True))
+    assert tree_allclose(run3(A.y), jnp.array(False))
 
 
 def test_where():

--- a/tests/test_finalise_jaxpr.py
+++ b/tests/test_finalise_jaxpr.py
@@ -7,7 +7,7 @@ import jax.numpy as jnp
 
 import equinox.internal as eqxi
 
-from .helpers import shaped_allclose
+from .helpers import tree_allclose
 
 
 def _safe_zip(*args):
@@ -68,14 +68,15 @@ def test_jaxpr2jaxpr_custom_idempotent():
 
 def test_fn2fn_nocustom_idempotent():
     def fn(x):
+        x = jnp.asarray(x)
         x = x + 1
         x = x * 2
         return x
 
     finalised_fn = eqxi.finalise_fn(fn)
-    assert shaped_allclose(fn(1), finalised_fn(1), match_weak=True)
-    assert shaped_allclose(fn(5), finalised_fn(5), match_weak=True)
-    assert shaped_allclose(fn(-1), finalised_fn(-1), match_weak=True)
+    assert tree_allclose(fn(1), finalised_fn(1))
+    assert tree_allclose(fn(5), finalised_fn(5))
+    assert tree_allclose(fn(-1), finalised_fn(-1))
 
     jaxpr = jax.make_jaxpr(fn)(1)
     jaxpr = cast(jax.core.ClosedJaxpr, jaxpr)
@@ -92,8 +93,8 @@ def test_fn2fn_custom_idempotent():
         return x
 
     finalised_fn = eqxi.finalise_fn(fn)
-    assert shaped_allclose(fn(False), finalised_fn(False))
-    assert shaped_allclose(fn(True), finalised_fn(True))
+    assert tree_allclose(fn(False), finalised_fn(False))
+    assert tree_allclose(fn(True), finalised_fn(True))
 
     finalised_jaxpr = jax.make_jaxpr(finalised_fn)(True)
     finalised_jaxpr = cast(jax.core.ClosedJaxpr, finalised_jaxpr)
@@ -111,7 +112,7 @@ def test_fn2fn_custom_idempotent():
         jnp.array([True, False]),
         jnp.array([True, True]),
     ):
-        assert shaped_allclose(vmap_fn(arg), finalised_vmap_fn(arg))
+        assert tree_allclose(vmap_fn(arg), finalised_vmap_fn(arg))
 
     finalised_vmap_jaxpr = jax.make_jaxpr(finalised_vmap_fn)(jnp.array([False, False]))
     finalised_vmap_jaxpr = cast(jax.core.ClosedJaxpr, finalised_vmap_jaxpr)

--- a/tests/test_jit.py
+++ b/tests/test_jit.py
@@ -9,7 +9,7 @@ import pytest
 
 import equinox as eqx
 
-from .helpers import shaped_allclose
+from .helpers import tree_allclose
 
 
 # We can't just use `lambda x: x` or any function just rearrange without modification
@@ -48,14 +48,14 @@ def test_filter_jit(donate, getkey):
     assert jnp.all(f1[0]["b"] == b + 1)
     assert jnp.all(f1[1][0] == c + 1)
     f2 = f(general_tree_)
-    assert shaped_allclose(f2[0], 1)
-    assert shaped_allclose(f2[1], True)
-    assert shaped_allclose(f2[2], general_tree[2])
+    assert tree_allclose(f2[0], 1)
+    assert tree_allclose(f2[1], True)
+    assert tree_allclose(f2[2], general_tree[2])
     assert jnp.all(f2[3]["a"] == a + 1)
-    assert shaped_allclose(f2[3]["tuple"][0], 2.0)
+    assert tree_allclose(f2[3]["tuple"][0], 2.0)
     assert jnp.all(f2[3]["tuple"][1] == b + 1)
     assert jnp.all(f2[4] == c + 1)
-    assert shaped_allclose(f2[5], mlp_add)
+    assert tree_allclose(f2[5], mlp_add)
 
 
 def test_num_traces():
@@ -243,11 +243,11 @@ def test_jit_vmap():
         return x + 1
 
     out = eqx.filter_jit(eqx.filter_vmap(f))(jnp.array([1, 2]))
-    assert shaped_allclose(out, jnp.array([2, 3]))
+    assert tree_allclose(out, jnp.array([2, 3]))
     assert num_traces == 1
 
     out = eqx.filter_jit(eqx.filter_vmap(f))(jnp.array([2, 3]))
-    assert shaped_allclose(out, jnp.array([3, 4]))
+    assert tree_allclose(out, jnp.array([3, 4]))
     assert num_traces == 1
 
 
@@ -274,7 +274,7 @@ def test_buffer_donation(getkey):
     x = jnp.array(0.0)
     old_p = x.unsafe_buffer_pointer()
     new_x = f(x)
-    assert shaped_allclose(new_x, jnp.array(1.0))
+    assert tree_allclose(new_x, jnp.array(1.0))
     assert new_x.unsafe_buffer_pointer() == old_p
     assert x.is_deleted()
 
@@ -310,7 +310,7 @@ def test_buffer_donation(getkey):
     _, new_m = new_m(jnp.ones((10,)))
     assert num_traces == 1
 
-    assert shaped_allclose(new_m.buffer[0], jnp.array(3.0))
+    assert tree_allclose(new_m.buffer[0], jnp.array(3.0))
     assert m.buffer.is_deleted()
     assert new_m.buffer.unsafe_buffer_pointer() == old_m_p.buffer
 

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -5,7 +5,7 @@ import pytest
 
 import equinox.internal as eqxi
 
-from .helpers import random_pytree, shaped_allclose, treedefs
+from .helpers import random_pytree, tree_allclose, treedefs
 
 
 def test_ω_add_mul(getkey):
@@ -22,7 +22,7 @@ def test_ω_add_mul(getkey):
 
         e1 = (a**ω * 2 + b**ω * c**ω - 3).ω
         e2 = jtu.tree_map(lambda ai, bi, ci: ai * 2 + bi * ci - 3, a, b, c)
-        assert shaped_allclose(e1, e2)
+        assert tree_allclose(e1, e2)
 
 
 def test_ω_inplace(getkey):
@@ -31,13 +31,13 @@ def test_ω_inplace(getkey):
         a = random_pytree(getkey(), treedef)
         b1 = ω(a).at[()].set(3).ω
         b2 = jtu.tree_map(lambda ai: ai.at[()].set(3), a)
-        assert shaped_allclose(b1, b2)
+        assert tree_allclose(b1, b2)
 
         a2 = jtu.tree_map(lambda x: x + 1, a)
 
         b3 = ω(a).at[()].set(ω(a2)).ω
         b4 = jtu.tree_map(lambda ai, a2i: ai.at[()].set(a2i[()]), a, a2)
-        assert shaped_allclose(b3, b4)
+        assert tree_allclose(b3, b4)
 
 
 def test_ω_is_leaf(getkey):

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -14,7 +14,7 @@ import pytest
 import equinox as eqx
 import equinox.internal as eqxi
 
-from .helpers import shaped_allclose
+from .helpers import tree_allclose
 
 
 def test_module_not_enough_attributes():
@@ -230,7 +230,7 @@ def test_converter():
     class MyModule(eqx.Module):
         field: jax.Array = eqx.field(converter=jnp.asarray)
 
-    assert shaped_allclose(MyModule(1.0).field, jnp.array(1.0))  # pyright: ignore
+    assert tree_allclose(MyModule(1.0).field, jnp.array(1.0))  # pyright: ignore
 
     class MyModuleWithInit(eqx.Module):
         field: jax.Array = eqx.field(converter=jnp.asarray)
@@ -239,7 +239,7 @@ def test_converter():
             self.field = a
             assert type(self.field) is float
 
-    assert shaped_allclose(MyModuleWithInit(1.0).field, jnp.array(1.0))
+    assert tree_allclose(MyModuleWithInit(1.0).field, jnp.array(1.0))
 
     called = False
 
@@ -250,7 +250,7 @@ def test_converter():
             nonlocal called
             assert not called
             called = True
-            assert shaped_allclose(self.field, jnp.array(1.0))
+            assert tree_allclose(self.field, jnp.array(1.0))
 
     MyModuleWithPostInit(1.0)  # pyright: ignore
     assert called
@@ -260,7 +260,7 @@ def test_converter_monkeypatched_init():
     class Foo(eqx.Module):
         field: jax.Array = eqx.field(converter=jnp.asarray)
 
-    assert shaped_allclose(Foo(1.0).field, jnp.array(1.0))  # pyright: ignore
+    assert tree_allclose(Foo(1.0).field, jnp.array(1.0))  # pyright: ignore
 
     called = False
     init = Foo.__init__
@@ -272,7 +272,7 @@ def test_converter_monkeypatched_init():
         init(self, *args, **kwargs)
 
     Foo.__init__ = __init__
-    assert shaped_allclose(Foo(1.0).field, jnp.array(1.0))  # pyright: ignore
+    assert tree_allclose(Foo(1.0).field, jnp.array(1.0))  # pyright: ignore
     assert called
 
 
@@ -290,9 +290,9 @@ def test_converter_monkeypatched_postinit():
             nonlocal called1
             assert not called1
             called1 = True
-            assert shaped_allclose(self.field, jnp.array(1.0))
+            assert tree_allclose(self.field, jnp.array(1.0))
 
-    assert shaped_allclose(Foo(1.0).field, jnp.array(1.0))  # pyright: ignore
+    assert tree_allclose(Foo(1.0).field, jnp.array(1.0))  # pyright: ignore
     assert called1
 
     called2 = False
@@ -307,7 +307,7 @@ def test_converter_monkeypatched_postinit():
         post_init(self)
 
     Foo.__post_init__ = __post_init__  # pyright: ignore
-    assert shaped_allclose(Foo(1.0).field, jnp.array(1.0))  # pyright: ignore
+    assert tree_allclose(Foo(1.0).field, jnp.array(1.0))  # pyright: ignore
     assert called2
     assert called1
 
@@ -335,10 +335,10 @@ def test_converter_init_hierarchy(base_is_module):
     # In either case, conversion should happen.
 
     called = False
-    assert shaped_allclose(C(1).x, jnp.array(1))
+    assert tree_allclose(C(1).x, jnp.array(1))
     assert called
 
-    assert shaped_allclose(D(1).x, jnp.array(1))  # pyright: ignore
+    assert tree_allclose(D(1).x, jnp.array(1))  # pyright: ignore
     # No `called` check, we're not using `A.__init__`.
 
 
@@ -360,11 +360,11 @@ def test_converter_post_init_hierarchy(base_is_module):
         pass
 
     called = False
-    assert shaped_allclose(C(1).x, jnp.array(1))  # pyright: ignore
+    assert tree_allclose(C(1).x, jnp.array(1))  # pyright: ignore
     assert called
 
     called = False
-    assert shaped_allclose(D(1).x, jnp.array(1))  # pyright: ignore
+    assert tree_allclose(D(1).x, jnp.array(1))  # pyright: ignore
     assert called
 
 
@@ -381,7 +381,7 @@ def test_init_and_postinit():
             def __init__(self):
                 self.field = 1  # pyright: ignore
 
-    assert shaped_allclose(Bar().field, jnp.array(1))
+    assert tree_allclose(Bar().field, jnp.array(1))
 
     class Qux(eqx.Module):
         field: jax.Array = eqx.field(converter=jnp.asarray)
@@ -395,7 +395,7 @@ def test_init_and_postinit():
             def __post_init__(self):
                 assert False
 
-    assert shaped_allclose(Quux().field, jnp.array(1))  # pyright: ignore
+    assert tree_allclose(Quux().field, jnp.array(1))  # pyright: ignore
 
 
 def test_wrap_method():

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -1036,3 +1036,22 @@ def signature_test_cases():
 def test_signature(dataclass, module):
     # Check module signature matches dataclass signatures.
     assert inspect.signature(dataclass) == inspect.signature(module)
+
+
+def test_module_setattr():
+    class Foo(eqx.Module):
+        def f(self):
+            pass
+
+    def f2(self):
+        pass
+
+    def g(self):
+        pass
+
+    Foo.f = f2
+    Foo.g = g  # pyright: ignore
+    assert Foo.f is f2
+    assert Foo.g is g  # pyright: ignore
+    assert type(Foo.__dict__["f"]).__name__ == "_wrap_method"
+    assert type(Foo.__dict__["g"]).__name__ == "_wrap_method"

--- a/tests/test_noinline.py
+++ b/tests/test_noinline.py
@@ -4,7 +4,7 @@ import jax.random as jr
 
 import equinox as eqx
 
-from .helpers import shaped_allclose
+from .helpers import tree_allclose
 
 
 def test_simple():
@@ -12,9 +12,9 @@ def test_simple():
     def addone(x):
         return x + 1
 
-    assert shaped_allclose(addone(1), 2)
-    assert shaped_allclose(addone(jnp.array(1)), jnp.array(2))
-    assert shaped_allclose(eqx.filter_jit(addone)(jnp.array(1)), jnp.array(2))
+    assert tree_allclose(addone(1), 2)
+    assert tree_allclose(addone(jnp.array(1)), jnp.array(2))
+    assert tree_allclose(eqx.filter_jit(addone)(jnp.array(1)), jnp.array(2))
 
 
 def test_mlp(getkey):
@@ -27,9 +27,9 @@ def test_mlp(getkey):
     o2 = mlp_jit(x)
     o3 = mlp_noinline(x)
     o4 = mlp_jit_noinline(x)
-    assert shaped_allclose(o1, o2)
-    assert shaped_allclose(o1, o3)
-    assert shaped_allclose(o1, o4)
+    assert tree_allclose(o1, o2)
+    assert tree_allclose(o1, o3)
+    assert tree_allclose(o1, o4)
 
 
 def test_vmap(getkey):
@@ -44,9 +44,9 @@ def test_vmap(getkey):
     o2 = mlp_jit_vmap(x)
     o3 = mlp_vmap_noinline(x)
     o4 = mlp_jit_vmap_noinline(x)
-    assert shaped_allclose(o1, o2, atol=1e-5)
-    assert shaped_allclose(o1, o3, atol=1e-5)
-    assert shaped_allclose(o1, o4, atol=1e-5)
+    assert tree_allclose(o1, o2, atol=1e-5)
+    assert tree_allclose(o1, o3, atol=1e-5)
+    assert tree_allclose(o1, o4, atol=1e-5)
 
 
 def test_jvp(getkey):
@@ -62,9 +62,9 @@ def test_jvp(getkey):
     o2 = mlp_jit_jvp(x, y)
     o3 = mlp_jvp_noinline(x, y)
     o4 = mlp_jit_jvp_noinline(x, y)
-    assert shaped_allclose(o1, o2)
-    assert shaped_allclose(o1, o3)
-    assert shaped_allclose(o1, o4)
+    assert tree_allclose(o1, o2)
+    assert tree_allclose(o1, o3)
+    assert tree_allclose(o1, o4)
 
 
 def test_grad(getkey):
@@ -79,9 +79,9 @@ def test_grad(getkey):
     o2 = mlp_jit_grad(x)
     o3 = mlp_grad_noinline(x)
     o4 = mlp_jit_grad_noinline(x)
-    assert shaped_allclose(o1, o2)
-    assert shaped_allclose(o1, o3)
-    assert shaped_allclose(o1, o4)
+    assert tree_allclose(o1, o2)
+    assert tree_allclose(o1, o3)
+    assert tree_allclose(o1, o4)
 
 
 def test_num_traces():
@@ -97,7 +97,7 @@ def test_num_traces():
     def g(x):
         return fn(x) + fn(x) + fn(x) + fn(x)
 
-    assert shaped_allclose(g(1), jnp.array(8))
+    assert tree_allclose(g(1), jnp.array(8))
     assert num_traces == 2
 
 
@@ -109,8 +109,8 @@ def test_pytree_in():
 
     o1 = fn(lambda x: x + 1, [(1,)])
     o2 = fn(lambda x: x + 1, ([jnp.array(1)],))
-    assert shaped_allclose(o1, 2)
-    assert shaped_allclose(o2, jnp.array(2))
+    assert tree_allclose(o1, 2)
+    assert tree_allclose(o2, jnp.array(2))
 
 
 def test_abstract():
@@ -140,8 +140,8 @@ def test_abstract():
         call_num_traces += 1
         return fn(x, y)
 
-    assert shaped_allclose(call(f, 2, 3), jnp.array(5))
-    assert shaped_allclose(call(g, 2, 3), jnp.array(6))
+    assert tree_allclose(call(f, 2, 3), jnp.array(5))
+    assert tree_allclose(call(g, 2, 3), jnp.array(6))
     assert f_num_traces == 1
     assert g_num_traces == 1
     assert call_num_traces == 1
@@ -197,7 +197,7 @@ def test_complicated(getkey):
 
     xs = jnp.array([1.0, 2.0, 3.0])
 
-    assert shaped_allclose(run(xs), run_noinline(xs))
+    assert tree_allclose(run(xs), run_noinline(xs))
     assert num_lowerings == 3
     # Why three lowerings?
     # 1. Primal computation

--- a/tests/test_nontraceable.py
+++ b/tests/test_nontraceable.py
@@ -9,16 +9,16 @@ import pytest
 import equinox as eqx
 import equinox.internal as eqxi
 
-from .helpers import shaped_allclose
+from .helpers import tree_allclose
 
 
 def test_nondiff():
     x = 1.0
     y = (jnp.array(1.0), object())
-    assert shaped_allclose(eqxi.nondifferentiable(x), x)
-    assert shaped_allclose(jax.jit(eqxi.nondifferentiable)(x), jnp.array(x))
-    assert shaped_allclose(eqxi.nondifferentiable(y), y)
-    assert shaped_allclose(eqx.filter_jit(eqxi.nondifferentiable, donate="none")(y), y)
+    assert tree_allclose(eqxi.nondifferentiable(x), x)
+    assert tree_allclose(jax.jit(eqxi.nondifferentiable)(x), jnp.array(x))
+    assert tree_allclose(eqxi.nondifferentiable(y), y)
+    assert tree_allclose(eqx.filter_jit(eqxi.nondifferentiable, donate="none")(y), y)
 
     with pytest.raises(RuntimeError):
         jax.jvp(eqxi.nondifferentiable, (x,), (x,))
@@ -29,19 +29,19 @@ def test_nondiff():
 def test_nondiff_back():
     x = 1.0
     y = (jnp.array(1.0), object())
-    assert shaped_allclose(eqxi.nondifferentiable_backward(x), x)
-    assert shaped_allclose(jax.jit(eqxi.nondifferentiable_backward)(x), jnp.array(x))
-    assert shaped_allclose(eqxi.nondifferentiable_backward(y), y)
-    assert shaped_allclose(
+    assert tree_allclose(eqxi.nondifferentiable_backward(x), x)
+    assert tree_allclose(jax.jit(eqxi.nondifferentiable_backward)(x), jnp.array(x))
+    assert tree_allclose(eqxi.nondifferentiable_backward(y), y)
+    assert tree_allclose(
         eqx.filter_jit(eqxi.nondifferentiable_backward, donate="none")(y), y
     )
 
     x1, x2 = jax.jvp(eqxi.nondifferentiable_backward, (x,), (x,))
     x3, x4 = jax.jvp(jax.jit(eqxi.nondifferentiable_backward), (x,), (x,))
-    assert shaped_allclose(x1, x)
-    assert shaped_allclose(x2, x)
-    assert shaped_allclose(x3, jnp.array(x))
-    assert shaped_allclose(x4, jnp.array(x))
+    assert tree_allclose(x1, x)
+    assert tree_allclose(x2, x)
+    assert tree_allclose(x3, jnp.array(x))
+    assert tree_allclose(x4, jnp.array(x))
 
     with pytest.raises(RuntimeError):
         jax.grad(eqxi.nondifferentiable_backward)(x)

--- a/tests/test_pmap.py
+++ b/tests/test_pmap.py
@@ -258,12 +258,15 @@ def test_keyword_default(getkey):
 
 
 # Issue 325
-def test_aot_compilation():
+
+
+@pytest.mark.parametrize("donate", ("all", "none"))
+def test_aot_compilation(donate):
     def f(x, y):
         return 2 * x + y
 
     x, y = jnp.array([3]), 4
-    lowered = filter_pmap(f).lower(x, y)
+    lowered = filter_pmap(f, donate=donate).lower(x, y)
     lowered.as_text()
     compiled = lowered.compile()
     compiled(x, y)

--- a/tests/test_pmap.py
+++ b/tests/test_pmap.py
@@ -9,7 +9,7 @@ import pytest
 
 import equinox as eqx
 
-from .helpers import shaped_allclose as _shaped_allclose
+from .helpers import tree_allclose as _shaped_allclose
 
 
 (cpu,) = jax.devices("cpu")

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -7,7 +7,7 @@ import pytest
 
 import equinox.internal as eqxi
 
-from .helpers import shaped_allclose
+from .helpers import tree_allclose
 
 
 @pytest.mark.parametrize("kind", ("lax", "checkpointed"))
@@ -55,9 +55,9 @@ def test_scan(kind, length, vjp, getkey):
 
         lax_out, lax_grad, ct_out = vjp_lax_run(init, xs)
         out, grad = vjp_run(init, xs, ct_out)
-        assert shaped_allclose(grad, lax_grad)
+        assert tree_allclose(grad, lax_grad)
     else:
         lax_out = jax.jit(lax_run)(init, xs)
         out = jax.jit(run)(init, xs)
 
-    assert shaped_allclose(out, lax_out)
+    assert tree_allclose(out, lax_out)

--- a/tests/test_vmap.py
+++ b/tests/test_vmap.py
@@ -7,7 +7,7 @@ import pytest
 
 import equinox as eqx
 
-from .helpers import shaped_allclose
+from .helpers import tree_allclose
 
 
 def _zero_if_inexact_array_else_none(x):
@@ -22,7 +22,7 @@ def test_args():
         return a + b[0]["a"] + c + d
 
     out = f(jnp.array([1]), [{"a": jnp.array([2])}], jnp.array([3]), 4)
-    assert shaped_allclose(out, jnp.array([[10]]))
+    assert tree_allclose(out, jnp.array([[10]]))
 
 
 def test_default():
@@ -30,7 +30,7 @@ def test_default():
     def f(a, b):
         return a + b
 
-    assert shaped_allclose(f(jnp.array(3), jnp.array([3.0])), jnp.array([6.0]))
+    assert tree_allclose(f(jnp.array(3), jnp.array([3.0])), jnp.array([6.0]))
 
     with pytest.raises(ValueError):
         f(jnp.array(3.0), jnp.array([3.0]))
@@ -45,10 +45,10 @@ def test_out():
     o3 = eqx.filter_vmap(f, out_axes=0, axis_size=5)(1)
     o4 = eqx.filter_vmap(f, in_axes=None, out_axes=0, axis_size=5)(jnp.array([3, 4]))
 
-    assert shaped_allclose(o1, 1)
-    assert shaped_allclose(o2, jnp.array([3, 4]))
-    assert shaped_allclose(o3, jnp.array([1, 1, 1, 1, 1]))
-    assert shaped_allclose(o4, jnp.array([[3, 4], [3, 4], [3, 4], [3, 4], [3, 4]]))
+    assert tree_allclose(o1, 1)
+    assert tree_allclose(o2, jnp.array([3, 4]))
+    assert tree_allclose(o3, jnp.array([1, 1, 1, 1, 1]))
+    assert tree_allclose(o4, jnp.array([[3, 4], [3, 4], [3, 4], [3, 4], [3, 4]]))
 
 
 def test_no_arrays():
@@ -56,7 +56,7 @@ def test_no_arrays():
     def f(x):
         return x
 
-    assert shaped_allclose(f(1), 1)
+    assert tree_allclose(f(1), 1)
 
 
 def test_ensemble(getkey):
@@ -120,7 +120,7 @@ def test_named_reduction():
         return jax.lax.psum(y, axis_name="device")
 
     output = eqx.filter_vmap(f, axis_name="device")(jnp.zeros(2))
-    assert shaped_allclose(output, jnp.array([2.0, 2.0]))
+    assert tree_allclose(output, jnp.array([2.0, 2.0]))
 
 
 def test_map_non_jax():
@@ -148,14 +148,14 @@ def test_keyword_in_axes(getkey):
     y = jr.normal(getkey(), (1, 3))
     out = eqx.filter_vmap(lambda x, y: x + y, in_axes=dict(y=1))(x, y)
     true_out = x + y.T
-    assert shaped_allclose(out, true_out)
+    assert tree_allclose(out, true_out)
 
 
 def test_keyword_default(getkey):
     x = jr.normal(getkey(), (3, 4))
     out = eqx.filter_vmap(lambda x, y=1: x + y, in_axes=dict(x=0))(x)
     true_out = x + 1
-    assert shaped_allclose(out, true_out)
+    assert tree_allclose(out, true_out)
 
     with pytest.raises(ValueError):
         eqx.filter_vmap(lambda x, y=1: x, in_axes=dict(y=0))(x)


### PR DESCRIPTION
- Added trace counting debug tools.
- Tidied up error docs.
- eqx.debug.store_dce now supports non-arrays
- Enhanced tree_equal to be able to perform shaped_allclose-type functionality.
- Better warnings
- Move GetKey into eqxi (to avoid duplication in downstream libraries).
- Added filter_jit(..., donate="{all,warn}-except-first")
- Fix MayberBuffer annotation
- eqx.tree_pprint now also supports torch
