### PR TITLE
Better error message when no kwargs passed to ```filter_grad```

### DIFF
--- a/equinox/_ad.py
+++ b/equinox/_ad.py
@@ -62,11 +62,18 @@ class _ValueAndGradWrapper(Module):
             return self._fun(_x, *_args, **_kwargs)
 
         if len(args) == 0:
-            raise TypeError(
-                "Functions wrapped with `equinox.filter_{grad, value_and_grad}` must "
-                "have their first argument passed by position, not keyword. (This is "
-                "the argument that is differentiated.)"
-            )
+            if len(kwargs) == 0:
+                raise TypeError(
+                    "Functions wrapped with `equinox.filter_{grad, value_and_grad}` "
+                    "must have at least one positional argument. (This is the "
+                    "argument that is differentiated.)"
+                )
+            else:
+                raise TypeError(
+                    "Functions wrapped with `equinox.filter_{grad, value_and_grad}` "
+                    "must have their first argument passed by position, not keyword. "
+                    "(This is the argument that is differentiated.)"
+                )
         x, *args = args
         diff_x, nondiff_x = partition(x, is_inexact_array)
         return fun_value_and_grad(diff_x, nondiff_x, *args, **kwargs)


### PR DESCRIPTION
Hi Patrick,

I encountered incorrect error message during using ```eqx.filter_grad```:
```python
import equinox as eqx
from jax import numpy as jnp, tree_util as jtu
@eqx.filter_grad
def f(a):
    return jnp.sum(a)
eqx.filter_grad(jtu.Partial(f, a=jnp.ones((3,2))))()
```
Throws 
```
Functions wrapped with `equinox.filter_{grad, value and grad}` must have their 
first argument passed by position, not keyword. (This is the argument that is differentiated).
```
which does not make sense in this scenario: there are no keyword arguments!


I simply added a check for no keyword arguments, that now states that ```... there must be at least one positional argument ... ``` when no kwargs are available.