### PR TITLE
Upgrade jax and fix deprecation warnings

### DIFF
--- a/equinox/_ad.py
+++ b/equinox/_ad.py
@@ -18,6 +18,7 @@ from typing_extensions import ParamSpec
 import jax
 import jax._src.traceback_util as traceback_util
 import jax.core
+import jax.extend.core
 import jax.interpreters.ad as ad
 import jax.numpy as jnp
 import jax.tree_util as jtu
@@ -598,7 +599,7 @@ class _ClosureConvert(Module):
     # Important that `jaxpr` be a leaf (and not static), so that it is a tuple element
     # when passing through `filter_primitive_bind` and thus visible to
     # `jax.core.subjaxprs`
-    jaxpr: jax.core.Jaxpr
+    jaxpr: jax.extend.core.Jaxpr
     consts: PyTree[ArrayLike]  # Captured in the PyTree structure of _ClosureConvert
     in_dynamic_struct: _FlatPyTree[jax.ShapeDtypeStruct] = field(static=True)
     out_dynamic_struct: _FlatPyTree[jax.ShapeDtypeStruct] = field(static=True)

--- a/equinox/_make_jaxpr.py
+++ b/equinox/_make_jaxpr.py
@@ -4,7 +4,7 @@ from typing_extensions import ParamSpec
 
 import jax
 import jax._src.traceback_util as traceback_util
-import jax.core
+import jax.extend.core
 import jax.tree_util as jtu
 from jaxtyping import PyTree
 
@@ -49,7 +49,7 @@ class _MakeJaxpr(Module):
 def filter_make_jaxpr(
     fun: Callable[_P, Any],
 ) -> Callable[
-    _P, tuple[jax.core.ClosedJaxpr, PyTree[jax.ShapeDtypeStruct], PyTree[Any]]
+    _P, tuple[jax.extend.core.ClosedJaxpr, PyTree[jax.ShapeDtypeStruct], PyTree[Any]]
 ]:
     """As `jax.make_jaxpr`, but accepts arbitrary PyTrees as input and output.
 

--- a/equinox/_unvmap.py
+++ b/equinox/_unvmap.py
@@ -2,6 +2,7 @@ from typing import cast
 
 import jax
 import jax.core
+import jax.extend.core
 import jax.interpreters.batching as batching
 import jax.interpreters.mlir as mlir
 import jax.numpy as jnp
@@ -10,7 +11,7 @@ from jaxtyping import Array, ArrayLike, Bool, Int
 
 # unvmap_all
 
-unvmap_all_p = jax.core.Primitive("unvmap_all")
+unvmap_all_p = jax.extend.core.Primitive("unvmap_all")
 
 
 def unvmap_all(x: Bool[ArrayLike, "..."]) -> Bool[Array, ""]:
@@ -41,7 +42,7 @@ mlir.register_lowering(
 
 # unvmap_any
 
-unvmap_any_p = jax.core.Primitive("unvmap_any")
+unvmap_any_p = jax.extend.core.Primitive("unvmap_any")
 
 
 def unvmap_any(x: Bool[ArrayLike, "..."]) -> Bool[Array, ""]:
@@ -72,7 +73,7 @@ mlir.register_lowering(
 
 # unvmap_max
 
-unvmap_max_p = jax.core.Primitive("unvmap_max")
+unvmap_max_p = jax.extend.core.Primitive("unvmap_max")
 
 
 def unvmap_max(x: Int[ArrayLike, "..."]) -> Int[Array, ""]:

--- a/equinox/debug/_announce_transform.py
+++ b/equinox/debug/_announce_transform.py
@@ -2,7 +2,7 @@ from collections.abc import Callable
 from typing import Any
 
 import jax
-import jax.core
+import jax.extend.core
 import jax.interpreters.ad as ad
 import jax.interpreters.batching as batching
 import jax.interpreters.mlir as mlir
@@ -124,7 +124,7 @@ def _mlir(*x, stack, name, intermediates, announce):
     return x
 
 
-announce_jaxpr_p = jax.core.Primitive("announce_jaxpr")
+announce_jaxpr_p = jax.extend.core.Primitive("announce_jaxpr")
 announce_jaxpr_p.multiple_results = True
 announce_jaxpr_p.def_impl(_impl)
 announce_jaxpr_p.def_abstract_eval(_abstract)

--- a/equinox/internal/_loop/common.py
+++ b/equinox/internal/_loop/common.py
@@ -2,7 +2,7 @@ import itertools as it
 from typing import Any, TYPE_CHECKING, Union
 
 import jax
-import jax.core
+import jax.extend.core
 import jax.interpreters.ad as ad
 import jax.interpreters.batching as batching
 import jax.interpreters.mlir as mlir
@@ -105,7 +105,7 @@ def _select_if_vmap_batch(axis_size, axis_name, trace, inputs, batch_axes):
     return out, out_axis
 
 
-select_if_vmap_p = jax.core.Primitive("select_if_vmap")
+select_if_vmap_p = jax.extend.core.Primitive("select_if_vmap")
 select_if_vmap_p.def_impl(_select_if_vmap_impl)
 select_if_vmap_p.def_abstract_eval(_select_if_vmap_abstract)
 ad.primitive_jvps[select_if_vmap_p] = _select_if_vmap_jvp

--- a/equinox/internal/_noinline.py
+++ b/equinox/internal/_noinline.py
@@ -4,6 +4,7 @@ from typing import Any, Optional, Union
 
 import jax
 import jax.core
+import jax.extend.core
 import jax.interpreters.ad as ad
 import jax.interpreters.batching as batching
 import jax.interpreters.mlir as mlir
@@ -330,7 +331,7 @@ def _noinline_mlir(ctx, *dynamic, treedef, static, flatten, **kwargs):
     return result
 
 
-noinline_p = jax.core.Primitive("noinline")
+noinline_p = jax.extend.core.Primitive("noinline")
 noinline_p.multiple_results = True
 noinline_p.def_impl(_noinline_impl)
 noinline_p.def_abstract_eval(_noinline_abstract)

--- a/equinox/internal/_nontraceable.py
+++ b/equinox/internal/_nontraceable.py
@@ -6,7 +6,7 @@ import functools as ft
 from typing import Optional
 
 import jax
-import jax.core
+import jax.extend.core
 import jax.interpreters.ad as ad
 import jax.interpreters.batching as batching
 import jax.interpreters.mlir as mlir
@@ -29,7 +29,7 @@ def _make_error(opname):
     return _error
 
 
-nontraceable_p = jax.core.Primitive("nontraceable")
+nontraceable_p = jax.extend.core.Primitive("nontraceable")
 nontraceable_p.def_impl(_nontraceable_impl)
 nontraceable_p.def_abstract_eval(_nontraceable_impl)
 ad.primitive_jvps[nontraceable_p] = _make_error("differentiation")
@@ -53,7 +53,7 @@ def nontraceable(x, *, name="nontraceable operation"):
     return combine(dynamic, static)
 
 
-nondifferentiable_backward_p = jax.core.Primitive("nondifferentiable_backward")
+nondifferentiable_backward_p = jax.extend.core.Primitive("nondifferentiable_backward")
 
 
 def _nondifferentiable_backward_batch(x, batch_axes, *, msg, symbolic):
@@ -137,7 +137,7 @@ def _cannot_batch(x, b, *, msg, allow_constant_across_batch):
             raise ValueError(msg)
 
 
-nonbatchable_p = jax.core.Primitive("nonbatchable")
+nonbatchable_p = jax.extend.core.Primitive("nonbatchable")
 nonbatchable_p.def_impl(lambda x, *, msg, allow_constant_across_batch: x)
 nonbatchable_p.def_abstract_eval(lambda x, *, msg, allow_constant_across_batch: x)
 batching.primitive_batchers[nonbatchable_p] = _cannot_batch

--- a/equinox/internal/_primitive.py
+++ b/equinox/internal/_primitive.py
@@ -3,6 +3,7 @@ from typing import Any
 
 import jax
 import jax.core
+import jax.extend.core
 import jax.interpreters.ad as ad
 import jax.interpreters.batching as batching
 import jax.interpreters.mlir as mlir
@@ -255,7 +256,7 @@ def filter_primitive_batching(rule):
     return _wrapper
 
 
-def filter_primitive_bind(prim: jax.core.Primitive, *args) -> PyTree:
+def filter_primitive_bind(prim: jax.extend.core.Primitive, *args) -> PyTree:
     """Calls a primitive that has had its rules defined using the filter
     functions above.
     """
@@ -301,7 +302,7 @@ _vprim_transpose_registry = {}
 
 
 def create_vprim(name: str, impl, abstract_eval, jvp, transpose):
-    prim = jax.core.Primitive(name)
+    prim = jax.extend.core.Primitive(name)
     prim.multiple_results = True
 
     def batch_rule(axis_size, axis_name, trace_type, inputs, batch_axes, **params):

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,8 +81,9 @@ plugins:
                     - import jaxtyping
                     - jaxtyping.set_array_name_format("array")
                     - import jax
+                    - import jax.extend.core
                     - jax.ShapeDtypeStruct.__module__ = "jax"
-                    - jax.core.ClosedJaxpr.__module__ = "jax.core"
+                    - jax.extend.core.ClosedJaxpr.__module__ = "jax.core"
 
                 selection:
                     inherited_members: true  # Allow looking up inherited methods

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "equinox"
 version = "0.11.10"
 description = "Elegant easy-to-use neural networks in JAX."
 readme = "README.md"
-requires-python =">=3.9"
+requires-python =">=3.10"
 license = {file = "LICENSE"}
 authors = [
   {name = "Patrick Kidger", email = "contact@kidger.site"},
@@ -23,7 +23,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Mathematics",
 ]
 urls = {repository = "https://github.com/patrick-kidger/equinox" }
-dependencies = ["jax>=0.4.13,!=0.4.27", "jaxtyping>=0.2.20", "typing_extensions>=4.5.0"]
+dependencies = ["jax>=0.4.38", "jaxtyping>=0.2.20", "typing_extensions>=4.5.0"]
 
 [build-system]
 requires = ["hatchling"]

--- a/tests/test_nontraceable.py
+++ b/tests/test_nontraceable.py
@@ -4,6 +4,7 @@ import equinox as eqx
 import equinox.internal as eqxi
 import jax
 import jax.core
+import jax.extend.core
 import jax.numpy as jnp
 import jax.tree_util as jtu
 import pytest
@@ -73,7 +74,7 @@ def test_nontraceable(getkey):
         jax.vmap(run, in_axes=(0, None))(dynamic_batch, static)
 
     jaxpr = jax.make_jaxpr(run, static_argnums=1)(dynamic, static)
-    jaxpr = cast(jax.core.ClosedJaxpr, jaxpr)
+    jaxpr = cast(jax.extend.core.ClosedJaxpr, jaxpr)
     run2 = jax.core.jaxpr_as_fun(jaxpr)
 
     run2(*dynamic_flat)  # pyright: ignore

--- a/tests/test_primitive.py
+++ b/tests/test_primitive.py
@@ -4,6 +4,7 @@ import equinox as eqx
 import equinox.internal as eqxi
 import jax
 import jax.core
+import jax.extend.core
 import jax.interpreters.ad as ad
 import jax.interpreters.batching as batching
 import jax.interpreters.mlir as mlir
@@ -14,7 +15,7 @@ from .helpers import tree_allclose
 
 
 def test_call():
-    newprim_p = jax.core.Primitive("newprim")
+    newprim_p = jax.extend.core.Primitive("newprim")
     newprim_p.multiple_results = True
 
     newprim = ft.partial(eqxi.filter_primitive_bind, newprim_p)


### PR DESCRIPTION
Jax v0.4.38 deprecated many APIs in jax.core, and can be replaced instead by jax.extend.core.
Jax v0.4.38 also required me to upgrade python.

Fixes: https://github.com/patrick-kidger/equinox/issues/913