### PR TITLE
Support setattr(module, name, function).

### DIFF
--- a/equinox/_module.py
+++ b/equinox/_module.py
@@ -493,6 +493,11 @@ class _ModuleMeta(ABCMeta):  # pyright: ignore
         else:
             return value
 
+    def __setattr__(cls, item, value):
+        if _not_magic(item) and inspect.isfunction(value):
+            value = _wrap_method(value)
+        super().__setattr__(item, value)
+
 
 if TYPE_CHECKING:
 

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -1036,3 +1036,22 @@ def signature_test_cases():
 def test_signature(dataclass, module):
     # Check module signature matches dataclass signatures.
     assert inspect.signature(dataclass) == inspect.signature(module)
+
+
+def test_module_setattr():
+    class Foo(eqx.Module):
+        def f(self):
+            pass
+
+    def f2(self):
+        pass
+
+    def g(self):
+        pass
+
+    Foo.f = f2
+    Foo.g = g  # pyright: ignore
+    assert Foo.f is f2
+    assert Foo.g is g  # pyright: ignore
+    assert type(Foo.__dict__["f"]).__name__ == "_wrap_method"
+    assert type(Foo.__dict__["g"]).__name__ == "_wrap_method"


### PR DESCRIPTION
This is to support downstream libraries (e.g. typecheckers) which may
wish to monkey-patch a method.
