### PR TITLE
Mixed precision for attention

### DIFF
--- a/equinox/nn/_attention.py
+++ b/equinox/nn/_attention.py
@@ -18,7 +18,6 @@ def dot_product_attention_weights(
     query: Float[Array, "q_seq qk_size"],
     key: Float[Array, "kv_seq qk_size"],
     mask: Optional[Bool[Array, "q_seq kv_seq"]] = None,
-    softmax_dtype: Optional[str] = None,
 ) -> Float[Array, "q_seq kv_seq"]:
     query = query / math.sqrt(query.shape[-1])
     logits = jnp.einsum("sd,Sd->sS", query, key)
@@ -31,10 +30,8 @@ def dot_product_attention_weights(
             )
         logits = jnp.where(mask, logits, jnp.finfo(logits.dtype).min)
 
-    if softmax_dtype is None:
-        softmax_dtype = logits.dtype  # pyright: ignore
-
-    weights = jax.nn.softmax(logits.astype(softmax_dtype), axis=-1)  # pyright: ignore
+    dtype = jnp.result_type(logits.dtype, jnp.float32)  # pyright: ignore
+    weights = jax.nn.softmax(logits.astype(dtype))  # pyright: ignore
     return weights.astype(logits.dtype)  # pyright: ignore
 
 
@@ -44,12 +41,11 @@ def dot_product_attention(
     value: Float[Array, "kv_seq v_size"],
     mask: Optional[Bool[Array, "q_seq kv_seq"]] = None,
     dropout: Optional[Dropout] = None,
-    softmax_dtype: Optional[str] = None,
     *,
     key: Optional[PRNGKeyArray] = None,
     inference: Optional[bool] = None,
 ) -> Float[Array, "q_seq v_size"]:
-    weights = dot_product_attention_weights(query, key_, mask, softmax_dtype)
+    weights = dot_product_attention_weights(query, key_, mask)
     if dropout is not None:
         weights = dropout(weights, key=key, inference=inference)
     attn = jnp.einsum("sS,Sd->sd", weights, value)
@@ -228,7 +224,6 @@ class MultiheadAttention(Module):
         mask: Union[
             None, Bool[Array, "q_seq kv_seq"], Bool[Array, "num_heads q_seq kv_seq"]
         ] = None,
-        softmax_dtype: Optional[str] = None,
         *,
         key: Optional[PRNGKeyArray] = None,
         inference: Optional[bool] = None,
@@ -246,8 +241,6 @@ class MultiheadAttention(Module):
             be a JAX array of shape `(query_seq_length, kv_seq_length)`, or (for custom
             per-head masking) `(num_heads, query_seq_length, kv_seq_length)`. A value of
             `False` at a position indicates that position should be ignored.
-        - `softmax_dtype`: Optional type to which weight logits will be cast before
-            applying softmax
         - `key`: A `jax.random.PRNGKey` used for dropout. Unused if `dropout = 0`.
             (Keyword only argument.)
         - `inference`: As [`equinox.nn.Dropout.__call__`][]. (Keyword only
@@ -278,10 +271,7 @@ class MultiheadAttention(Module):
         value_heads = self._project(self.value_proj, value)
 
         attn_fn = partial(
-            dot_product_attention,
-            dropout=self.dropout,
-            softmax_dtype=softmax_dtype,
-            inference=inference,
+            dot_product_attention, dropout=self.dropout, inference=inference
         )
         keys = None if key is None else jax.random.split(key, query_heads.shape[1])
         if mask is not None and mask.ndim == 3:

--- a/equinox/nn/_attention.py
+++ b/equinox/nn/_attention.py
@@ -2,7 +2,7 @@ import functools as ft
 import math
 import warnings
 from functools import partial
-from typing import Optional, Union
+from typing import cast, Optional, Union
 
 import jax
 import jax.numpy as jnp
@@ -29,10 +29,11 @@ def dot_product_attention_weights(
                 f"{key.shape[0]}). Got {mask.shape}."
             )
         logits = jnp.where(mask, logits, jnp.finfo(logits.dtype).min)
+        logits = cast(Array, logits)
 
-    dtype = jnp.result_type(logits.dtype, jnp.float32)  # pyright: ignore
-    weights = jax.nn.softmax(logits.astype(dtype))  # pyright: ignore
-    return weights.astype(logits.dtype)  # pyright: ignore
+    dtype = jnp.result_type(logits.dtype, jnp.float32)
+    weights = jax.nn.softmax(logits.astype(dtype)).astype(logits.dtype)
+    return weights
 
 
 def dot_product_attention(

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -642,6 +642,18 @@ def test_dot_product_attention_weights(getkey):
     weights = eqx.nn._attention.dot_product_attention_weights(q, k, mask)
     assert jnp.allclose(weights, jnp.array([[1.0, 0.0]]))
 
+    q = jnp.array([[1.0]], dtype="float16")
+    k = jnp.array([[9.0], [1.0]], dtype="float16")
+    weights = eqx.nn._attention.dot_product_attention_weights(q, k)
+    assert weights.dtype == q.dtype
+    assert weights.max() == 1
+
+    weights = eqx.nn._attention.dot_product_attention_weights(
+        q, k, softmax_dtype="float32"
+    )
+    assert weights.dtype == q.dtype
+    assert weights.max() < 1
+
 
 def test_dot_product_attention(getkey):
     q = jnp.array([[0.0, 2**0.5]])

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -646,12 +646,6 @@ def test_dot_product_attention_weights(getkey):
     k = jnp.array([[9.0], [1.0]], dtype="float16")
     weights = eqx.nn._attention.dot_product_attention_weights(q, k)
     assert weights.dtype == q.dtype
-    assert weights.max() == 1
-
-    weights = eqx.nn._attention.dot_product_attention_weights(
-        q, k, softmax_dtype="float32"
-    )
-    assert weights.dtype == q.dtype
     assert weights.max() < 1
 
 


### PR DESCRIPTION
resolves #553
I had the same problem as described in the issue in my own implementation. I added `softmax_dtype` as an argument.
Its type should be `jax.typing.DTypeLike`, but this type is not runtime checkable.
I made it a string for now, but I hope there is a better solution.