### PR TITLE
Simple `dtype` argument addition

### DIFF
--- a/equinox/nn/_linear.py
+++ b/equinox/nn/_linear.py
@@ -23,6 +23,7 @@ class Linear(Module, strict=True):
         in_features: Union[int, Literal["scalar"]],
         out_features: Union[int, Literal["scalar"]],
         use_bias: bool = True,
+        dtype=jnp.float32,
         *,
         key: PRNGKeyArray,
     ):
@@ -47,10 +48,12 @@ class Linear(Module, strict=True):
         out_features_ = 1 if out_features == "scalar" else out_features
         lim = 1 / math.sqrt(in_features_)
         self.weight = jrandom.uniform(
-            wkey, (out_features_, in_features_), minval=-lim, maxval=lim
+            wkey, (out_features_, in_features_), minval=-lim, maxval=lim, dtype=dtype
         )
         if use_bias:
-            self.bias = jrandom.uniform(bkey, (out_features_,), minval=-lim, maxval=lim)
+            self.bias = jrandom.uniform(
+                bkey, (out_features_,), minval=-lim, maxval=lim, dtype=dtype
+            )
         else:
             self.bias = None
 

--- a/equinox/nn/_linear.py
+++ b/equinox/nn/_linear.py
@@ -6,6 +6,7 @@ import jax.numpy as jnp
 import jax.random as jrandom
 from jaxtyping import Array, PRNGKeyArray
 
+from .._misc import default_floating_dtype
 from .._module import field, Module
 
 
@@ -23,7 +24,7 @@ class Linear(Module, strict=True):
         in_features: Union[int, Literal["scalar"]],
         out_features: Union[int, Literal["scalar"]],
         use_bias: bool = True,
-        dtype=jnp.float32,
+        dtype=None,
         *,
         key: PRNGKeyArray,
     ):
@@ -34,6 +35,8 @@ class Linear(Module, strict=True):
         - `out_features`: The output size. The output from the layer will be a vector
             of shape `(out_features,)`.
         - `use_bias`: Whether to add on a bias as well.
+        - `dtype`: The dtype to use. Defaults to either `jax.numpy.float32` or
+            `jax.numpy.float64` depending on whether JAX is in 64-bit mode.
         - `key`: A `jax.random.PRNGKey` used to provide randomness for parameter
             initialisation. (Keyword only argument.)
 
@@ -47,6 +50,10 @@ class Linear(Module, strict=True):
         in_features_ = 1 if in_features == "scalar" else in_features
         out_features_ = 1 if out_features == "scalar" else out_features
         lim = 1 / math.sqrt(in_features_)
+
+        if dtype is None:
+            dtype = default_floating_dtype()
+
         self.weight = jrandom.uniform(
             wkey, (out_features_, in_features_), minval=-lim, maxval=lim, dtype=dtype
         )

--- a/equinox/nn/_linear.py
+++ b/equinox/nn/_linear.py
@@ -35,8 +35,9 @@ class Linear(Module, strict=True):
         - `out_features`: The output size. The output from the layer will be a vector
             of shape `(out_features,)`.
         - `use_bias`: Whether to add on a bias as well.
-        - `dtype`: The dtype to use. Defaults to either `jax.numpy.float32` or
-            `jax.numpy.float64` depending on whether JAX is in 64-bit mode.
+        - `dtype`: The dtype to use for the weight and the bias in this layer.
+            Defaults to either `jax.numpy.float32` or `jax.numpy.float64` depending
+            on whether JAX is in 64-bit mode.
         - `key`: A `jax.random.PRNGKey` used to provide randomness for parameter
             initialisation. (Keyword only argument.)
 

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -44,6 +44,10 @@ def test_linear(getkey):
     x = jrandom.normal(getkey(), (2,))
     assert linear(x).shape == ()
 
+    linear = eqx.nn.Linear(2, "scalar", key=getkey(), dtype=jnp.float16)
+    x = jrandom.normal(getkey(), (2,), dtype=jnp.float16)
+    assert linear(x).dtype == jnp.float16
+
 
 def test_identity(getkey):
     identity1 = eqx.nn.Identity()


### PR DESCRIPTION
Simple addition of the dtype argument along with a very simple test (will increase the code coverage later).

A few thoughts:

1. If we don't make dtype an attribute, then we won't be able to do certain "nice to have" things in the `__call__`. For example, what if the user passed a `float32` array to a layer initialized with `float16`? Ideally we should warn the user to avoid silent bugs
2. I am not sure what should be the right annotation for the dtype argument