### PR TITLE
Added RoPE Offset + Test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ examples/MNIST
 examples/multipart_serialised.eqx
 .python-version
 .DS_Store
+.ruff_cache
+.pytest_cache
+.venv

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -239,8 +239,8 @@ def test_mlp_learnt_activation():
         key=jrandom.PRNGKey(5678),
     )
     x = jnp.array([0.5, 0.7])
-    assert mlp.activation.negative_slope.shape == (2, 8)
-    assert mlp.final_activation.negative_slope.shape == (5,)
+    assert mlp.activation.negative_slope.shape == (2, 8)  # pyright: ignore
+    assert mlp.final_activation.negative_slope.shape == (5,)  # pyright: ignore
 
     @eqx.filter_jit
     @eqx.filter_grad
@@ -1353,12 +1353,13 @@ def test_prelu(getkey):
 
 def test_rope_embeddings_shapes(getkey):
     embedding_size = 32
-    rope_embeddings = eqx.nn.RotaryPositionalEmbedding(embedding_size)
 
     n_heads = 4
     seq_length = 8
     query_size = 32
     key_size = 32
+
+    rope_embeddings = eqx.nn.RotaryPositionalEmbedding(embedding_size)
 
     query_heads = jax.random.normal(
         key=getkey(), shape=(seq_length, n_heads, query_size)
@@ -1450,6 +1451,10 @@ def test_rope_embeddings_values():
     rope_embeddings = eqx.nn.RotaryPositionalEmbedding(
         embedding_size, dtype=jnp.float32
     )
+    res = rope_embeddings(x)
+
+    assert jnp.allclose(res, expected_values, atol=1e-6)
+
     res = rope_embeddings(x)
 
     assert jnp.allclose(res, expected_values, atol=1e-6)

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -1482,3 +1482,20 @@ def test_rope_embeddings_values():
         jnp.allclose(res.astype(jnp.float32), expected_values, rtol=1e-2)
         and res.dtype == jnp.float16
     )
+
+
+def test_rope_with_offset():
+    embedding_size = 2
+
+    rotary_emb = eqx.nn.RotaryPositionalEmbedding(embedding_size=embedding_size)
+    rotary_emb = eqx.filter_jit(rotary_emb)
+
+    out1 = rotary_emb(jnp.ones(shape=(2, embedding_size)), offset=1)
+    out2 = rotary_emb(jnp.ones(shape=(3, embedding_size)), offset=2)
+
+    assert jnp.allclose(out1[1], out2[0])
+
+    out3 = rotary_emb(jnp.ones(shape=(2, embedding_size)), offset=1)
+    out4 = rotary_emb(jnp.ones(shape=(3, embedding_size)), offset=1)
+
+    assert jnp.allclose(out3, out4[:2])


### PR DESCRIPTION
This PR follows #799 and adds the possibility for an offset in RoPE.

I've rebased my changes on the latest main branch and added one more test.

For your convenience, here's some code to test it with MHA:

<details>
<summary>
Toggle me
</summary>
        
    import functools
    import equinox as eqx
    import jax
    import jax.numpy as jnp
    from equinox.nn._attention import MultiheadAttention
    from equinox.nn._embedding import RotaryPositionalEmbedding
    from jaxtyping import Array, Float, Int
    
    
    embedding_size = 32
    max_seq_length = 8
    seq_length = 4
    num_heads = 2
    query_size = 64
    
    
    class TransformerBlock(eqx.Module):
        rope_embeddings: RotaryPositionalEmbedding
        mha_attention: MultiheadAttention
    
        def __init__(self, embedding_size, max_seq_length, num_heads, query_size):
            self.rope_embeddings = RotaryPositionalEmbedding(embedding_size, max_seq_length)
            self.mha_attention = MultiheadAttention(
                num_heads=num_heads, query_size=query_size, key=jax.random.key(0)
            )
    
        def __call__(self, query, key_, value, index):
            def process_heads(
                query_heads: Float[Array, "seq_length num_heads qk_size"],
                key_heads: Float[Array, "seq_length num_heads qk_size"],
                value_heads: Float[Array, "seq_length num_heads vo_size"],
                index: Int[Array, ""],
            ) -> tuple[
                Float[Array, "seq_length num_heads qk_size"],
                Float[Array, "seq_length num_heads qk_size"],
                Float[Array, "seq_length num_heads vo_size"],
            ]:
                # index is the autoregressive index of the current token
                rope_partial = functools.partial(self.rope_embeddings, offset=index)
                query_heads = jax.vmap(rope_partial, in_axes=1, out_axes=1)(query_heads)
                key_heads = jax.vmap(rope_partial, in_axes=1, out_axes=1)(key_heads)
    
                return query_heads, key_heads, value_heads
    
            x = self.mha_attention(
                query=query,
                key_=key_,
                value=value,
                process_heads=functools.partial(process_heads, index=index),
            )
    
            return x
    
    
    transformer_block = TransformerBlock(
        embedding_size, max_seq_length, num_heads, query_size
    )
    transformer_block = eqx.filter_jit(transformer_block)
    
    
    q = jnp.ones(shape=(seq_length, query_size))
    k = jnp.ones(shape=(seq_length, query_size))
    v = jnp.ones(shape=(seq_length, query_size))
    
    out = transformer_block(q, k, v, 0)
    out = transformer_block(q, k, v, 1)
    out = transformer_block(q, k, v, 2)
    out = transformer_block(q, k, v, 3)
    out = transformer_block(q, k, v, 4)
    out = transformer_block(q, k, v, 5)

</details>
