### PR TITLE
Better AD for checkpointed while loop.

### DIFF
--- a/equinox/_ad.py
+++ b/equinox/_ad.py
@@ -835,7 +835,7 @@ def _none_to_zero(ct, x):
         else:
             # No raising-to-vspace. JAX is internally inconsistent, and expects integers
             # to have integer tangents from custom_{jvp,vjp} rules
-            aval = jax.core.get_aval(x)  # .at_least_vspace()
+            aval = jax.core.raise_to_shaped(jax.core.get_aval(x))  # .at_least_vspace()
             return jax.custom_derivatives.SymbolicZero(aval)
     else:
         return ct

--- a/equinox/internal/_loop/common.py
+++ b/equinox/internal/_loop/common.py
@@ -197,7 +197,7 @@ def _maybe_set_transpose(
             ct_x = _select_if_vmap(pred, ct_x, jnp.zeros_like(ct_x), makes_false_steps)
     else:
         ct_x = None
-    return [None, ct_xs, ct_x, None]
+    return [None, ct_xs, ct_x] + [None] * len(i_dynamic_leaves)
 
 
 maybe_set_p = create_vprim(


### PR DESCRIPTION
The main improvement here is that a checkpointed while loop will now only propagate perturbations for those outputs that are actually perturbed. Whilst this doesn't affect the backward pass at all (we were already trimming the cotangents according to this criterion), this now means that any calls to `eqx.nondifferentiable`, or any primitive without a JVP rule, will now no longer throw an error.

In addition, this commit includes a couple of crash fixes (needed to pass the new test).

In particular this fixes the use of `TextProgressBar` reported in https://github.com/patrick-kidger/diffrax/issues/396.