### PR TITLE
Add autoregressiveness to MHA (again)

### DIFF
--- a/equinox/_misc.py
+++ b/equinox/_misc.py
@@ -18,3 +18,10 @@ def default_floating_dtype():
         return jnp.float64
     else:
         return jnp.float32
+
+
+def default_int_dtype():
+    if jax.config.jax_enable_x64:  # pyright: ignore
+        return jnp.int64
+    else:
+        return jnp.int32

--- a/equinox/nn/_attention.py
+++ b/equinox/nn/_attention.py
@@ -401,22 +401,9 @@ class MultiheadAttention(Module, strict=True):
                     "`MultiheadAttention(..., state_length=...)`."
                 )
             key_state, value_state, index = state.get(self.autoregressive_index)
-            key_seq_length = key_heads.shape[0]
-            if index + key_seq_length > self.state_length:
-                key_shift = index + key_seq_length - self.state_length
-                key_shift = min(key_shift, key_seq_length)
-                key_state = jnp.roll(key_state, -key_shift, axis=0)
-
             key_state = lax.dynamic_update_slice_in_dim(
                 key_state, key_heads, index, axis=0
             )
-
-            value_seq_length = value_heads.shape[0]
-            if index + value_seq_length > self.state_length:
-                value_shift = index + value_seq_length - self.state_length
-                value_shift = min(value_shift, value_seq_length)
-                value_state = jnp.roll(value_state, -value_shift, axis=0)
-
             value_state = lax.dynamic_update_slice_in_dim(
                 value_state, value_heads, index, axis=0
             )

--- a/equinox/nn/_kv_cache.py
+++ b/equinox/nn/_kv_cache.py
@@ -1,0 +1,103 @@
+from abc import abstractmethod
+
+import jax.lax as lax
+import jax.numpy as jnp
+from jaxtyping import Array, Float, Int
+
+from .._misc import default_int_dtype
+from .._module import field, Module
+from ._stateful import State, StateIndex
+
+
+class AbstractKVCache(Module, strict=True):
+    key_shape: tuple[int, int, int] = field(static=True)
+    value_shape: tuple[int, int, int] = field(static=True)
+
+    autoregressive_index: StateIndex
+
+    def __init__(
+        self,
+        key_shape: tuple[int, int, int],
+        value_shape: tuple[int, int, int],
+    ):
+        self.key_shape = key_shape
+        self.value_shape = value_shape
+
+        def _make_cache(**_):
+            _int = default_int_dtype()
+            return jnp.empty(key_shape), jnp.empty(value_shape), jnp.zeros((), _int)
+
+        self.autoregressive_index = StateIndex(_make_cache())
+
+    @abstractmethod
+    def _get_cache(
+        self,
+        state: State,
+        key_heads: Float[Array, "seq_length num_heads qk_size"],
+        value_heads: Float[Array, "seq_length num_heads vo_size"],
+    ) -> tuple[
+        Float[Array, "state_length num_heads qk_size"],
+        Float[Array, "state_length num_heads vo_size"],
+        Int[Array, ""],
+        State,
+    ]:
+        raise NotImplementedError
+
+    def __call__(
+        self,
+        state: State,
+        key_heads: Float[Array, "seq_length num_heads qk_size"],
+        value_heads: Float[Array, "seq_length num_heads vo_size"],
+    ) -> tuple[
+        Float[Array, "state_length num_heads qk_size"],
+        Float[Array, "state_length num_heads vo_size"],
+        Int[Array, ""],
+        State,
+    ]:
+        key_state, value_state, index, state = self._get_cache(
+            state, key_heads, value_heads
+        )
+        key_shape = key_state.shape
+        value_shape = value_state.shape
+        if key_shape != self.key_shape:
+            raise ValueError(f"Expected key shape {self.key_shape}, got {key_shape}")
+        if value_shape != self.value_shape:
+            raise ValueError(
+                f"Expected value shape {self.value_shape}, got {value_shape}"
+            )
+        return key_state, value_state, index, state
+
+
+class StandardKVCache(AbstractKVCache):
+    def __init__(
+        self,
+        key_shape: tuple[int, int, int],
+        value_shape: tuple[int, int, int],
+    ):
+        super().__init__(key_shape, value_shape)
+
+    def _get_cache(
+        self,
+        state: State,
+        key_heads: Float[Array, "seq_length num_heads qk_size"],
+        value_heads: Float[Array, "seq_length num_heads vo_size"],
+    ) -> tuple[
+        Float[Array, "state_length num_heads qk_size"],
+        Float[Array, "state_length num_heads vo_size"],
+        Int[Array, ""],
+        State,
+    ]:
+        kv_seq_length, _, _ = key_heads.shape
+        kv_seq_length2, _, _ = value_heads.shape
+        if kv_seq_length != kv_seq_length2:
+            # query length can be different
+            raise ValueError("key and value must both be sequences of equal length.")
+        key_state, value_state, index = state.get(self.autoregressive_index)
+        key_state = lax.dynamic_update_slice_in_dim(key_state, key_heads, index, axis=0)
+        value_state = lax.dynamic_update_slice_in_dim(
+            value_state, value_heads, index, axis=0
+        )
+        index = index + kv_seq_length
+        state = state.set(self.autoregressive_index, (key_state, value_state, index))
+
+        return key_state, value_state, index, state

--- a/test.py
+++ b/test.py
@@ -1,0 +1,28 @@
+import equinox as eqx
+import jax
+from equinox.nn._attention import MultiheadAttention
+from equinox.nn._kv_cache import StandardKVCache
+
+
+query_size = 6
+num_heads = 1
+state_length = 8
+seq_len = 3
+
+standard_kv_cache = StandardKVCache(
+    key_shape=(state_length, num_heads, query_size),
+    value_shape=(state_length, num_heads, query_size),
+)
+
+key = jax.random.PRNGKey(0)
+mha, state = eqx.nn.make_with_state(MultiheadAttention)(
+    query_size=query_size,
+    num_heads=num_heads,
+    state_length=state_length,
+    kv_cache=standard_kv_cache,
+    key=key,
+)
+
+for states in range(state_length - 3):
+    x = jax.numpy.ones(shape=(seq_len, query_size)) * (states + 1)
+    y, state = mha(x, x, x, mask="causal", state=state)


### PR DESCRIPTION
Hi, I noticed that the autoregressive-attention branch has become stale and a few things have changed in the dev branch since then. So I thought I'd revive the auto regressive branch.

Note that this does not yet have the MQA <-> MHA interpolation. In our last discussion, I told you about my "double VMAP" strategy and that LLMs such as LLaMA don't use that but instead simply "repeat" the keys and values until they match the queries. You were not sure which approach to follow.

I actually have a working version of the MHA implementation in which I allow the user to choose which one they want (see [this](https://github.com/Artur-Galstyan/kira/blob/main/kira/modules/mha.py#L136). Maybe in the future we could have something similar, but for now, I think it's ok to add autoregressive decoding - even without the MHA<->MQA interpolation. 

WDYT?