### PR TITLE
fix: RoPE embeddings do not preserve dtypes

### DIFF
--- a/equinox/nn/_embedding.py
+++ b/equinox/nn/_embedding.py
@@ -110,15 +110,6 @@ class RotaryPositionalEmbedding(Module, strict=True):
     can be used in any context, it is particularly useful for providing positional
     information to transformer models.
 
-    `RotaryPositionalEmbedding` should be initialised with:
-
-    - `embedding_size`: Size of each embedding vector. Must be non-negative.
-    - `theta`: Specifies how quickly the inner-product will decay with relative
-        distance. Chosen as 10_000 by default, as in the original paper.
-    - `dtype`: The dtype to use for the precomputed frequencies. Defaults to either
-        `jax.numpy.float32` or `jax.numpy.float64` depending on whether JAX is in
-        64-bit mode.
-
     !!! Example
 
         The following example demonstrates how to use `RotaryPositionalEmbedding` in
@@ -260,9 +251,12 @@ class RotaryPositionalEmbedding(Module, strict=True):
 
 RotaryPositionalEmbedding.__init__.__doc__ = """**Arguments:**
 
-- `embedding_size`: Size of the token embeddings. Must be non-negative and even.
-- `theta`: The base frequency for the sinusoidal functions. It defines the rate
-   of oscillation for the sine and cosine waves that encode positional information
-   into the embeddings. The larger the theta value, the slower the oscillations
-   and vice versa. Defaults to 10_000.0
+- `embedding_size`: Size of each embedding vector. Must be non-negative and even.
+- `theta`: The base frequency for the sinusoidal functions used in positional encoding.
+    Specifies how quickly the inner-product will decay with relative distance between
+    tokens. Larger values of theta will result in slower oscillations. Default is
+    10_000, as per the original paper.
+- `dtype`: The dtype to use for the precomputed frequencies. Defaults to either
+    `jax.numpy.float32` or `jax.numpy.float64` depending on whether JAX is in
+    64-bit mode.
 """

--- a/equinox/nn/_embedding.py
+++ b/equinox/nn/_embedding.py
@@ -242,7 +242,7 @@ class RotaryPositionalEmbedding(Module, strict=True):
 
         rotate_x = self.rotate_half(x)
         x_rope = (x * freqs_cos) + (rotate_x * freqs_sin)
-        return x_rope
+        return x_rope.astype(x.dtype)
 
 
 RotaryPositionalEmbedding.__init__.__doc__ = """**Arguments:**

--- a/equinox/nn/_embedding.py
+++ b/equinox/nn/_embedding.py
@@ -185,11 +185,14 @@ class RotaryPositionalEmbedding(Module, strict=True):
     ) -> tuple[Float[Array, "end half_emb_size"], Float[Array, "end half_emb_size"]]:
         freqs = 1.0 / (
             theta
-            ** (jnp.arange(0.0, embedding_size, 2)[jnp.newaxis, :] / embedding_size)
+            ** (
+                jnp.arange(0.0, embedding_size, 2, dtype=dtype)[jnp.newaxis, :]
+                / embedding_size
+            )
         )
 
-        t = jnp.arange(float(end))
-        freqs_outer = jnp.outer(t, freqs).astype(dtype)
+        t = jnp.arange(float(end), dtype=dtype)
+        freqs_outer = jnp.outer(t, freqs)
 
         return jnp.cos(freqs_outer), jnp.sin(freqs_outer)
 

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -7,6 +7,7 @@ import jax.nn as jnn
 import jax.numpy as jnp
 import jax.random as jrandom
 import pytest
+from jax._src.dtypes import TypePromotionError
 
 
 def test_custom_init():
@@ -1462,6 +1463,10 @@ def test_rope_embeddings_values():
             expected_values.astype(jnp.float16),
             rtol=1e-3,
         )
+
+    # check that without dtype promotion we throw an error
+    with pytest.raises(TypePromotionError):
+        rope_embeddings(x.astype(jnp.float16))
 
     rope_embeddings = eqx.nn.RotaryPositionalEmbedding(
         embedding_size, dtype=jnp.float16


### PR DESCRIPTION
RoPE embeddings use complex as an underlying representation for the frequencies, which leads to it enforcing ```float32``` dtype when applying to any float type that is lower in the promotion chain than ```float32``` (e.g. ```float16```/```bfloat16```). This PR fixes the issue by adding a new keyword argument, ```dtype```, and using the frequencies with the correct ```dtype``` throughout the implementation.