### PR TITLE
Fix breaking changes introduced in JAX 0.4.36.

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -7,7 +7,8 @@ jobs:
   run-test:
     strategy:
       matrix:
-        python-version: [ 3.9, 3.11 ]
+        # must match the `language_version` in `.pre-commit-config.yaml`
+        python-version: [ 3.11 ]
         os: [ ubuntu-latest ]
       fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,8 @@ repos:
     rev: v1.1.379
     hooks:
       - id: pyright
+        # must match the Python version used in CI
+        language_version: python3.11
         additional_dependencies:
           [
             beartype,

--- a/equinox/_ad.py
+++ b/equinox/_ad.py
@@ -340,7 +340,9 @@ def filter_jvp(
     flat_tangents = jtu.tree_leaves(tangents)  # all non-None tangents are dynamic
 
     def _fn(*_flat_dynamic):
-        _main = jax.core.find_top_trace(_flat_dynamic).main
+        _top_trace = jax.core.find_top_trace(_flat_dynamic)
+        assert _top_trace is not None
+        _main = _top_trace.main
         _dynamic = jtu.tree_unflatten(treedef, _flat_dynamic)
         _in = combine(_dynamic, static_primals)
         _out = fn(*_in, **kwargs)

--- a/equinox/internal/__init__.py
+++ b/equinox/internal/__init__.py
@@ -30,7 +30,6 @@ from .._unvmap import (
     unvmap_max as unvmap_max,
     unvmap_max_p as unvmap_max_p,
 )
-from .._vmap_pmap import if_mapped as if_mapped
 
 # Backward compatibility: expose via `equinox.internal`. Now available under
 # `equinox.debug`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "equinox"
-version = "0.11.9"
+version = "0.11.10"
 description = "Elegant easy-to-use neural networks in JAX."
 readme = "README.md"
 requires-python =">=3.9"

--- a/tests/test_pmap.py
+++ b/tests/test_pmap.py
@@ -272,23 +272,6 @@ def test_aot_compilation(donate):
     compiled(x, y)
 
 
-def test_double_if_mapped():
-    out_axes = eqx.internal.if_mapped(1)
-
-    def f(x):
-        assert x.shape == (3, 1)
-
-        def g(y):
-            assert y.shape == (1,)
-            return y + 1, x + 1
-
-        a, b = eqx.filter_vmap(g, out_axes=out_axes)(x)
-        assert a.shape == (1, 3)
-        assert b.shape == (3, 1)
-
-    filter_pmap(f)(jnp.arange(3).reshape(1, 3, 1))
-
-
 # https://github.com/patrick-kidger/equinox/issues/900
 # Unlike the vmap case we only test nonnegative integers, as pmap does not support
 # negative indexing for `in_axes` or `out_axes`.

--- a/tests/test_primitive.py
+++ b/tests/test_primitive.py
@@ -136,11 +136,11 @@ def test_call():
 def test_vprim():
     def impl(x):
         assert x.shape == (2,)
-        return 2 * x, jnp.concatenate([x, jnp.flip(x)])
+        return [2 * x, jnp.concatenate([x, jnp.flip(x)])]
 
     def abstract(x):
         assert type(x) is jax.core.ShapedArray
-        return x, jax.core.ShapedArray((4,), x.dtype)
+        return [x, jax.core.ShapedArray((4,), x.dtype)]
 
     def jvp(primals, tangents):
         (x,) = primals

--- a/tests/test_vmap.py
+++ b/tests/test_vmap.py
@@ -160,23 +160,6 @@ def test_keyword_default(getkey):
         eqx.filter_vmap(lambda x, y=1: x, in_axes=dict(y=0))(x)
 
 
-def test_double_if_mapped():
-    out_axes = eqx.internal.if_mapped(1)
-
-    def f(x):
-        assert x.shape == (3, 1)
-
-        def g(y):
-            assert y.shape == (1,)
-            return y + 1, x + 1
-
-        a, b = eqx.filter_vmap(g, out_axes=out_axes)(x)
-        assert a.shape == (1, 3)
-        assert b.shape == (3, 1)
-
-    eqx.filter_vmap(f)(jnp.arange(6).reshape(2, 3, 1))
-
-
 # https://github.com/patrick-kidger/equinox/issues/900
 @pytest.mark.parametrize("out_axes", (0, 1, 2, -1, -2, -3))
 def test_out_axes_with_at_least_three_dimensions(out_axes):


### PR DESCRIPTION
See:

- https://github.com/jax-ml/jax/issues/25289
- https://github.com/patrick-kidger/diffrax/issues/532

The problem was that batching has now become a dynamic trace, and our batching rules were not set up to handle the case that every batch axis is `not_mapped`.