### PR TITLE
Add dtypes to the rest of eqx.nn

### DIFF
--- a/equinox/nn/_batch_norm.py
+++ b/equinox/nn/_batch_norm.py
@@ -81,20 +81,19 @@ class BatchNorm(StatefulLayer, strict=True):
             statistics are directly used for normalisation. This may be toggled with
             [`equinox.nn.inference_mode`][] or overridden during
             [`equinox.nn.BatchNorm.__call__`][].
-        - `dtype`: The dtype to use for the running statistics. Defaults to either
+        - `dtype`: The dtype to use for the running statistics and the weight and bias
+            if `channelwise_affine` is `True`. Defaults to either
             `jax.numpy.float32` or `jax.numpy.float64` depending on whether JAX is in
             64-bit mode.
         """
-
+        dtype = default_floating_dtype() if dtype is None else dtype
         if channelwise_affine:
-            self.weight = jnp.ones((input_size,))
-            self.bias = jnp.zeros((input_size,))
+            self.weight = jnp.ones((input_size,), dtype=dtype)
+            self.bias = jnp.zeros((input_size,), dtype=dtype)
         else:
             self.weight = None
             self.bias = None
         self.first_time_index = StateIndex(jnp.array(True))
-        if dtype is None:
-            dtype = default_floating_dtype()
         init_buffers = (
             jnp.empty((input_size,), dtype=dtype),
             jnp.empty((input_size,), dtype=dtype),

--- a/equinox/nn/_conv.py
+++ b/equinox/nn/_conv.py
@@ -10,6 +10,7 @@ import jax.random as jrandom
 import numpy as np
 from jaxtyping import Array, PRNGKeyArray
 
+from .._misc import default_floating_dtype
 from .._module import field, Module
 from ._misc import all_sequences
 
@@ -95,6 +96,7 @@ class Conv(Module, strict=True):
         groups: int = 1,
         use_bias: bool = True,
         padding_mode: str = "ZEROS",
+        dtype=None,
         *,
         key: PRNGKeyArray,
     ):
@@ -122,6 +124,9 @@ class Conv(Module, strict=True):
             - `'REPLICATE'`: pads with the replication of edge values,
                 `1234 -> 11123444`.
             - `'CIRCULAR'`: pads with circular values, `1234 -> 34123412`.
+        - `dtype`: The dtype to use for the weight and the bias in this layer.
+            Defaults to either `jax.numpy.float32` or `jax.numpy.float64` depending
+            on whether JAX is in 64-bit mode.
         - `key`: A `jax.random.PRNGKey` used to provide randomness for parameter
             initialisation. (Keyword only argument.)
 
@@ -148,6 +153,7 @@ class Conv(Module, strict=True):
                 case the padding is an odd number, then the extra padding is added at
                 the end for `'SAME'` and at the beginning for `'SAME_LOWER'`.
         """
+        dtype = default_floating_dtype() if dtype is None else dtype
         wkey, bkey = jrandom.split(key, 2)
 
         parse = _ntuple(num_spatial_dims)
@@ -168,6 +174,7 @@ class Conv(Module, strict=True):
             (out_channels, grouped_in_channels) + kernel_size,
             minval=-lim,
             maxval=lim,
+            dtype=dtype,
         )
         if use_bias:
             self.bias = jrandom.uniform(
@@ -175,6 +182,7 @@ class Conv(Module, strict=True):
                 (out_channels,) + (1,) * num_spatial_dims,
                 minval=-lim,
                 maxval=lim,
+                dtype=dtype,
             )
         else:
             self.bias = None
@@ -270,6 +278,7 @@ class Conv1d(Conv):
         groups: int = 1,
         use_bias: bool = True,
         padding_mode: str = "ZEROS",
+        dtype=None,
         *,
         key: PRNGKeyArray,
     ):
@@ -284,6 +293,7 @@ class Conv1d(Conv):
             groups=groups,
             use_bias=use_bias,
             padding_mode=padding_mode,
+            dtype=dtype,
             key=key,
         )
 
@@ -302,6 +312,7 @@ class Conv2d(Conv):
         groups: int = 1,
         use_bias: bool = True,
         padding_mode: str = "ZEROS",
+        dtype=None,
         *,
         key: PRNGKeyArray,
     ):
@@ -316,6 +327,7 @@ class Conv2d(Conv):
             groups=groups,
             use_bias=use_bias,
             padding_mode=padding_mode,
+            dtype=dtype,
             key=key,
         )
 
@@ -334,6 +346,7 @@ class Conv3d(Conv):
         groups: int = 1,
         use_bias: bool = True,
         padding_mode: str = "ZEROS",
+        dtype=None,
         *,
         key: PRNGKeyArray,
     ):
@@ -348,6 +361,7 @@ class Conv3d(Conv):
             groups=groups,
             use_bias=use_bias,
             padding_mode=padding_mode,
+            dtype=dtype,
             key=key,
         )
 
@@ -382,6 +396,7 @@ class ConvTranspose(Module, strict=True):
         groups: int = 1,
         use_bias: bool = True,
         padding_mode: str = "ZEROS",
+        dtype=None,
         *,
         key: PRNGKeyArray,
     ):
@@ -409,6 +424,9 @@ class ConvTranspose(Module, strict=True):
             - `'ZEROS'` (default): pads with zeros, no extra connectivity.
             - `'CIRCULAR'`: pads with circular values, extra connectivity (see the Tip
                 below).
+        - `dtype`: The dtype to use for the weight and the bias in this layer.
+            Defaults to either `jax.numpy.float32` or `jax.numpy.float64` depending
+            on whether JAX is in 64-bit mode.
         - `key`: A `jax.random.PRNGKey` used to provide randomness for parameter
             initialisation. (Keyword only argument.)
 
@@ -474,7 +492,7 @@ class ConvTranspose(Module, strict=True):
             `padding_mode='CIRCULAR'` is only implemented for `output_padding=0` and
             `padding='SAME'` or `'SAME_LOWER'`.
         """  # noqa: E501
-
+        dtype = default_floating_dtype() if dtype is None else dtype
         wkey, bkey = jrandom.split(key, 2)
 
         parse = _ntuple(num_spatial_dims)
@@ -494,6 +512,7 @@ class ConvTranspose(Module, strict=True):
             (out_channels, grouped_in_channels) + kernel_size,
             minval=-lim,
             maxval=lim,
+            dtype=dtype,
         )
         if use_bias:
             self.bias = jrandom.uniform(
@@ -501,6 +520,7 @@ class ConvTranspose(Module, strict=True):
                 (out_channels,) + (1,) * num_spatial_dims,
                 minval=-lim,
                 maxval=lim,
+                dtype=dtype,
             )
         else:
             self.bias = None
@@ -628,6 +648,7 @@ class ConvTranspose1d(ConvTranspose):
         groups: int = 1,
         use_bias: bool = True,
         padding_mode: str = "ZEROS",
+        dtype=None,
         *,
         key: PRNGKeyArray,
     ):
@@ -643,6 +664,7 @@ class ConvTranspose1d(ConvTranspose):
             groups=groups,
             use_bias=use_bias,
             padding_mode=padding_mode,
+            dtype=dtype,
             key=key,
         )
 
@@ -662,6 +684,7 @@ class ConvTranspose2d(ConvTranspose):
         groups: int = 1,
         use_bias: bool = True,
         padding_mode: str = "ZEROS",
+        dtype=None,
         *,
         key: PRNGKeyArray,
     ):
@@ -677,6 +700,7 @@ class ConvTranspose2d(ConvTranspose):
             groups=groups,
             use_bias=use_bias,
             padding_mode=padding_mode,
+            dtype=dtype,
             key=key,
         )
 
@@ -696,6 +720,7 @@ class ConvTranspose3d(ConvTranspose):
         groups: int = 1,
         use_bias: bool = True,
         padding_mode: str = "ZEROS",
+        dtype=None,
         *,
         key: PRNGKeyArray,
     ):

--- a/equinox/nn/_rnn.py
+++ b/equinox/nn/_rnn.py
@@ -7,6 +7,7 @@ import jax.numpy as jnp
 import jax.random as jrandom
 from jaxtyping import Array, PRNGKeyArray
 
+from .._misc import default_floating_dtype
 from .._module import field, Module
 
 
@@ -45,6 +46,7 @@ class GRUCell(Module, strict=True):
         input_size: int,
         hidden_size: int,
         use_bias: bool = True,
+        dtype=None,
         *,
         key: PRNGKeyArray,
     ):
@@ -54,25 +56,28 @@ class GRUCell(Module, strict=True):
         - `hidden_size`: The dimensionality of the hidden state passed along between
             time steps.
         - `use_bias`: Whether to add on a bias after each update.
+        - `dtype`: The dtype to use for all weights and biases in this GRU cell.
+            Defaults to either `jax.numpy.float32` or `jax.numpy.float64` depending on
+            whether JAX is in 64-bit mode.
         - `key`: A `jax.random.PRNGKey` used to provide randomness for parameter
             initialisation. (Keyword only argument.)
         """
-
+        dtype = default_floating_dtype() if dtype is None else dtype
         ihkey, hhkey, bkey, bkey2 = jrandom.split(key, 4)
         lim = math.sqrt(1 / hidden_size)
 
         self.weight_ih = jrandom.uniform(
-            ihkey, (3 * hidden_size, input_size), minval=-lim, maxval=lim
+            ihkey, (3 * hidden_size, input_size), minval=-lim, maxval=lim, dtype=dtype
         )
         self.weight_hh = jrandom.uniform(
-            hhkey, (3 * hidden_size, hidden_size), minval=-lim, maxval=lim
+            hhkey, (3 * hidden_size, hidden_size), minval=-lim, maxval=lim, dtype=dtype
         )
         if use_bias:
             self.bias = jrandom.uniform(
-                bkey, (3 * hidden_size,), minval=-lim, maxval=lim
+                bkey, (3 * hidden_size,), minval=-lim, maxval=lim, dtype=dtype
             )
             self.bias_n = jrandom.uniform(
-                bkey2, (hidden_size,), minval=-lim, maxval=lim
+                bkey2, (hidden_size,), minval=-lim, maxval=lim, dtype=dtype
             )
         else:
             self.bias = None
@@ -147,6 +152,7 @@ class LSTMCell(Module, strict=True):
         input_size: int,
         hidden_size: int,
         use_bias: bool = True,
+        dtype=None,
         *,
         key: PRNGKeyArray,
     ):
@@ -156,22 +162,25 @@ class LSTMCell(Module, strict=True):
         - `hidden_size`: The dimensionality of the hidden state passed along between
             time steps.
         - `use_bias`: Whether to add on a bias after each update.
+        - `dtype`: The dtype to use for all weights and biases in this LSTM cell.
+            Defaults to either `jax.numpy.float32` or `jax.numpy.float64` depending on
+            whether JAX is in 64-bit mode.
         - `key`: A `jax.random.PRNGKey` used to provide randomness for parameter
             initialisation. (Keyword only argument.)
         """
-
+        dtype = default_floating_dtype() if dtype is None else dtype
         ihkey, hhkey, bkey = jrandom.split(key, 3)
         lim = math.sqrt(1 / hidden_size)
 
         self.weight_ih = jrandom.uniform(
-            ihkey, (4 * hidden_size, input_size), minval=-lim, maxval=lim
+            ihkey, (4 * hidden_size, input_size), minval=-lim, maxval=lim, dtype=dtype
         )
         self.weight_hh = jrandom.uniform(
-            hhkey, (4 * hidden_size, hidden_size), minval=-lim, maxval=lim
+            hhkey, (4 * hidden_size, hidden_size), minval=-lim, maxval=lim, dtype=dtype
         )
         if use_bias:
             self.bias = jrandom.uniform(
-                bkey, (4 * hidden_size,), minval=-lim, maxval=lim
+                bkey, (4 * hidden_size,), minval=-lim, maxval=lim, dtype=dtype
             )
         else:
             self.bias = None

--- a/equinox/nn/_spectral_norm.py
+++ b/equinox/nn/_spectral_norm.py
@@ -6,6 +6,7 @@ import jax.numpy as jnp
 import jax.random as jr
 from jaxtyping import Array, Float, PRNGKeyArray
 
+from .._misc import default_floating_dtype
 from .._module import field
 from .._tree import tree_at
 from ._sequential import StatefulLayer
@@ -66,6 +67,7 @@ class SpectralNorm(StatefulLayer, Generic[_Layer], strict=True):
         num_power_iterations: int = 1,
         eps: float = 1e-12,
         inference: bool = False,
+        dtype=None,
         *,
         key: PRNGKeyArray,
     ):
@@ -81,10 +83,13 @@ class SpectralNorm(StatefulLayer, Generic[_Layer], strict=True):
         - `inference`: Whether this is in inference mode, at which time no power
             iterations are performed.  This may be toggled with
             [`equinox.nn.inference_mode`][].
+        - `dtype`: The dtype to use for the `u` and `v` vectors. Defaults to either
+            `jax.numpy.float32` or `jax.numpy.float64` depending on whether JAX is in
+            64-bit mode.
         - `key`: A `jax.random.PRNGKey` used to provide randomness for initialisation.
             (Keyword only argument.)
         """
-
+        dtype = default_floating_dtype() if dtype is None else dtype
         self.layer = layer
         self.weight_name = weight_name
         self.num_power_iterations = num_power_iterations
@@ -97,8 +102,8 @@ class SpectralNorm(StatefulLayer, Generic[_Layer], strict=True):
         weight = jnp.reshape(weight, (weight.shape[0], -1))
         u_len, v_len = weight.shape
         ukey, vkey = jr.split(key)
-        u0 = jr.normal(ukey, (u_len,))
-        v0 = jr.normal(vkey, (v_len,))
+        u0 = jr.normal(ukey, (u_len,), dtype=dtype)
+        v0 = jr.normal(vkey, (v_len,), dtype=dtype)
         for _ in range(15):
             u0, v0 = _power_iteration(weight, u0, v0, eps)
         self.uv_index = StateIndex((u0, v0))


### PR DESCRIPTION
Basically the same as #680 but for the rest of the API.

Double check `SpectralNorm` - I'm not 100% confident in that one.