### PR TITLE
Fix for https://github.com/patrick-kidger/optimistix/issues/48

### DIFF
--- a/equinox/internal/_loop/bounded.py
+++ b/equinox/internal/_loop/bounded.py
@@ -32,7 +32,7 @@ def bounded_while_loop(
     - `body_fun`: As `lax.while_loop`.
     - `init_val`: As `lax.while_loop`.
     - `max_steps`: A bound on the maximum number of steps, after which the loop
-        terminates unconditionally. Can be set to `None` for arbitrarily many steps.
+        terminates unconditionally.
     - `buffers`: If passed, then every leaf of `tree_leaves(buffers(init_val))` must
         be an array; all such arrays become buffers supporting only `[]` and
         `.at[].set()`. However they will act efficiently, without spurious copies.
@@ -43,7 +43,6 @@ def bounded_while_loop(
     **Returns:**
 
     The final value; as `lax.while_loop`.
-
     """
 
     if not isinstance(max_steps, int) or max_steps < 0:


### PR DESCRIPTION
This is a fix for https://github.com/patrick-kidger/optimistix/issues/48

It happens occasionally that JAX will insert a spurious vmap. It seems like we're hitting one of these cases.

In particular I found that:
- We are hitting this `nonbatchable` call https://github.com/patrick-kidger/equinox/blob/60612c13666ec75350a83972396c94fc684d223c/equinox/internal/_loop/common.py#L432, due to `step` getting batched.
- Inserting a `val = (nonbatchable(val[0]),) + val[1:]` here: https://github.com/patrick-kidger/equinox/blob/60612c13666ec75350a83972396c94fc684d223c/equinox/internal/_loop/bounded.py#L72 will also trigger an error before the previously-mentioned one. But shifting this additional check to the other side of the `jax.checkpoint` (a few lines further down) will not raise an error before the previously-mentioned one.

Spelunking through the (very deep) JAX stack traces, it seems to be due to the `lax.scan` saving its evolving state for use in the backward pass -- in particular including this `step` -- and for some reason the insertion of the `jax.checkpoint` causes this state to become batched. Then when we run the backwards scan during backprop, we re-run this function with the batched state and so things explode. I didn't try digging into it further than that, as I'm not hugely surprised -- such spurious batching is a thing JAX does every now and again.

In terms of a fix: for the actual mathematical correctness, we do continue to disallow a batch to have nonconstant `step`s (I would need to think a lot harder about whether nonconstant `step` can ever be valid). However if a batch tracer does arise, then we simply punt the nonconstancy check to runtime. This definitely isn't ideal, but this is (a) a pretty unusual edge-case (`DirectAdjoint` + `vmap` + `optimistix`), and (b) it's better than crashing. (Hopefully all of this becomes unnecessary if `jvp-of-custom_vjp` is implemented and we can remove `DirectAdjoint` entirely.)
