### PR TITLE
Update parallelism.ipynb

### DIFF
--- a/examples/parallelism.ipynb
+++ b/examples/parallelism.ipynb
@@ -90,7 +90,7 @@
    "source": [
     "Okay, now the interesting things start happening!\n",
     "\n",
-    "First, we're going to arrange to \\\"donate\\\" memory, which specifes that we can re-use the memory for our input arrays (e.g. model parameters) to store the output arrays (e.g. updated model parameters). (This isn't technically related to autoparallelism, but it's good practice so you should do it anyway :)\n",
+    "First, we're going to arrange to \"donate\" memory, which specifes that we can re-use the memory for our input arrays (e.g. model parameters) to store the output arrays (e.g. updated model parameters). (This isn't technically related to autoparallelism, but it's good practice so you should do it anyway :)\n",
     "\n",
     "Second, we're going to use `eqx.filter_shard` to assert (on the inputs) and enforce (on the outputs) how each array is split across each of our devices. As we're doing data parallelism in this example, then we'll be replicating our model parameters on to every device, whilst sharding our data between devices."
    ]
@@ -198,9 +198,7 @@
     "\n",
     "Once you've specified how you want to split up your input data, then JAX does the rest of it for you! It takes your single JIT'd computation (which you wrote as if you were targeting a single huge device), and it then automatically determined how to split up that computation and have each device handle part of the computation. This is JAX's computation-follows-data approach to autoparallelism.\n",
     "\n",
-    "If you ran the above example on a cluster of NVIDIA GPUs, then you can check whether you're using as many GPUs as you expected by running `nvidia-smi` from the command line. You can also use `jax.debug.visualize_array_sharding(array)` to inspect the sharding manually.\n",
-    "\n",
-    "One possible optimisation here is to re-use the memory used by the input arrays, to store the output arrays. This often improves speed a little bit. This is disabled by default, but can be enabled by passing `eqx.filter_jit(donate=\"all\")`.\n",
+    "If you ran the above example on a computer with multiple NVIDIA GPUs, then you can check whether you're using as many GPUs as you expected by running `nvidia-smi` from the command line. You can also use `jax.debug.visualize_array_sharding(array)` to inspect the sharding manually.\n",
     "\n",
     "**What about pmap?**\n",
     "\n",


### PR DESCRIPTION
Minor improvements:
* `nvidia-smi` works on a single computer, not a cluster.
* The example code already does donate arguments, so the sentence about adding that is unneeded.
* Remove backslashes around double quotes. They are rendered in the equinox web site and don't appear to be needed.