### PR TITLE
Update users of jax.tree.map() to be more careful about how they hand…

### DIFF
--- a/equinox/internal/_primitive.py
+++ b/equinox/internal/_primitive.py
@@ -77,7 +77,7 @@ def _replace_none(x):
 
 
 def _get_second(x, y):
-    return y
+    return None if x is None else y
 
 
 def _make_spec(x, y):
@@ -128,7 +128,7 @@ class Flatten:
                 assert treedef_out_old == treedef_out
                 assert tree_equal(static_out_old, static_out)
             like = jtu.tree_map(_replace_none, like, is_leaf=_is_none)
-            like = jtu.tree_map(_get_second, dynamic_out, like)
+            like = jtu.tree_map(_get_second, dynamic_out, like, is_leaf=_is_none)
             flat_like, treedef_like = jtu.tree_flatten(like)
             flat_like = [None if x is _dummy_none else x for x in flat_like]
             assert treedef_like == treedef_out


### PR DESCRIPTION
…le Nones.

Due to a bug in JAX, JAX previously permitted jax.tree.map(f, None, x) where x is not None, effectively treating None as if it were pytree-prefix of any value. But None is a pytree container, and it is only a prefix of None itself.

Fix user code that was relying on this bug. Most commonly, the fix is to write jax.tree.map(lambda a, b: (None if a is None else f(a, b)), x, y, is_leaf=lambda t: t is None).