### PR TITLE
Fixing broken link to Enumueration objects

### DIFF
--- a/equinox/_enum.py
+++ b/equinox/_enum.py
@@ -96,7 +96,7 @@ class _EnumerationMeta(type):
         if "__doc__" not in cls.__dict__ or cls.__doc__ is None:
             doc_pieces = [
                 """An
-[enumeration](https://docs.kidger.site/equinox/api/utilities/enumerations/), with the
+[enumeration](https://docs.kidger.site/equinox/api/enumerations/), with the
 following entries:
 """
             ]


### PR DESCRIPTION
The link to the `Enumeration` objects was stale, linking to the old docs location. This was propagating up through `Lineax` and `Optimisitx`.