### PR TITLE
Fix computation in normalization layers

### DIFF
--- a/equinox/nn/_normalisation.py
+++ b/equinox/nn/_normalisation.py
@@ -94,10 +94,6 @@ class LayerNorm(Module, strict=True):
             )
         self.use_weight = use_weight
         self.use_bias = use_bias
-
-        with jax.numpy_dtype_promotion("standard"):
-            dtype = jnp.result_type(dtype, jnp.float32)
-
         self.weight = jnp.ones(shape, dtype=dtype) if use_weight else None
         self.bias = jnp.zeros(shape, dtype=dtype) if use_bias else None
 

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -886,11 +886,19 @@ def test_layer_norm(getkey):
     assert jnp.allclose(ln(x1), ln(x2), atol=1e-4)
     assert jnp.allclose(ln(x1), x3, atol=1e-4)
 
+    ln = eqx.nn.LayerNorm(128, dtype=jnp.bfloat16)
+    x = jrandom.uniform(getkey(), (128,), dtype=jnp.bfloat16)
+    assert ln(x).dtype == jnp.bfloat16
+
 
 def test_group_norm(getkey):
     gn = eqx.nn.GroupNorm(groups=4, channels=128)
     x = jrandom.uniform(getkey(), (128,))
     assert gn(x).shape == (128,)
+
+    gn = eqx.nn.GroupNorm(groups=4, channels=128, dtype=jnp.bfloat16)
+    x = jrandom.uniform(getkey(), (128,), dtype=jnp.bfloat16)
+    assert gn(x).dtype == jnp.bfloat16
 
     gn = eqx.nn.GroupNorm(groups=4, channels=128)
     x = jrandom.uniform(getkey(), (128, 4, 5))


### PR DESCRIPTION
Irrespective of the dtype passed to the normalization layers, the calculations should be done with fp32 or higher dtype. Not doing that can cause instabilities in training which is too common when someone is training models in half-precision. Now, we can delegate this to the end user to do this explicitly, but it is an easy thing to miss. This PR takes care of that.