### PR TITLE
v0.11.6

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -33,7 +33,7 @@ jobs:
           mkdocs build  # twice, see https://github.com/patrick-kidger/pytkdocs_tweaks
 
       - name: Upload docs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: docs
           path: site  # where `mkdocs build` puts the built site

--- a/equinox/_ad.py
+++ b/equinox/_ad.py
@@ -35,6 +35,7 @@ from ._filters import (
 )
 from ._make_jaxpr import filter_make_jaxpr
 from ._module import field, Module, module_update_wrapper, Partial, Static
+from ._pretty_print import tree_pformat
 from ._tree import tree_equal
 
 
@@ -546,12 +547,16 @@ def _check_closure_convert_input(self, args, kwargs):
     if tree_equal(in_dynamic_struct, self_in_dynamic_struct) is not True:
         raise ValueError(
             "Closure-converted function called with different dynamic arguments to "
-            "the example arguments provided."
+            "the example arguments provided:\n\n"
+            f"Called with: {tree_pformat(in_dynamic)}\n\n"
+            f"Closure-converted with: {tree_pformat(self_in_dynamic_struct)}"
         )
     if tree_equal(in_static, self_in_static) is not True:
         raise ValueError(
             "Closure-converted function called with different static arguments to "
-            "the example arguments provided."
+            "the example arguments provided:\n\n"
+            f"Called with: {tree_pformat(in_static)}\n\n"
+            f"Closure-converted with: {tree_pformat(self_in_static)}"
         )
     return in_dynamic
 

--- a/equinox/nn/_stateful.py
+++ b/equinox/nn/_stateful.py
@@ -119,9 +119,8 @@ class State:
             if _is_index(leaf):
                 if leaf.init is _sentinel:
                     raise ValueError(
-                        "Cannot call `eqx.nn.State(eqx.nn.delete_init_state(model))`. "
-                        "You should call `eqx.nn.State(model)`, using the original "
-                        "model."
+                        "Do not call `eqx.nn.State(model)` directly. You should call "
+                        "`eqx.nn.make_with_state(ModelClass)(...args...)` instead."
                     )
                 state[leaf.marker] = jtu.tree_map(jnp.asarray, leaf.init)
         self._state = state

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "equinox"
-version = "0.11.5"
+version = "0.11.6"
 description = "Elegant easy-to-use neural networks in JAX."
 readme = "README.md"
 requires-python ="~=3.9"

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -126,7 +126,7 @@ def test_assert_dce():
         g(1.0)
 
 
-def test_traceback_runtime_eqx():
+def test_traceback_runtime_eqx(caplog):
     @eqx.filter_jit
     def f(x):
         return g(x)
@@ -138,8 +138,10 @@ def test_traceback_runtime_eqx():
     try:
         f(jnp.array(1.0))
     except Exception as e:
+        assert caplog.text == ""
         assert e.__cause__ is None
         msg = str(e).strip()
+        assert msg.startswith("Above is the stack outside of JIT")
         assert "egads" in msg
         assert "EQX_ON_ERROR" in msg
 

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -7,6 +7,7 @@ import jax.nn as jnn
 import jax.numpy as jnp
 import jax.random as jrandom
 import pytest
+from jax._src.dtypes import TypePromotionError
 
 
 def test_custom_init():
@@ -1398,9 +1399,20 @@ def test_rope_embeddings_freqs_cis():
     embedding_size = 8
     seq_length = 16
     freqs_cis = eqx.nn.RotaryPositionalEmbedding.precompute_freqs_cis(
-        embedding_size, seq_length, theta
+        embedding_size, seq_length, theta, jnp.float32
     )
-    assert jnp.allclose(freqs_cis, expected_freqs_cis, atol=1e-4)
+    assert jnp.allclose(
+        freqs_cis[0], expected_freqs_cis.real, atol=1e-4
+    ) and jnp.allclose(freqs_cis[1], expected_freqs_cis.imag, atol=1e-4)
+
+    freqs_cis = eqx.nn.RotaryPositionalEmbedding.precompute_freqs_cis(
+        embedding_size, seq_length, theta, jnp.float16
+    )
+    assert jnp.allclose(
+        freqs_cis[0].astype(jnp.float32), expected_freqs_cis.real, rtol=1e-2
+    ) and jnp.allclose(
+        freqs_cis[1].astype(jnp.float32), expected_freqs_cis.imag, rtol=1e-2
+    )
 
 
 def test_rope_embeddings_values():
@@ -1435,7 +1447,33 @@ def test_rope_embeddings_values():
         seq_length, embedding_size
     )
 
-    rope_embeddings = eqx.nn.RotaryPositionalEmbedding(embedding_size)
+    rope_embeddings = eqx.nn.RotaryPositionalEmbedding(
+        embedding_size, dtype=jnp.float32
+    )
     res = rope_embeddings(x)
 
     assert jnp.allclose(res, expected_values, atol=1e-6)
+
+    with jax.numpy_dtype_promotion("standard"):
+        # Test that high precision rope on low precision input is more
+        # accurate than low precision rope on low precision input
+        res = rope_embeddings(x.astype(jnp.float16))
+        assert jnp.allclose(
+            res.astype(jnp.float16),
+            expected_values.astype(jnp.float16),
+            rtol=1e-3,
+        )
+
+    # check that without dtype promotion we throw an error
+    with pytest.raises(TypePromotionError):
+        rope_embeddings(x.astype(jnp.float16))
+
+    rope_embeddings = eqx.nn.RotaryPositionalEmbedding(
+        embedding_size, dtype=jnp.float16
+    )
+    res = rope_embeddings(x.astype(jnp.float16))
+
+    assert (
+        jnp.allclose(res.astype(jnp.float32), expected_values, rtol=1e-2)
+        and res.dtype == jnp.float16
+    )


### PR DESCRIPTION
This is primarily a bug fix release.

- Runtime error messages (those from `eqx.error_if`, in particular when wrapped with `eqx.filter_jit`) should now be compatible with PyCharm's debugger, and with certain multithreaded contexts. (Thanks @adam-hartshorne, @dlwh! #828, #844, #849)

- Marking a `jax.Array` or `np.ndarray` as an `eqx.field(static=True)` will now raise a warning. This was *technically* okay as long as you use it in certain very narrow contexts  (e.g. to smuggle it into a JIT'd region without being traced), but in practice it was nearly always just a common new-user footgun. (Thanks @lockwo! #800)

- Using `eqx.tree_at` for replacing empty tuples is improved. (Thanks @danielward27! #818, #819)

- Mypy now understands that `eqx.Module`s are dataclasses. (Pyright always did, but mypy needed a slightly different approach to appreciate this fact.) (Thanks @NeilGirdhar! #822)

- Multiple `eqx.Module`s participating in co-operative multiple inheritance (at least 5 inheriting from each other seem to be necessary?), with some of them overriding the `__post_init__`s of others, should now follow their expected resolution order. (Thanks @NeilGirdhar! #832, #834)

- Improvements for contributors: we now have a `.editorconfig` file, (thanks @NeilGirdhar! #821) and test-time dependencies can now be installed as `pip install equinox[tests]` (thanks @dlwh! #848)

- Doc improvements. (Thanks @garymm, @ColCarroll! #804, #805)