### PR TITLE
Make code that parses callback errors more tolerant of message format.

### DIFF
--- a/equinox/_jit.py
+++ b/equinox/_jit.py
@@ -212,7 +212,7 @@ class _JitWrapper(Module):
             (msg,) = e.args
             if "EqxRuntimeError: " in msg:
                 _, msg = msg.split("EqxRuntimeError: ", 1)
-                msg, _ = msg.rsplit("\n\nAt:\n", 1)
+                msg, *_ = msg.rsplit("\n\nAt:\n", 1)
                 msg = msg + _eqx_on_error_msg
                 e.args = (msg,)
                 if jax.config.jax_traceback_filtering in (  # pyright: ignore


### PR DESCRIPTION
JAX is switching from pybind11 to nanobind, and nanobind formats this error differently, with the traceback preceding the EqxRuntimeError message. If we change the "At:" split to accept zero or more "At:" pieces, things work as intended with both versions.