### PR TITLE
Disable static arrays

### DIFF
--- a/equinox/_ad.py
+++ b/equinox/_ad.py
@@ -344,12 +344,15 @@ def filter_jvp(
         _in = combine(_dynamic, static_primals)
         _out = fn(*_in, **kwargs)
         _dynamic_out, _static_out = partition(_out, _is_jvp_tracer(_main))
-        return _dynamic_out, Static(_static_out)
+        _arr_out, _non_arr_out = partition(_static_out, is_array)
+        return _dynamic_out, _arr_out, Static(_non_arr_out)
 
     primal_out, tangent_out = jax.jvp(_fn, flat_dynamic_primals, flat_tangents)
-    dynamic_primal_out, static_primal_out = primal_out
-    primal_out = combine(dynamic_primal_out, static_primal_out.value)
-    tangent_out, _ = tangent_out
+    dynamic_primal_out, arr_primal_out, static_primal_out = primal_out
+    primal_out = combine(
+        dynamic_primal_out, combine(arr_primal_out, static_primal_out.value)
+    )
+    tangent_out, _, _ = tangent_out
 
     return primal_out, tangent_out
 

--- a/equinox/_ad.py
+++ b/equinox/_ad.py
@@ -349,9 +349,7 @@ def filter_jvp(
 
     primal_out, tangent_out = jax.jvp(_fn, flat_dynamic_primals, flat_tangents)
     dynamic_primal_out, arr_primal_out, static_primal_out = primal_out
-    primal_out = combine(
-        dynamic_primal_out, combine(arr_primal_out, static_primal_out.value)
-    )
+    primal_out = combine(dynamic_primal_out, arr_primal_out, static_primal_out.value)
     tangent_out, _, _ = tangent_out
 
     return primal_out, tangent_out

--- a/equinox/_module.py
+++ b/equinox/_module.py
@@ -24,7 +24,7 @@ from jaxtyping import Array, Bool, PyTreeDef
 from ._better_abstract import ABCMeta, dataclass
 from ._caches import cache_clears
 from ._doc_utils import doc_repr
-from ._filters import is_array, is_array_like
+from ._filters import is_array_like
 from ._pretty_print import tree_pformat
 from ._tree import tree_equal
 
@@ -1237,7 +1237,10 @@ class Static(Module):
         # By flattening, we handle pytrees without `__eq__` methods.
         # When comparing static metadata for equality, this means we never actually
         # call `value.__eq__`.
-        if is_array(value):
+        # if is_array(value):
+        try:
+            hash(value)
+        except Exception as _:
             raise ValueError("JAX arrays cannot be set as Static!")
         self._leaves, self._treedef = jtu.tree_flatten(value)
 

--- a/equinox/_module.py
+++ b/equinox/_module.py
@@ -592,7 +592,11 @@ class _ModuleMeta(ABCMeta):  # pyright: ignore
                         is_array, jtu.tree_flatten(getattr(self, field.name))[0]
                     )
                 ):
-                    raise ValueError("JAX Arrays cannot be marked as static!")
+                    warnings.warn(
+                        "A JAX array is being set as static! This can result "
+                        "in unexpected behavior and is usually a mistake to do.",
+                        stacklevel=2,
+                    )
         # Freeze.
         object.__setattr__(self, "__class__", cls)
         # [Step 4] Run any custom validators. (After freezing; as they run

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -1158,8 +1158,14 @@ def test_no_jax_array_static():
 
     Valid((), jnp.ones(2))
 
-    with pytest.raises(ValueError, match="JAX Arrays cannot be marked as static!"):
+    with pytest.warns(
+        UserWarning,
+        match="A JAX array is being set as static!",
+    ):
         InvalidTuple((jnp.ones(10),), jnp.ones(10))
 
-    with pytest.raises(ValueError, match="JAX Arrays cannot be marked as static!"):
+    with pytest.warns(
+        UserWarning,
+        match="A JAX array is being set as static!",
+    ):
         InvalidArr((), jnp.ones(10))

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -1141,3 +1141,25 @@ def test_converter_annotations():
     assert Foo1.__init__.__annotations__["x"] is Any
     assert Foo2.__init__.__annotations__["x"] is int
     assert Foo3.__init__.__annotations__["x"] is bool
+
+
+def test_no_jax_array_static():
+    class Valid(eqx.Module):
+        a: tuple
+        b: jax.Array
+
+    class InvalidTuple(eqx.Module):
+        a: tuple = eqx.field(static=True)
+        b: jax.Array
+
+    class InvalidArr(eqx.Module):
+        a: tuple
+        b: jax.Array = eqx.field(static=True)
+
+    Valid((), jnp.ones(2))
+
+    with pytest.raises(ValueError, match="JAX Arrays cannot be marked as static!"):
+        InvalidTuple((jnp.ones(10),), jnp.ones(10))
+
+    with pytest.raises(ValueError, match="JAX Arrays cannot be marked as static!"):
+        InvalidArr((), jnp.ones(10))


### PR DESCRIPTION
Originally, by just checking the type, users could still footgun themselves with `Static` arrays if they hide them in pytrees (they still can if they use field). For example, tuple of array will still try to do this and won't error, but is actually an error since a tuple relies on the hashes of its members. 


As a solution, I figured it would be more direct to just see if it was hashable at all, but perhaps there are some edge cases where this might not be ideal(?). However, I could only do this for the `Static` directly not the field marker, since we don't access the `init` of the user so if they just type a `tuple` and mark it as static then fill it with arrays, I'm not sure how we could catch that.