### PR TITLE
Removed the requirement for a particular version of Python in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,8 +11,6 @@ repos:
     rev: v1.1.379
     hooks:
       - id: pyright
-        # must match the Python version used in CI
-        language_version: python3.11
         additional_dependencies:
           [
             beartype,
@@ -21,7 +19,5 @@ repos:
             jaxtyping,
             optax,
             pytest,
-            tensorflow,
-            tf2onnx,
             typing_extensions,
           ]

--- a/equinox/_enum.py
+++ b/equinox/_enum.py
@@ -140,7 +140,7 @@ following entries:
 
 
 class EnumerationItem(Module):
-    _value: Int[Union[Array, np.ndarray], ""]
+    _value: Int[Union[Array, np.ndarray[Any, np.dtype[np.signedinteger]]], ""]
     # Should have annotation `"type[Enumeration]"`, but this fails due to beartype bug
     # #289.
     _enumeration: Any = field(static=True)

--- a/equinox/_filters.py
+++ b/equinox/_filters.py
@@ -37,7 +37,7 @@ def is_inexact_array(element: Any) -> bool:
     array.
     """
     if isinstance(element, (np.ndarray, np.generic)):
-        return np.issubdtype(element.dtype, np.inexact)
+        return bool(np.issubdtype(element.dtype, np.inexact))
     elif isinstance(element, jax.Array):
         return jnp.issubdtype(element.dtype, jnp.inexact)
     else:
@@ -51,7 +51,7 @@ def is_inexact_array_like(element: Any) -> bool:
     if hasattr(element, "__jax_array__"):
         element = element.__jax_array__()
     if isinstance(element, (np.ndarray, np.generic)):
-        return np.issubdtype(element.dtype, np.inexact)
+        return bool(np.issubdtype(element.dtype, np.inexact))
     elif isinstance(element, jax.Array):
         return jnp.issubdtype(element.dtype, jnp.inexact)
     else:

--- a/equinox/internal/_onnx.py
+++ b/equinox/internal/_onnx.py
@@ -24,8 +24,8 @@ def to_onnx(fn):
         ```
     """
     import jax.experimental.jax2tf as jax2tf
-    import tensorflow as tf
-    import tf2onnx
+    import tensorflow as tf  # pyright: ignore[reportMissingImports]
+    import tf2onnx  # pyright: ignore[reportMissingImports]
 
     def _to_onnx(*args):
         finalised_fn = finalise_fn(fn)


### PR DESCRIPTION
I've realised that this only works if you have that particular version of Python installed locally -- pre-commit doesn't download this for you.

This unacceptably raises the bar for making contributions -- folks shouldn't have to modify their global system just to offer a PR against Equinox.

Unfortunately this has meant that I've had to remove a couple of dependencies from the `additional_dependencies` list, as they don't support Python 3.13, which is what is sometimes selected.

(Alternatives considered:

- Install the specified version of Python as part of the pre-commit hook. This would be ideal. Unfortunately `pre-commit` passes the specified `language_version` to `python -m virtualenv` under the hood, and that doesn't seem to offer a way to do this.

- Based on the above: something with `uv`? Unfortunately `pre-commit` have also elected *not* to support `uv` (https://github.com/pre-commit/pre-commit/pull/3131, https://github.com/pre-commit/pre-commit/issues/3222), which would have done this automatically. Maybe we just need to wait until the folks at Astral write their own version of pre-commit as well!

- Specify a range of versions for Python, so that we use whatever the system Python is, as long as it is below 3.13. Unfortunately pre-commit doesn't seem to support this.

- Write our own local hook that does whatever we damn well please: `uv` to install the right version of Python, downloads pyright, and run it. If this becomes problematic amongst the rest of the ecosystem then it may be worth doing exactly this.

)