### PR TITLE
Fix documentation bug

### DIFF
--- a/equinox/nn/_normalisation.py
+++ b/equinox/nn/_normalisation.py
@@ -290,7 +290,7 @@ class RMSNorm(Module, strict=True):
             author={Biao Zhang and Rico Sennrich},
             year={2019},
             journal={arXiv:1910.07467}
-    }
+        }
         ```
     """
 


### PR DESCRIPTION
In the documentation with the new RMS the citation is not rendering properly
<img width="929" alt="Screenshot 2024-01-10 at 4 48 44 PM" src="https://github.com/patrick-kidger/equinox/assets/42878312/67ef62ed-eda9-4830-9eae-466e2735c5fb">

I believe this is just because the } was offset, so I changed that to match the other citations