### PR TITLE
Broken links and how to find them

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -126,7 +126,7 @@ eqx.filter_jit(loss_fn)(model, x, y) # ok
 
 This error happens because a model, when treated as a PyTree, may have leaves that are not JAX types (such as functions). It only makes sense to trace arrays. Filtering is used to handle this.
 
-Instead of [`jax.jit`](https://jax.readthedocs.io/en/latest/_autosummary/jax.jit.html), use [`equinox.filter_jit`][]. Likewise for [other transformations](https://docs.kidger.site/equinox/api/filtering/transformations).
+Instead of [`jax.jit`](https://jax.readthedocs.io/en/latest/_autosummary/jax.jit.html), use [`equinox.filter_jit`][]. Likewise for [other transformations](https://docs.kidger.site/equinox/api/transformations/).
 
 ## How to mark arrays as non-trainable? (Like PyTorch's buffers?)
 

--- a/equinox/_sharding.py
+++ b/equinox/_sharding.py
@@ -30,7 +30,7 @@ def filter_shard(
     A copy of `x` with the specified sharding constraints.
 
     !!! Example
-        See also the [autoparallelism example](../../../examples/parallelism).
+        See also the [autoparallelism example](../../examples/parallelism).
     """
     if isinstance(device_or_shardings, Device):
         shardings = jax.sharding.SingleDeviceSharding(device_or_shardings)

--- a/equinox/_update.py
+++ b/equinox/_update.py
@@ -25,7 +25,7 @@ def apply_updates(model: PyTree, updates: PyTree) -> PyTree:
     This is often useful when updating a model's parameters via stochastic gradient
     descent. (This function is essentially the same as `optax.apply_updates`, except
     that it understands `None`.) For example see the
-    [Train RNN example](../../../examples/train_rnn/).
+    [Train RNN example](../../examples/train_rnn/).
 
     **Arguments:**
 

--- a/examples/score_based_diffusion.ipynb
+++ b/examples/score_based_diffusion.ipynb
@@ -25,7 +25,7 @@
     "\n",
     "$y(1) \\sim \\mathcal{N}(0, I)\\qquad\\mathrm{d}y(t) = -\\frac{1}{2}β(t) (y(t) + s_\\theta(t, y(t)))\\mathrm{d}t \\qquad\\text{for }t \\in [0, T].$\n",
     "\n",
-    "- Uses an [MLP-Mixer](https://arxiv.org/abs/2105.01601) to parameterise the score model $s_\\theta$. ([See here](./unet/) for a U-Net implementation that could be substituted.)\n",
+    "- Uses an [MLP-Mixer](https://arxiv.org/abs/2105.01601) to parameterise the score model $s_\\theta$. ([See here](./unet.ipynb) for a U-Net implementation that could be substituted.)\n",
     "\n",
     "This example is available as a Jupyter notebook [here](https://github.com/patrick-kidger/equinox/blob/main/examples/score_based_diffusion.ipynb).\n",
     "\n",

--- a/examples/serialisation.ipynb
+++ b/examples/serialisation.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Serialising both weights and hyperparameters\n",
     "\n",
-    "Equinox has [facilities](/equinox/api/utilities/serialisation/) for the serialisation of the leaves of arbitrary PyTrees. The most basic use is to call `eqx.tree_serialise_leaves(filename, model)` to write all weights to a file. Deserialisation requires a PyTree of the correct shape to serve as a \"skeleton\" of sorts, whose weights are then read from the file with `model = eqx.tree_deserialise_leaves(filename, skeleton)`.\n",
+    "Equinox has [facilities](https://docs.kidger.site/equinox/api/serialisation/) for the serialisation of the leaves of arbitrary PyTrees. The most basic use is to call `eqx.tree_serialise_leaves(filename, model)` to write all weights to a file. Deserialisation requires a PyTree of the correct shape to serve as a \"skeleton\" of sorts, whose weights are then read from the file with `model = eqx.tree_deserialise_leaves(filename, skeleton)`.\n",
     "\n",
     "However, a typical model has both weights (arrays stored as leaves in the PyTree) and hyperparameters (the size of the network, etc.). When deserialising, we would like to read the hyperparameters as well as the weights. Ideally they should be stored in the same file. We can accomplish this as follows."
    ]

--- a/examples/unet.ipynb
+++ b/examples/unet.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "This is an advanced example, providing an implementation of a U-Net architecture.\n",
     "\n",
-    "This version is intended for use in a [score-based diffusion](../score_based_diffusion/), so it accepts a `t` argument.\n",
+    "This version is intended for use in a [score-based diffusion](score_based_diffusion.ipynb), so it accepts a `t` argument.\n",
     "\n",
     "This example is available as a Jupyter notebook [here](https://github.com/patrick-kidger/equinox/blob/main/examples/unet.ipynb)\n",
     "\n",


### PR DESCRIPTION
To catch broken links you can run this every time you do a major refactoring of the documentation.

```bash
wget --spider  -o wget.log  -e robots=off --wait 1 -r -p https://docs.kidger.site/equinox/
```
[source](https://stackoverflow.com/questions/65515/how-to-find-broken-links-on-a-website)