### PR TITLE
Wrap dropout probability into an array

### DIFF
--- a/equinox/nn/_attention.py
+++ b/equinox/nn/_attention.py
@@ -8,7 +8,7 @@ from typing import cast, Optional, Union
 import jax
 import jax.numpy as jnp
 import jax.random as jrandom
-from jaxtyping import Array, Bool, Float, PRNGKeyArray
+from jaxtyping import Array, ArrayLike, Bool, Float, PRNGKeyArray
 
 from .._module import field, Module
 from ._dropout import Dropout
@@ -148,7 +148,7 @@ class MultiheadAttention(Module, strict=True):
         use_key_bias: bool = False,
         use_value_bias: bool = False,
         use_output_bias: bool = False,
-        dropout_p: float = 0.0,
+        dropout_p: Float[ArrayLike, ""] = 0.0,
         inference: bool = False,
         *,
         key: PRNGKeyArray,

--- a/equinox/nn/_dropout.py
+++ b/equinox/nn/_dropout.py
@@ -6,7 +6,7 @@ import jax.lax as lax
 import jax.numpy as jnp
 import jax.random as jrandom
 import numpy as np
-from jaxtyping import Array, Float, PRNGKeyArray
+from jaxtyping import Array, ArrayLike, Float, PRNGKeyArray
 
 from .._errors import error_if
 from .._filters import is_array
@@ -23,14 +23,14 @@ class Dropout(Module, strict=True):
     """
 
     # Not static fields as it makes sense to modify them via equinox.tree_at
-    p: Float[np.ndarray, ""] = field(
-        converter=lambda x: x if is_array(x) else np.array(x)
+    p: Float[ArrayLike, ""] = field(
+        converter=lambda x: x if is_array(x) else np.array(x, dtype=np.float32)
     )
     inference: bool
 
     def __init__(
         self,
-        p: float = 0.5,
+        p: ArrayLike = 0.5,
         inference: bool = False,
         *,
         deterministic: Optional[bool] = None,
@@ -51,7 +51,7 @@ class Dropout(Module, strict=True):
                 "Dropout(deterministic=...) is deprecated "
                 "in favour of Dropout(inference=...)"
             )
-        self.p = p  # type: ignore
+        self.p = p
         self.inference = inference
 
     # Backward compatibility

--- a/equinox/nn/_dropout.py
+++ b/equinox/nn/_dropout.py
@@ -5,9 +5,10 @@ import jax
 import jax.lax as lax
 import jax.numpy as jnp
 import jax.random as jrandom
-from jaxtyping import Array, PRNGKeyArray
+from jaxtyping import Array, Float, PRNGKeyArray
 
-from .._module import Module
+from .._filters import is_array
+from .._module import field, Module
 
 
 class Dropout(Module, strict=True):
@@ -20,7 +21,7 @@ class Dropout(Module, strict=True):
     """
 
     # Not static fields as it makes sense to want to modify them via equinox.tree_at.
-    p: float
+    p: Float[Array, ""] = field(converter=lambda x: x if is_array(x) else jnp.array(x))
     inference: bool
 
     def __init__(
@@ -46,7 +47,7 @@ class Dropout(Module, strict=True):
                 "Dropout(deterministic=...) is deprecated "
                 "in favour of Dropout(inference=...)"
             )
-        self.p = p
+        self.p = p  # type: ignore
         self.inference = inference
 
     # Backward compatibility

--- a/equinox/nn/_dropout.py
+++ b/equinox/nn/_dropout.py
@@ -84,8 +84,6 @@ class Dropout(Module, strict=True):
 
         if inference is None:
             inference = self.inference
-        if isinstance(self.p, (int, float)) and self.p == 0:
-            inference = True
         if inference:
             return x
         elif key is None:

--- a/equinox/nn/_dropout.py
+++ b/equinox/nn/_dropout.py
@@ -30,7 +30,7 @@ class Dropout(Module, strict=True):
 
     def __init__(
         self,
-        p: ArrayLike = 0.5,
+        p: Float[ArrayLike, ""] = 0.5,
         inference: bool = False,
         *,
         deterministic: Optional[bool] = None,

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -1450,7 +1450,7 @@ def test_optax_scan_attn(dropout_p):
                 )
             )(model)
             # this does not throw only if dropout is dynamic
-            model = eqx.tree_at(lambda m: m._dropout.p, model, jnp.absolute(loss_value))
+            model = eqx.tree_at(lambda m: m.dropout.p, model, jnp.absolute(loss_value))
             updates, opt_state = optim.update(grads, opt_state, model)
             model = eqx.apply_updates(model, updates)
             return (model, opt_state), None

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -763,12 +763,11 @@ def test_multihead_attention(getkey):
         qk_size=13,
         vo_size=17,
         key=getkey(),
-        inference=True,
     )
     q = jrandom.uniform(getkey(), (19, 3))
     k = jrandom.uniform(getkey(), (23, 5))
     v = jrandom.uniform(getkey(), (23, 7))
-    assert attn(q, k, v, key=jrandom.PRNGKey(1)).shape == (19, 11)
+    assert attn(q, k, v).shape == (19, 11)
 
     attn = eqx.nn.MultiheadAttention(num_heads=2, query_size=4, key=getkey())
     attn = eqx.tree_at(
@@ -782,21 +781,18 @@ def test_multihead_attention(getkey):
         [jnp.arange(16.0).reshape(4, 4) for _ in range(4)],
     )
     x = jnp.array([[1.0, 2.0, 3.0, 4.0]])
-    assert jnp.allclose(
-        attn(x, x, x, key=jrandom.PRNGKey(2)),
-        jnp.array([[680.0, 1960.0, 3240.0, 4520.0]]),
-    )
+    assert jnp.allclose(attn(x, x, x), jnp.array([[680.0, 1960.0, 3240.0, 4520.0]]))
 
     x = jnp.arange(1, 13, dtype=jnp.float32).reshape(3, 4)
     mask = jnp.broadcast_to(jnp.array([True, False, False]), (2, 3, 3))
     assert jnp.allclose(
-        attn(x, x, x, mask, key=jrandom.PRNGKey(3)),
+        attn(x, x, x, mask),
         jnp.broadcast_to(jnp.array([[680.0, 1960.0, 3240.0, 4520.0]]), (3, 4)),
     )
 
     mask = jnp.broadcast_to(jnp.array([True, False, False]), (3, 3))
     assert jnp.allclose(
-        attn(x, x, x, mask, key=jrandom.PRNGKey(4)),
+        attn(x, x, x, mask),
         jnp.broadcast_to(jnp.array([[680.0, 1960.0, 3240.0, 4520.0]]), (3, 4)),
     )
 

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -763,11 +763,12 @@ def test_multihead_attention(getkey):
         qk_size=13,
         vo_size=17,
         key=getkey(),
+        inference=True,
     )
     q = jrandom.uniform(getkey(), (19, 3))
     k = jrandom.uniform(getkey(), (23, 5))
     v = jrandom.uniform(getkey(), (23, 7))
-    assert attn(q, k, v).shape == (19, 11)
+    assert attn(q, k, v, key=jrandom.PRNGKey(1)).shape == (19, 11)
 
     attn = eqx.nn.MultiheadAttention(num_heads=2, query_size=4, key=getkey())
     attn = eqx.tree_at(
@@ -781,18 +782,21 @@ def test_multihead_attention(getkey):
         [jnp.arange(16.0).reshape(4, 4) for _ in range(4)],
     )
     x = jnp.array([[1.0, 2.0, 3.0, 4.0]])
-    assert jnp.allclose(attn(x, x, x), jnp.array([[680.0, 1960.0, 3240.0, 4520.0]]))
+    assert jnp.allclose(
+        attn(x, x, x, key=jrandom.PRNGKey(2)),
+        jnp.array([[680.0, 1960.0, 3240.0, 4520.0]]),
+    )
 
     x = jnp.arange(1, 13, dtype=jnp.float32).reshape(3, 4)
     mask = jnp.broadcast_to(jnp.array([True, False, False]), (2, 3, 3))
     assert jnp.allclose(
-        attn(x, x, x, mask),
+        attn(x, x, x, mask, key=jrandom.PRNGKey(3)),
         jnp.broadcast_to(jnp.array([[680.0, 1960.0, 3240.0, 4520.0]]), (3, 4)),
     )
 
     mask = jnp.broadcast_to(jnp.array([True, False, False]), (3, 3))
     assert jnp.allclose(
-        attn(x, x, x, mask),
+        attn(x, x, x, mask, key=jrandom.PRNGKey(4)),
         jnp.broadcast_to(jnp.array([[680.0, 1960.0, 3240.0, 4520.0]]), (3, 4)),
     )
 

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -39,7 +39,7 @@ def test_shared_node(getkey):
 
         def __init__(self):
             attention = eqx.nn.MultiheadAttention(
-                num_heads=3, query_size=12, key=getkey(), inference=True
+                num_heads=3, query_size=12, key=getkey()
             )
             my_proj = eqx.nn.Linear(12, 12, use_bias=False, key=getkey())
             where = lambda pair: pair[1].key_proj
@@ -88,7 +88,7 @@ def test_multi_shared(getkey):
         def __init__(self):
             my_proj = eqx.nn.Linear(12, 12, use_bias=False, key=getkey())
             attention = eqx.nn.MultiheadAttention(
-                num_heads=3, query_size=12, key=getkey(), inference=True
+                num_heads=3, query_size=12, key=getkey()
             )
             where = lambda pair: (pair[1].key_proj, pair[1].query_proj.weight)
             get = lambda pair: (pair[0], pair[0].weight + 1)

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -39,7 +39,7 @@ def test_shared_node(getkey):
 
         def __init__(self):
             attention = eqx.nn.MultiheadAttention(
-                num_heads=3, query_size=12, key=getkey()
+                num_heads=3, query_size=12, key=getkey(), inference=True
             )
             my_proj = eqx.nn.Linear(12, 12, use_bias=False, key=getkey())
             where = lambda pair: pair[1].key_proj
@@ -88,7 +88,7 @@ def test_multi_shared(getkey):
         def __init__(self):
             my_proj = eqx.nn.Linear(12, 12, use_bias=False, key=getkey())
             attention = eqx.nn.MultiheadAttention(
-                num_heads=3, query_size=12, key=getkey()
+                num_heads=3, query_size=12, key=getkey(), inference=True
             )
             where = lambda pair: (pair[1].key_proj, pair[1].query_proj.weight)
             get = lambda pair: (pair[0], pair[0].weight + 1)


### PR DESCRIPTION
Hey, Patrick!

I was working a bit with attention recently, and I discovered that the obvious implementation of a training loop with ```scan``` and ```optax``` fails. The culprit is the probability of the dropout: the value is ```float```, so it is not included in the model filtered with ```eqx.filter(model, eqx.is_array)``` since ```float``` is not an array. So, when initializing optax optimizer using this filtered model, the value is for ```p``` is None. Later, if we try to apply gradients, everything fails, because the gradient, on the other hand, is ```0.0``` and not None. And optax cannot comprehend this. 

I thought about three main solutions:
1. Force the gradient of p to be None. After some experiments with custom jvp rules it seems to be impossible, since the output shapes of the gradient function should be different: either static None or a jnp.float; And using just jnp.nan instead of None does not work.
2. Add new ```eqx.field(differentiate=True/False)``` flag, and new ```is_differentiable``` filter, that would together allow to specify whether field is forced to be differentiable or forced to be non-differentiable. This sounds like quite a bit of work, for such a simple bug-fix. But it might be useful for people who write libraries: like, users of the 3rd party library would love to be able to figure out dynamic and static parameters using the same ```eqx.is_differentiable```, which might have sensible defaults (e.g. similar to ```is_array```).
3. Just wrap the p in Dropout into jax array if it is not a jax array. This might break some compatibility... But I am not sure how badly is it in reality.

I implemented the 3rd approach + added a test with a very simple training pipeline for a multihead attention. WDYT?