### PR TITLE
docs: Add conda-forge feedstock mention

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,13 @@ _Coming from [Flax](https://github.com/google/flax) or [Haiku](https://github.co
 
 ## Installation
 
+Requires Python 3.10+.
+
 ```bash
 pip install equinox
 ```
 
-Requires Python 3.10+.
+Equinox is also available through a community-supported build on [conda-forge](https://github.com/conda-forge/equinox-feedstock).
 
 ## Documentation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,11 +15,13 @@ _Coming from [Flax](https://github.com/google/flax) or [Haiku](https://github.co
 
 ## Installation
 
+Requires Python 3.10+.
+
 ```bash
 pip install equinox
 ```
 
-Requires Python 3.10+.
+Equinox is also available through a community-supported build on [conda-forge](https://github.com/conda-forge/equinox-feedstock).
 
 ## Quick example
 


### PR DESCRIPTION
Resolves #929 

* Note existence of conda-forge feedstock in install instructions.
   - c.f. https://github.com/conda-forge/equinox-feedstock