### PR TITLE
Remove polyfill

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,9 +42,8 @@ edit_uri: ""  # No edit button, as some of our pages are in /docs and some in /e
 strict: true  # Don't allow warnings during the build process
 
 extra_javascript: 
-    # The below three make MathJax work, see https://squidfunk.github.io/mkdocs-material/reference/mathjax/
+    # The below two make MathJax work, see https://squidfunk.github.io/mkdocs-material/reference/mathjax/
     - _static/mathjax.js
-    - https://polyfill.io/v3/polyfill.min.js?features=es6
     - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 
 extra_css:


### PR DESCRIPTION
This updates the documentation by removing polyfill. IANAFED (I am not a front end developer), but I guess polyfill.io allowed all browsers to use the es6 features. Turns out:

- polyfill [has been serving malware](https://www.techradar.com/pro/security/thousands-of-websites-told-to-ditch-polyfill-service-after-chinese-hackers-hijack-it-to-serve-malware)
- https://squidfunk.github.io/mkdocs-material/reference/math/#mathjax-mkdocsyml no longer suggests polyfill
- It [probably isn't needed for 97% of traffic for es6 features](https://caniuse.com/?search=es6#google_vignette)
