### PR TITLE
Avoid use of deprecated jax.tree_map

### DIFF
--- a/tests/test_ad.py
+++ b/tests/test_ad.py
@@ -184,7 +184,7 @@ def test_grad_jit_old():
 
 
 def test_filter_jvp():
-    _map_is_array_like = lambda pytree: jax.tree_map(
+    _map_is_array_like = lambda pytree: jtu.tree_map(
         lambda x: jnp.array(x) if eqx.is_array_like(x) else x, pytree
     )
 

--- a/tests/test_sharding.py
+++ b/tests/test_sharding.py
@@ -1,6 +1,7 @@
 import equinox as eqx
 import jax
 import jax.random as jr
+import jax.tree_util as jtu
 
 
 [cpu] = jax.local_devices(backend="cpu")
@@ -15,7 +16,7 @@ def test_sharding():
     @eqx.filter_jit
     def f(x):
         a, b = eqx.partition(x, eqx.is_array)
-        a = jax.tree_map(lambda x: x + 1, a)
+        a = jtu.tree_map(lambda x: x + 1, a)
         x = eqx.combine(a, b)
         return eqx.filter_shard(x, sharding)
 


### PR DESCRIPTION
`jax.tree_map` was deprecated in JAX v0.4.26; preferred replacements are `jax.tree.map` (JAX v0.4.25 or later) or `jax.tree_util.tree_map` (any JAX version).