### PR TITLE
Updated ruff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ examples/CIFAR
 examples/MNIST
 examples/multipart_serialised.eqx
 .python-version
+.DS_Store

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,14 +1,25 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.7
+    rev: v0.4.4
     hooks:
-      - id: ruff  # linter
-        types_or: [ python, pyi, jupyter ]
-        args: [ --fix ]
-      - id: ruff-format  # formatter
-        types_or: [ python, pyi, jupyter ]
+      - id: ruff # linter
+        types_or: [python, pyi, jupyter]
+        args: [--fix]
+      - id: ruff-format # formatter
+        types_or: [python, pyi, jupyter]
   - repo: https://github.com/RobertCraigie/pyright-python
     rev: v1.1.351
     hooks:
-    - id: pyright
-      additional_dependencies: [beartype, einops, jax, jaxtyping, optax, pytest, tensorflow, tf2onnx, typing_extensions]
+      - id: pyright
+        additional_dependencies:
+          [
+            beartype,
+            einops,
+            jax,
+            jaxtyping,
+            optax,
+            pytest,
+            tensorflow,
+            tf2onnx,
+            typing_extensions,
+          ]

--- a/equinox/_ad.py
+++ b/equinox/_ad.py
@@ -114,15 +114,13 @@ _ScalarTy = TypeVar("_ScalarTy", bound=_Scalar)
 def filter_value_and_grad(
     *,
     has_aux: Literal[False] = False,
-) -> Callable[[Callable[_P, _ScalarTy]], Callable[_P, tuple[_ScalarTy, PyTree]]]:
-    ...
+) -> Callable[[Callable[_P, _ScalarTy]], Callable[_P, tuple[_ScalarTy, PyTree]]]: ...
 
 
 @overload
 def filter_value_and_grad(
     fun: Callable[_P, _ScalarTy], *, has_aux: Literal[False] = False
-) -> Callable[_P, tuple[_ScalarTy, PyTree]]:
-    ...
+) -> Callable[_P, tuple[_ScalarTy, PyTree]]: ...
 
 
 @overload
@@ -132,22 +130,19 @@ def filter_value_and_grad(
 ) -> Callable[
     [Callable[_P, tuple[_ScalarTy, _T]]],
     Callable[_P, tuple[tuple[_ScalarTy, _T], PyTree]],
-]:
-    ...
+]: ...
 
 
 @overload
 def filter_value_and_grad(
     fun: Callable[_P, tuple[_ScalarTy, _T]], *, has_aux: Literal[True] = True
-) -> Callable[_P, tuple[tuple[_ScalarTy, _T], PyTree]]:
-    ...
+) -> Callable[_P, tuple[tuple[_ScalarTy, _T], PyTree]]: ...
 
 
 @overload
 def filter_value_and_grad(
     fun: Callable[_P, _T], *, has_aux: bool = False
-) -> Callable[_P, tuple[_T, PyTree]]:
-    ...
+) -> Callable[_P, tuple[_T, PyTree]]: ...
 
 
 @doc_remove_args("gradkwargs")
@@ -197,15 +192,13 @@ def filter_value_and_grad(
 def filter_grad(
     *,
     has_aux: Literal[False] = False,
-) -> Callable[[Callable[_P, _Scalar]], Callable[_P, PyTree[Float[Array, "..."]]]]:
-    ...
+) -> Callable[[Callable[_P, _Scalar]], Callable[_P, PyTree[Float[Array, "..."]]]]: ...
 
 
 @overload
 def filter_grad(
     fun: Callable[_P, _Scalar], *, has_aux: Literal[False] = False
-) -> Callable[_P, PyTree[Float[Array, "..."]]]:
-    ...
+) -> Callable[_P, PyTree[Float[Array, "..."]]]: ...
 
 
 @overload
@@ -215,20 +208,19 @@ def filter_grad(
 ) -> Callable[
     [Callable[_P, tuple[_Scalar, _T]]],
     Callable[_P, tuple[PyTree[Float[Array, "..."]], _T]],
-]:
-    ...
+]: ...
 
 
 @overload
 def filter_grad(
     fun: Callable[_P, tuple[_Scalar, _T]], *, has_aux: Literal[True] = True
-) -> Callable[_P, tuple[PyTree[Float[Array, "..."]], _T]]:
-    ...
+) -> Callable[_P, tuple[PyTree[Float[Array, "..."]], _T]]: ...
 
 
 @overload
-def filter_grad(fun: Callable[_P, Any], *, has_aux: bool = False) -> Callable[_P, Any]:
-    ...
+def filter_grad(
+    fun: Callable[_P, Any], *, has_aux: bool = False
+) -> Callable[_P, Any]: ...
 
 
 @doc_remove_args("gradkwargs")
@@ -365,15 +357,13 @@ def filter_jvp(
 @overload
 def filter_vjp(
     fun: Callable[..., _T], *primals, has_aux: Literal[False] = False
-) -> tuple[_T, Callable[..., tuple[PyTree, ...]]]:
-    ...
+) -> tuple[_T, Callable[..., tuple[PyTree, ...]]]: ...
 
 
 @overload
 def filter_vjp(
     fun: Callable[..., tuple[_T, _S]], *primals, has_aux: Literal[True] = True
-) -> tuple[_T, Callable[..., tuple[PyTree, ...]], _S]:
-    ...
+) -> tuple[_T, Callable[..., tuple[PyTree, ...]], _S]: ...
 
 
 def filter_vjp(fun, *primals, has_aux: bool = False):

--- a/equinox/_better_abstract.py
+++ b/equinox/_better_abstract.py
@@ -5,6 +5,7 @@ Provides enhanced versions of `abc.ABCMeta` and `dataclasses.dataclass` that res
 this type annotation. (In practice the sole consumer of these is `equinox.Module`, which
 is the public API. But the two pieces aren't directly related under-the-hood.)
 """
+
 import abc
 import dataclasses
 from typing import (

--- a/equinox/_enum.py
+++ b/equinox/_enum.py
@@ -205,11 +205,9 @@ if TYPE_CHECKING:
     from typing_extensions import Self
 
     class _Sequence(type):
-        def __getitem__(cls, item) -> str:
-            ...
+        def __getitem__(cls, item) -> str: ...
 
-        def __len__(cls) -> int:
-            ...
+        def __len__(cls) -> int: ...
 
     class Enumeration(  # pyright: ignore
         enum.Enum, EnumerationItem, metaclass=_Sequence
@@ -219,12 +217,10 @@ if TYPE_CHECKING:
         _base_offsets: ClassVar[dict["Enumeration", int]]
 
         @classmethod
-        def promote(cls, item: "Enumeration") -> Self:
-            ...
+        def promote(cls, item: "Enumeration") -> Self: ...
 
         @classmethod
-        def where(cls, pred: Bool[ArrayLike, "..."], a: Self, b: Self) -> Self:
-            ...
+        def where(cls, pred: Bool[ArrayLike, "..."], a: Self, b: Self) -> Self: ...
 
 else:
     _Enumeration = doc_repr(Any, "Enumeration")

--- a/equinox/_jit.py
+++ b/equinox/_jit.py
@@ -244,8 +244,7 @@ def filter_jit(
     donate: Literal[
         "all", "all-except-first", "warn", "warn-except-first", "none"
     ] = "none",
-) -> Callable[[Callable[_P, _T]], Callable[_P, _T]]:
-    ...
+) -> Callable[[Callable[_P, _T]], Callable[_P, _T]]: ...
 
 
 @overload
@@ -255,8 +254,7 @@ def filter_jit(
     donate: Literal[
         "all", "all-except-first", "warn", "warn-except-first", "none"
     ] = "none",
-) -> Callable[_P, _T]:
-    ...
+) -> Callable[_P, _T]: ...
 
 
 @doc_remove_args("jitkwargs")

--- a/equinox/_module.py
+++ b/equinox/_module.py
@@ -3,6 +3,7 @@
 This includes both the core dataclass+pytree combo, plus various related pieces of
 functionality.
 """
+
 import abc
 import dataclasses
 import functools as ft

--- a/equinox/_vmap_pmap.py
+++ b/equinox/_vmap_pmap.py
@@ -244,8 +244,7 @@ def filter_vmap(
     out_axes: PyTree[AxisSpec] = if_array(0),
     axis_name: Hashable = None,
     axis_size: Optional[int] = None,
-) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
-    ...
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]: ...
 
 
 @overload
@@ -256,8 +255,7 @@ def filter_vmap(
     out_axes: PyTree[AxisSpec] = if_array(0),
     axis_name: Hashable = None,
     axis_size: Optional[int] = None,
-) -> Callable[..., Any]:
-    ...
+) -> Callable[..., Any]: ...
 
 
 @doc_remove_args("vmapkwargs")
@@ -573,8 +571,7 @@ def filter_pmap(
     axis_name: Hashable = None,
     axis_size: Optional[int] = None,
     donate: Literal["all", "warn", "none"] = "none",
-) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
-    ...
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]: ...
 
 
 @overload
@@ -586,8 +583,7 @@ def filter_pmap(
     axis_name: Hashable = None,
     axis_size: Optional[int] = None,
     donate: Literal["all", "warn", "none"] = "none",
-) -> Callable[..., Any]:
-    ...
+) -> Callable[..., Any]: ...
 
 
 @doc_remove_args("pmapkwargs")

--- a/equinox/debug/_max_traces.py
+++ b/equinox/debug/_max_traces.py
@@ -86,16 +86,14 @@ class _AssertMaxTraces(Module):
 @overload
 def assert_max_traces(
     fn: Callable[_P, _T], *, max_traces: Optional[int]
-) -> Callable[_P, _T]:
-    ...
+) -> Callable[_P, _T]: ...
 
 
 @overload
 def assert_max_traces(
     *,
     max_traces: Optional[int],
-) -> Callable[[Callable[_P, _T]], Callable[_P, _T]]:
-    ...
+) -> Callable[[Callable[_P, _T]], Callable[_P, _T]]: ...
 
 
 def assert_max_traces(fn: Callable = sentinel, *, max_traces: Optional[int]):

--- a/equinox/internal/_finalise_jaxpr.py
+++ b/equinox/internal/_finalise_jaxpr.py
@@ -136,15 +136,13 @@ def finalise_fn(fn):
 @overload
 def finalise_make_jaxpr(
     fn, *, return_shape: Literal[False] = False
-) -> Callable[..., jax.core.ClosedJaxpr]:
-    ...
+) -> Callable[..., jax.core.ClosedJaxpr]: ...
 
 
 @overload
 def finalise_make_jaxpr(
     fn, *, return_shape: Literal[True] = True
-) -> Callable[..., tuple[jax.core.ClosedJaxpr, PyTree[jax.ShapeDtypeStruct]]]:
-    ...
+) -> Callable[..., tuple[jax.core.ClosedJaxpr, PyTree[jax.ShapeDtypeStruct]]]: ...
 
 
 @overload
@@ -155,8 +153,7 @@ def finalise_make_jaxpr(
     Union[
         jax.core.ClosedJaxpr, tuple[jax.core.ClosedJaxpr, PyTree[jax.ShapeDtypeStruct]]
     ],
-]:
-    ...
+]: ...
 
 
 def finalise_make_jaxpr(fn, *, return_shape: bool = False):
@@ -213,7 +210,7 @@ def _stop_gradient_finalisation(x):
     return x
 
 
-primitive_finalisations[
-    jax.custom_derivatives.custom_jvp_call_p
-] = _jvp_call_p_finalisation
+primitive_finalisations[jax.custom_derivatives.custom_jvp_call_p] = (
+    _jvp_call_p_finalisation
+)
 primitive_finalisations[jax.lax.stop_gradient_p] = _stop_gradient_finalisation

--- a/equinox/internal/_nontraceable.py
+++ b/equinox/internal/_nontraceable.py
@@ -1,6 +1,7 @@
 """This module provides operations to assert that a particular value is always
 unbatched, or not differentiated, etc.
 """
+
 import functools as ft
 from typing import Optional
 
@@ -93,12 +94,12 @@ _nondifferentiable_backward_impl = lambda x, *, msg, symbolic: x
 nondifferentiable_backward_p.def_impl(_nondifferentiable_backward_impl)
 nondifferentiable_backward_p.def_abstract_eval(_nondifferentiable_backward_impl)
 ad.primitive_jvps[nondifferentiable_backward_p] = _nondifferentiable_backward_jvp
-ad.primitive_transposes[
-    nondifferentiable_backward_p
-] = _nondifferentiable_backward_transpose
-batching.primitive_batchers[
-    nondifferentiable_backward_p
-] = _nondifferentiable_backward_batch
+ad.primitive_transposes[nondifferentiable_backward_p] = (
+    _nondifferentiable_backward_transpose
+)
+batching.primitive_batchers[nondifferentiable_backward_p] = (
+    _nondifferentiable_backward_batch
+)
 mlir.register_lowering(
     nondifferentiable_backward_p,
     mlir.lower_fun(_nondifferentiable_backward_impl, multiple_results=False),

--- a/equinox/nn/_misc.py
+++ b/equinox/nn/_misc.py
@@ -11,8 +11,7 @@ if TYPE_CHECKING:
     # https://github.com/microsoft/pyright/issues/3450
     def all_sequences(
         x: Union[Sequence[Any], Sequence[_T]],
-    ) -> "te.TypeIs[Sequence[_T]]":
-        ...
+    ) -> "te.TypeIs[Sequence[_T]]": ...
 
 else:
     # beartype doesn't like StrictTypeGuard

--- a/equinox/nn/_normalisation.py
+++ b/equinox/nn/_normalisation.py
@@ -98,14 +98,12 @@ class LayerNorm(Module, strict=True):
         self.bias = jnp.zeros(shape, dtype=dtype) if use_bias else None
 
     @overload
-    def __call__(self, x: Array, *, key: Optional[PRNGKeyArray] = None) -> Array:
-        ...
+    def __call__(self, x: Array, *, key: Optional[PRNGKeyArray] = None) -> Array: ...
 
     @overload
     def __call__(
         self, x: Array, state: State, *, key: Optional[PRNGKeyArray] = None
-    ) -> tuple[Array, State]:
-        ...
+    ) -> tuple[Array, State]: ...
 
     @jax.named_scope("eqx.nn.LayerNorm")
     def __call__(
@@ -228,14 +226,12 @@ class GroupNorm(Module, strict=True):
         self.bias = jnp.zeros(channels, dtype=dtype) if channelwise_affine else None
 
     @overload
-    def __call__(self, x: Array, *, key: Optional[PRNGKeyArray] = None) -> Array:
-        ...
+    def __call__(self, x: Array, *, key: Optional[PRNGKeyArray] = None) -> Array: ...
 
     @overload
     def __call__(
         self, x: Array, state: State, *, key: Optional[PRNGKeyArray] = None
-    ) -> tuple[Array, State]:
-        ...
+    ) -> tuple[Array, State]: ...
 
     @jax.named_scope("eqx.nn.GroupNorm")
     def __call__(
@@ -343,14 +339,12 @@ class RMSNorm(Module, strict=True):
         self.bias = jnp.zeros(shape, dtype=dtype) if use_bias else None
 
     @overload
-    def __call__(self, x: Array, *, key: Optional[PRNGKeyArray] = None) -> Array:
-        ...
+    def __call__(self, x: Array, *, key: Optional[PRNGKeyArray] = None) -> Array: ...
 
     @overload
     def __call__(
         self, x: Array, state: State, *, key: Optional[PRNGKeyArray] = None
-    ) -> tuple[Array, State]:
-        ...
+    ) -> tuple[Array, State]: ...
 
     @jax.named_scope("eqx.nn.RMSNorm")
     def __call__(

--- a/equinox/nn/_sequential.py
+++ b/equinox/nn/_sequential.py
@@ -64,14 +64,12 @@ class Sequential(StatefulLayer, strict=StrictConfig(allow_method_override=True))
         )
 
     @overload
-    def __call__(self, x: Array, *, key: Optional[PRNGKeyArray] = None) -> Array:
-        ...
+    def __call__(self, x: Array, *, key: Optional[PRNGKeyArray] = None) -> Array: ...
 
     @overload
     def __call__(
         self, x: Array, state: State, *, key: Optional[PRNGKeyArray] = None
-    ) -> tuple[Array, State]:
-        ...
+    ) -> tuple[Array, State]: ...
 
     @jax.named_scope("eqx.nn.Sequential")
     def __call__(

--- a/equinox/nn/_stateful.py
+++ b/equinox/nn/_stateful.py
@@ -358,8 +358,7 @@ def make_with_state(make_model: Callable[_P, _T]) -> Callable[_P, tuple[_T, Stat
 
         def make_with_state_impl(
             *args: _P.args, **kwargs: _P.kwargs
-        ) -> tuple[_T, State]:
-            ...
+        ) -> tuple[_T, State]: ...
 
     else:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,13 +37,15 @@ addopts = "--jaxtyping-packages=equinox,beartype.beartype(conf=beartype.Beartype
 
 [tool.ruff]
 extend-include = ["*.ipynb"]
+src = []
+
+[tool.ruff.lint]
 fixable = ["I001", "F401"]
 ignore = ["E402", "E721", "E731", "E741", "F722"]
 ignore-init-module-imports = true
 select = ["E", "F", "I001"]
-src = []
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 combine-as-imports = true
 extra-standard-library = ["typing_extensions"]
 lines-after-imports = 2

--- a/tests/test_abstract.py
+++ b/tests/test_abstract.py
@@ -14,8 +14,7 @@ else:
 def test_abstract_method():
     class A(eqx.Module):
         @abc.abstractmethod
-        def x(self):
-            ...
+        def x(self): ...
 
     class B(A):
         pass


### PR DESCRIPTION
I've updated the pre-commit hook's ruff version to v.0.4.4.

This also meant that the top level "lint" section in the pyproject.toml had to change as well (I think this change came after v.0.2.0). 