### PR TITLE
Allow splitting to any number of partitions

### DIFF
--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -143,8 +143,24 @@ def test_partition_and_combine(getkey):
 
 
 def test_partition_subtree():
-    a, b = eqx.partition([(1,), 2], [True, False])
-    eqx.combine(a, b)
+    pytree = [(1,), 2]
+
+    a, b = eqx.partition(pytree, [True, False])
+
+    assert eqx.combine(a, b) == pytree
+
+
+def test_partition_multi():
+    pytree = [(1,), 2, (3.0, "four")]
+
+    partitions = eqx.partition(
+        pytree,
+        [True, False, False],
+        [False, False, (False, True)],
+        lambda x: isinstance(x, float),
+    )
+
+    assert eqx.combine(*partitions) == pytree
 
 
 def test_is_leaf():


### PR DESCRIPTION
Targets #824 

Hi @patrick-kidger, in this PR I modify `eqx.partition` such that it accepts any ($N$) number of filter specifications and returns $N + 1$ partitions. To keep backward compatibility, I have kept the `filter_spec` argument and added a variadic positional argument `*filter_specs`. This however forces `replace` and `is_leaf` to become keyword arguments. I think that is ok.