### PR TITLE
Fix rmsnorm

### DIFF
--- a/equinox/nn/_normalisation.py
+++ b/equinox/nn/_normalisation.py
@@ -382,8 +382,10 @@ class RMSNorm(Module, strict=True):
                 f"Received `shape={self.shape} and `x.shape={x.shape}`. You might need "
                 "to replace `rms_norm(x)` with `jax.vmap(rms_norm)(x)`.\n"
             )
-        inv_rms = jax.lax.rsqrt(jnp.mean(x**2) + self.eps)
-        out = inv_rms * x
+        x_dtype = x.dtype
+        upscaled_x = x.astype(jnp.float32)
+        inv_rms = jax.lax.rsqrt(jnp.mean(upscaled_x**2) + self.eps)
+        out = (inv_rms * upscaled_x).astype(x_dtype)
         if self.use_weight:
             out = self.weight * out
         if self.use_bias:

--- a/equinox/nn/_normalisation.py
+++ b/equinox/nn/_normalisation.py
@@ -383,9 +383,9 @@ class RMSNorm(Module, strict=True):
                 "to replace `rms_norm(x)` with `jax.vmap(rms_norm)(x)`.\n"
             )
         x_dtype = x.dtype
-        upscaled_x = x.astype(jnp.float32)
-        inv_rms = jax.lax.rsqrt(jnp.mean(upscaled_x**2) + self.eps)
-        out = (inv_rms * upscaled_x).astype(x_dtype)
+        upcasted_x = x.astype(jnp.float32)
+        inv_rms = jax.lax.rsqrt(jnp.mean(upcasted_x**2) + self.eps)
+        out = (inv_rms * upcasted_x).astype(x_dtype)
         if self.use_weight:
             out = self.weight * out
         if self.use_bias:


### PR DESCRIPTION
The norm calculations should always be done with at least `fp32` dtype, and then the result should be casted back to the original dtype