### PR TITLE
Allow Python versions higher than 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "equinox"
 version = "0.11.7"
 description = "Elegant easy-to-use neural networks in JAX."
 readme = "README.md"
-requires-python ="~=3.9"
+requires-python =">=3.9"
 license = {file = "LICENSE"}
 authors = [
   {name = "Patrick Kidger", email = "contact@kidger.site"},


### PR DESCRIPTION
It is currently impossible to add equinox to a modern Python project using Poetry, because the current pyproject.toml says that it only supports Python 3.9

This PR fixes this