### PR TITLE
BatchNorm training instability fix

### DIFF
--- a/equinox/nn/_batch_norm.py
+++ b/equinox/nn/_batch_norm.py
@@ -53,7 +53,7 @@ class BatchNorm(StatefulLayer, strict=True):
     axis_name: Union[Hashable, Sequence[Hashable]]
     inference: bool
     input_size: int = field(static=True)
-    approach: Union[None, str] = field(static=True)
+    approach: Literal["batch", "ema"] = field(static=True)
     eps: float = field(static=True)
     channelwise_affine: bool = field(static=True)
     momentum: float = field(static=True)

--- a/equinox/nn/_batch_norm.py
+++ b/equinox/nn/_batch_norm.py
@@ -1,10 +1,11 @@
+import warnings
 from collections.abc import Hashable, Sequence
-from typing import Optional, Union
+from typing import Literal, Optional, Union
 
 import jax
 import jax.lax as lax
 import jax.numpy as jnp
-from jaxtyping import Array, Bool, Float, PRNGKeyArray
+from jaxtyping import Array, Float, Int, PRNGKeyArray
 
 from .._misc import default_floating_dtype
 from .._module import field
@@ -44,24 +45,29 @@ class BatchNorm(StatefulLayer, strict=True):
 
     weight: Optional[Float[Array, "input_size"]]
     bias: Optional[Float[Array, "input_size"]]
-    first_time_index: StateIndex[Bool[Array, ""]]
+    count_index: StateIndex[Int[Array, ""]]
     state_index: StateIndex[
         tuple[Float[Array, "input_size"], Float[Array, "input_size"]]
     ]
+    zero_frac_index: StateIndex[Float[Array, ""]]
     axis_name: Union[Hashable, Sequence[Hashable]]
     inference: bool
     input_size: int = field(static=True)
+    approach: Union[None, str] = field(static=True)
     eps: float = field(static=True)
     channelwise_affine: bool = field(static=True)
     momentum: float = field(static=True)
+    warmup_period: int = field(static=True)
 
     def __init__(
         self,
         input_size: int,
         axis_name: Union[Hashable, Sequence[Hashable]],
+        approach: Optional[Literal["batch", "ema"]] = None,
         eps: float = 1e-5,
         channelwise_affine: bool = True,
         momentum: float = 0.99,
+        warmup_period: int = 1000,
         inference: bool = False,
         dtype=None,
     ):
@@ -71,11 +77,17 @@ class BatchNorm(StatefulLayer, strict=True):
         - `axis_name`: The name of the batch axis to compute statistics over, as passed
             to `axis_name` in `jax.vmap` or `jax.pmap`. Can also be a sequence (e.g. a
             tuple or a list) of names, to compute statistics over multiple named axes.
+        - `approach`: The approach to use for the running statistics. If `approach=None`
+            a warning will be raised and approach will default to `"batch"`. During
+            training `"batch"` only uses batch statisics while`"ema"` uses the running
+            statistics.
         - `eps`: Value added to the denominator for numerical stability.
         - `channelwise_affine`: Whether the module has learnable channel-wise affine
             parameters.
         - `momentum`: The rate at which to update the running statistics. Should be a
             value between 0 and 1 exclusive.
+        - `warmup_period`: The period to warm up the running statistics. Only used when
+            `approach=\"ema\"`.
         - `inference`: If `False` then the batch means and variances will be calculated
             and used to update the running statistics. If `True` then the running
             statistics are directly used for normalisation. This may be toggled with
@@ -86,26 +98,37 @@ class BatchNorm(StatefulLayer, strict=True):
             64-bit mode.
         """
 
+        if approach is None:
+            warnings.warn('BatchNorm approach is None, defaults to approach="batch"')
+            approach = "batch"
+
+        valid_approaches = {"batch", "ema"}
+        if approach not in valid_approaches:
+            raise ValueError(f"approach must be one of {valid_approaches}")
+        self.approach = approach
+
         if channelwise_affine:
             self.weight = jnp.ones((input_size,))
             self.bias = jnp.zeros((input_size,))
         else:
             self.weight = None
             self.bias = None
-        self.first_time_index = StateIndex(jnp.array(True))
+        self.count_index = StateIndex(jnp.array(0, dtype=jnp.int32))
         if dtype is None:
             dtype = default_floating_dtype()
         init_buffers = (
-            jnp.empty((input_size,), dtype=dtype),
-            jnp.empty((input_size,), dtype=dtype),
+            jnp.zeros((input_size,), dtype=dtype),
+            jnp.zeros((input_size,), dtype=dtype),
         )
         self.state_index = StateIndex(init_buffers)
+        self.zero_frac_index = StateIndex(jnp.array(1.0, dtype=dtype))
         self.inference = inference
         self.axis_name = axis_name
         self.input_size = input_size
         self.eps = eps
         self.channelwise_affine = channelwise_affine
         self.momentum = momentum
+        self.warmup_period = max(1, warmup_period)
 
     @jax.named_scope("eqx.nn.BatchNorm")
     def __call__(
@@ -143,7 +166,10 @@ class BatchNorm(StatefulLayer, strict=True):
         if inference is None:
             inference = self.inference
         if inference:
+            zero_frac = state.get(self.zero_frac_index)
             running_mean, running_var = state.get(self.state_index)
+            norm_mean = running_mean / jnp.maximum(1.0 - zero_frac, self.eps)
+            norm_var = running_var / jnp.maximum(1.0 - zero_frac, self.eps)
         else:
 
             def _stats(y):
@@ -154,17 +180,29 @@ class BatchNorm(StatefulLayer, strict=True):
                 var = jnp.maximum(0.0, var)
                 return mean, var
 
-            first_time = state.get(self.first_time_index)
-            state = state.set(self.first_time_index, jnp.array(False))
+            momentum = self.momentum
+            zero_frac = state.get(self.zero_frac_index)
+            zero_frac *= momentum
+            state = state.set(self.zero_frac_index, zero_frac)
 
             batch_mean, batch_var = jax.vmap(_stats)(x)
             running_mean, running_var = state.get(self.state_index)
-            momentum = self.momentum
             running_mean = (1 - momentum) * batch_mean + momentum * running_mean
             running_var = (1 - momentum) * batch_var + momentum * running_var
-            running_mean = lax.select(first_time, batch_mean, running_mean)
-            running_var = lax.select(first_time, batch_var, running_var)
             state = state.set(self.state_index, (running_mean, running_var))
+
+            if self.approach == "ema":
+                warmup_count = state.get(self.count_index)
+                warmup_count = jnp.minimum(warmup_count + 1, self.warmup_period)
+                state = state.set(self.count_index, warmup_count)
+
+                warmup_frac = warmup_count / self.warmup_period
+                norm_mean = zero_frac * batch_mean + running_mean
+                norm_mean = (1.0 - warmup_frac) * batch_mean + warmup_frac * norm_mean
+                norm_var = zero_frac * batch_var + running_var
+                norm_var = (1.0 - warmup_frac) * batch_var + warmup_frac * norm_var
+            else:
+                norm_mean, norm_var = batch_mean, batch_var
 
         def _norm(y, m, v, w, b):
             out = (y - m) / jnp.sqrt(v + self.eps)
@@ -172,5 +210,5 @@ class BatchNorm(StatefulLayer, strict=True):
                 out = out * w + b
             return out
 
-        out = jax.vmap(_norm)(x, running_mean, running_var, self.weight, self.bias)
+        out = jax.vmap(_norm)(x, norm_mean, norm_var, self.weight, self.bias)
         return out, state

--- a/tests/test_stateful.py
+++ b/tests/test_stateful.py
@@ -7,7 +7,7 @@ import pytest
 
 
 def test_delete_init_state():
-    model = eqx.nn.BatchNorm(3, "batch")
+    model = eqx.nn.BatchNorm(3, "batch", approach="batch")
     eqx.nn.State(model)
     model2 = eqx.nn.delete_init_state(model)
 
@@ -17,7 +17,7 @@ def test_delete_init_state():
 
     leaves = [x for x in jtu.tree_leaves(model) if eqx.is_array(x)]
     leaves2 = [x for x in jtu.tree_leaves(model2) if eqx.is_array(x)]
-    assert len(leaves) == len(leaves2) + 3
+    assert len(leaves) == len(leaves2) + 4
 
 
 def test_double_state():


### PR DESCRIPTION
This is in reference to issue [659](https://github.com/patrick-kidger/equinox/issues/659).

I modified BatchNorm to have two approaches `"batch"` and `"ema"`.  `"batch"` just uses the batch statistics during training time.  If approach is not specified it defaults to `"batch"` with a warning.  It's robust and seems to be the standard choice - it's far less likely to kill a model just by adding it.

`"ema"` is based of the smooth start method in the above issue.  So keep a running mean and variance but instead of renormalizing Adam style the parts of the running averages that are zeroed are filled with the batch statistics.   The problem is it's still not robust - the momentum parameter is simultaneously specifying a warmup period (when we're expecting the input distribution to change significantly) and how long we want the running average to be.  So I added a linear warmup period.

Now for any choice of momentum there seems to be a `warmup_period` choice that will give good results.  And validation performance was at least as good as with batch mode for my tests.  However, I don't see a good default for `warmup_period`.

Some considerations:
- having `approach="batch"` and the common `axis_name="batch"` is a little awkward
- There's an example using BatchNorm - that will start raising a warning and should probably get changed
- The current BatchNorm behavior can't be exactly replicated (ema / momentum=0.99 / warmup_period=1) is close but different at the start
- There's one more piece of state hence the test_stateful.py change.  Though this could be conditionally removed for `approach="batch"` if desired

Let me know what you think or if any changes or tests need to be added

![image](https://github.com/patrick-kidger/equinox/assets/5267190/e3b43cb5-1cd7-41cc-bf43-4c826cf80bca)


