### PR TITLE
Batch BatchNorm

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -27,7 +27,7 @@ jobs:
           python -m pip install -r ./tests/requirements.txt
 
       - name: Checks with pre-commit
-        uses: pre-commit/action@v2.0.3
+        uses: pre-commit/action@v3.0.1
 
       - name: Test with pytest
         run: |

--- a/equinox/nn/_batch_norm.py
+++ b/equinox/nn/_batch_norm.py
@@ -1,9 +1,11 @@
+import warnings
 from collections.abc import Hashable, Sequence
+from typing import Literal
 
 import jax
 import jax.lax as lax
 import jax.numpy as jnp
-from jaxtyping import Array, Bool, Float, PRNGKeyArray
+from jaxtyping import Array, Bool, Float, Int, PRNGKeyArray
 
 from .._misc import default_floating_dtype
 from .._module import field
@@ -40,25 +42,70 @@ class BatchNorm(StatefulLayer, strict=True):
     statistics updated. During inference then just the running statistics are used.
     Whether the model is in training or inference mode should be toggled using
     [`equinox.nn.inference_mode`][].
+
+    With `mode = "batch"` during training the batch mean and variance are used
+    for normalization.  For inference the exponential running mean and unbiased
+    variance are used for normalization. This is in line with how other machine
+    learning packages (e.g. PyTorch, flax, haiku) implement batch norm.
+
+    With `mode = "ema"` exponential running means and variances are kept.  During
+    training the batch statistics are used to fill in the running statistics until
+    they are populated.  During inference the running statistics are used for
+    normalization.
+
+    ??? cite
+
+        [Batch Normalization: Accelerating Deep Network Training by Reducing
+         Internal Covariate Shift](https://arxiv.org/abs/1502.03167)
+
+        ```bibtex
+        @article{DBLP:journals/corr/IoffeS15,
+        author       = {Sergey Ioffe and
+                        Christian Szegedy},
+        title        = {Batch Normalization: Accelerating Deep Network Training
+                        by Reducing Internal Covariate Shift},
+        journal      = {CoRR},
+        volume       = {abs/1502.03167},
+        year         = {2015},
+        url          = {http://arxiv.org/abs/1502.03167},
+        eprinttype    = {arXiv},
+        eprint       = {1502.03167},
+        timestamp    = {Mon, 13 Aug 2018 16:47:06 +0200},
+        biburl       = {https://dblp.org/rec/journals/corr/IoffeS15.bib},
+        bibsource    = {dblp computer science bibliography, https://dblp.org}
+        }
+        ```
     """  # noqa: E501
 
     weight: Float[Array, "input_size"] | None
     bias: Float[Array, "input_size"] | None
-    first_time_index: StateIndex[Bool[Array, ""]]
-    state_index: StateIndex[
-        tuple[Float[Array, "input_size"], Float[Array, "input_size"]]
-    ]
+    ema_first_time_index: None | StateIndex[Bool[Array, ""]]
+    ema_state_index: (
+        None | StateIndex[tuple[Float[Array, "input_size"], Float[Array, "input_size"]]]
+    )
+    batch_counter: None | StateIndex[Int[Array, ""]]
+    batch_state_index: (
+        None
+        | StateIndex[
+            tuple[
+                tuple[Float[Array, "input_size"], Float[Array, "input_size"]],
+                tuple[Float[Array, "input_size"], Float[Array, "input_size"]],
+            ],
+        ]
+    )
     axis_name: Hashable | Sequence[Hashable]
     inference: bool
     input_size: int = field(static=True)
     eps: float = field(static=True)
     channelwise_affine: bool = field(static=True)
     momentum: float = field(static=True)
+    mode: Literal["ema", "batch"] = field(static=True)
 
     def __init__(
         self,
         input_size: int,
         axis_name: Hashable | Sequence[Hashable],
+        mode: Literal["ema", "batch", "legacy"] = "legacy",
         eps: float = 1e-5,
         channelwise_affine: bool = True,
         momentum: float = 0.99,
@@ -71,6 +118,7 @@ class BatchNorm(StatefulLayer, strict=True):
         - `axis_name`: The name of the batch axis to compute statistics over, as passed
             to `axis_name` in `jax.vmap` or `jax.pmap`. Can also be a sequence (e.g. a
             tuple or a list) of names, to compute statistics over multiple named axes.
+        - `mode`: The variant of batch norm to use, either 'ema' or 'batch'.
         - `eps`: Value added to the denominator for numerical stability.
         - `channelwise_affine`: Whether the module has learnable channel-wise affine
             parameters.
@@ -86,6 +134,16 @@ class BatchNorm(StatefulLayer, strict=True):
             `jax.numpy.float32` or `jax.numpy.float64` depending on whether JAX is in
             64-bit mode.
         """
+        if mode == "legacy":
+            mode = "ema"
+            warnings.warn(
+                "When mode is unspecified it defaults to 'ema'. This can have "
+                "substantial performance impacts, and the user is encouraged to "
+                "consider and pick which mode they need."
+            )
+        if mode not in ("ema", "batch"):
+            raise ValueError("Invalid mode, must be 'ema' or 'batch'.")
+        self.mode = mode
         dtype = default_floating_dtype() if dtype is None else dtype
         if channelwise_affine:
             self.weight = jnp.ones((input_size,), dtype=dtype)
@@ -93,12 +151,28 @@ class BatchNorm(StatefulLayer, strict=True):
         else:
             self.weight = None
             self.bias = None
-        self.first_time_index = StateIndex(jnp.array(True))
-        init_buffers = (
-            jnp.empty((input_size,), dtype=dtype),
-            jnp.empty((input_size,), dtype=dtype),
-        )
-        self.state_index = StateIndex(init_buffers)
+        if mode == "ema":
+            self.ema_first_time_index = StateIndex(jnp.array(True))
+            init_buffers = (
+                jnp.empty((input_size,), dtype=dtype),
+                jnp.empty((input_size,), dtype=dtype),
+            )
+            self.ema_state_index = StateIndex(init_buffers)
+            self.batch_counter = None
+            self.batch_state_index = None
+        else:
+            self.batch_counter = StateIndex(jnp.array(0))
+            init_hidden = (
+                jnp.zeros((input_size,), dtype=dtype),
+                jnp.ones((input_size,), dtype=dtype),
+            )
+            init_avg = (
+                jnp.zeros((input_size,), dtype=dtype),
+                jnp.ones((input_size,), dtype=dtype),
+            )
+            self.batch_state_index = StateIndex((init_hidden, init_avg))
+            self.ema_first_time_index = None
+            self.ema_state_index = None
         self.inference = inference
         self.axis_name = axis_name
         self.input_size = input_size
@@ -138,32 +212,16 @@ class BatchNorm(StatefulLayer, strict=True):
         A `NameError` if no `vmap`s are placed around this operation, or if this vmap
         does not have a matching `axis_name`.
         """
-
         if inference is None:
             inference = self.inference
-        if inference:
-            running_mean, running_var = state.get(self.state_index)
-        else:
 
-            def _stats(y):
-                mean = jnp.mean(y)
-                mean = lax.pmean(mean, self.axis_name)
-                var = jnp.mean((y - mean) * jnp.conj(y - mean))
-                var = lax.pmean(var, self.axis_name)
-                var = jnp.maximum(0.0, var)
-                return mean, var
-
-            first_time = state.get(self.first_time_index)
-            state = state.set(self.first_time_index, jnp.array(False))
-
-            batch_mean, batch_var = jax.vmap(_stats)(x)
-            running_mean, running_var = state.get(self.state_index)
-            momentum = self.momentum
-            running_mean = (1 - momentum) * batch_mean + momentum * running_mean
-            running_var = (1 - momentum) * batch_var + momentum * running_var
-            running_mean = lax.select(first_time, batch_mean, running_mean)
-            running_var = lax.select(first_time, batch_var, running_var)
-            state = state.set(self.state_index, (running_mean, running_var))
+        def _stats(y):
+            mean = jnp.mean(y)
+            mean = lax.pmean(mean, self.axis_name)
+            var = jnp.mean((y - mean) * jnp.conj(y - mean))
+            var = lax.pmean(var, self.axis_name)
+            var = jnp.maximum(0.0, var)
+            return mean, var
 
         def _norm(y, m, v, w, b):
             out = (y - m) / jnp.sqrt(v + self.eps)
@@ -171,5 +229,62 @@ class BatchNorm(StatefulLayer, strict=True):
                 out = out * w + b
             return out
 
-        out = jax.vmap(_norm)(x, running_mean, running_var, self.weight, self.bias)
-        return out, state
+        if self.mode == "ema":
+            assert (
+                self.ema_first_time_index is not None
+                and self.ema_state_index is not None
+            )
+            if inference:
+                running_mean, running_var = state.get(self.ema_state_index)
+            else:
+                first_time = state.get(self.ema_first_time_index)
+                state = state.set(self.ema_first_time_index, jnp.array(False))
+
+                batch_mean, batch_var = jax.vmap(_stats)(x)
+                running_mean, running_var = state.get(self.ema_state_index)
+                momentum = self.momentum
+                running_mean = (1 - momentum) * batch_mean + momentum * running_mean
+                running_var = (1 - momentum) * batch_var + momentum * running_var
+                # since jnp.array(0) == False
+                running_mean = lax.select(first_time, batch_mean, running_mean)
+                running_var = lax.select(first_time, batch_var, running_var)
+                state = state.set(self.ema_state_index, (running_mean, running_var))
+
+            out = jax.vmap(_norm)(x, running_mean, running_var, self.weight, self.bias)
+            return out, state
+        else:
+            assert self.batch_state_index is not None and self.batch_counter is not None
+            if inference:
+                _, (mean, var) = state.get(self.batch_state_index)
+            else:
+                batch_mean, batch_var = jax.vmap(_stats)(x)
+                counter = state.get(self.batch_counter)
+                (hidden_mean, hidden_var), (running_mean, running_var) = state.get(
+                    self.batch_state_index
+                )
+
+                decay = self.momentum
+                one = jnp.array(1.0, dtype=x.dtype)
+
+                # Update hidden_{mean,var}
+                new_hidden_mean = hidden_mean * decay + batch_mean * (one - decay)
+                new_hidden_var = hidden_var * decay + batch_var * (one - decay)
+
+                # Zero-debias approach: average_ = hidden_ / (1 - decay^counter)
+                # For simplicity we do the minimal version here (no warmup).
+                new_counter = counter + 1
+                decay_power = decay**new_counter
+                new_running_mean = new_hidden_mean / (one - decay_power)
+                new_running_var = new_hidden_var / (one - decay_power)
+
+                state = state.set(self.batch_counter, new_counter)
+                new_state_data = (
+                    (new_hidden_mean, new_hidden_var),
+                    (new_running_mean, new_running_var),
+                )
+                state = state.set(self.batch_state_index, new_state_data)
+
+                mean, var = (batch_mean, batch_var)
+
+            out = jax.vmap(_norm)(x, mean, var, self.weight, self.bias)
+            return out, state

--- a/equinox/nn/_batch_norm.py
+++ b/equinox/nn/_batch_norm.py
@@ -244,7 +244,7 @@ class BatchNorm(StatefulLayer, strict=True):
             counter = state.get(self.batch_counter)
             hidden_mean, hidden_var = state.get(self.batch_state_index)
             if inference:
-                # Zero-debias approach: average_ = hidden_ / (1 - decay^counter)
+                # Zero-debias approach: mean = hidden_mean / (1 - momentum^counter)
                 # For simplicity we do the minimal version here (no warmup).
                 scale = 1 - self.momentum**counter
                 mean = hidden_mean / scale

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -970,7 +970,7 @@ def test_batch_norm(getkey, mode):
             running_mean, running_var = state.get(bn.ema_state_index)
         else:
             assert bn.batch_state_index is not None
-            _, (running_mean, running_var) = state.get(bn.batch_state_index)
+            running_mean, running_var = state.get(bn.batch_state_index)
         assert running_mean.shape == (5,)
         assert running_var.shape == (5,)
 
@@ -996,7 +996,7 @@ def test_batch_norm(getkey, mode):
         running_mean, running_var = state.get(bn.ema_state_index)
     else:
         assert bn.batch_state_index is not None
-        _, (running_mean, running_var) = state.get(bn.batch_state_index)
+        running_mean, running_var = state.get(bn.batch_state_index)
     assert running_mean.shape == (10, 5)
     assert running_var.shape == (10, 5)
 
@@ -1015,7 +1015,7 @@ def test_batch_norm(getkey, mode):
         running_mean, running_var = out_vvstate.get(vvbn.ema_state_index)
     else:
         assert vvbn.batch_state_index is not None
-        _, (running_mean, running_var) = out_vvstate.get(vvbn.batch_state_index)
+        running_mean, running_var = out_vvstate.get(vvbn.batch_state_index)
     assert running_mean.shape == (6,)
     assert running_var.shape == (6,)
 
@@ -1038,14 +1038,14 @@ def test_batch_norm(getkey, mode):
         running_mean, running_var = state.get(bn.ema_state_index)
     else:
         assert bn.batch_state_index is not None
-        _, (running_mean, running_var) = state.get(bn.batch_state_index)
+        running_mean, running_var = state.get(bn.batch_state_index)
     out, state = vbn(3 * x1 + 10, state)
     if mode == "ema":
         assert bn.ema_state_index is not None
         running_mean2, running_var2 = state.get(bn.ema_state_index)
     else:
         assert bn.batch_state_index is not None
-        _, (running_mean2, running_var2) = state.get(bn.batch_state_index)
+        running_mean2, running_var2 = state.get(bn.batch_state_index)
     assert not jnp.allclose(running_mean, running_mean2)
     assert not jnp.allclose(running_var, running_var2)
 
@@ -1059,7 +1059,7 @@ def test_batch_norm(getkey, mode):
         running_mean3, running_var3 = state.get(bn.ema_state_index)
     else:
         assert bn.batch_state_index is not None
-        _, (running_mean3, running_var3) = state.get(bn.batch_state_index)
+        running_mean3, running_var3 = state.get(bn.batch_state_index)
     assert jnp.array_equal(running_mean2, running_mean3)
     assert jnp.array_equal(running_var2, running_var3)
 

--- a/tests/test_serialisation.py
+++ b/tests/test_serialisation.py
@@ -239,12 +239,16 @@ def test_stateful(tmp_path):
         norm1: eqx.nn.BatchNorm
         norm2: eqx.nn.BatchNorm
 
-    model = Model(eqx.nn.BatchNorm(3, "hi"), eqx.nn.BatchNorm(4, "bye"))
+    model = Model(
+        eqx.nn.BatchNorm(3, "hi", mode="ema"), eqx.nn.BatchNorm(4, "bye", mode="ema")
+    )
     state = eqx.nn.State(model)
 
     eqx.tree_serialise_leaves(tmp_path, (model, state))
 
-    model2 = Model(eqx.nn.BatchNorm(3, "hi"), eqx.nn.BatchNorm(4, "bye"))
+    model2 = Model(
+        eqx.nn.BatchNorm(3, "hi", mode="ema"), eqx.nn.BatchNorm(4, "bye", mode="ema")
+    )
     state2 = eqx.nn.State(model2)
 
     eqx.tree_deserialise_leaves(tmp_path, (model2, state2))

--- a/tests/test_stateful.py
+++ b/tests/test_stateful.py
@@ -7,7 +7,7 @@ import pytest
 
 
 def test_delete_init_state():
-    model = eqx.nn.BatchNorm(3, "batch")
+    model = eqx.nn.BatchNorm(3, "batch", mode="ema")
     eqx.nn.State(model)
     model2 = eqx.nn.delete_init_state(model)
 


### PR DESCRIPTION
Revives https://github.com/patrick-kidger/equinox/pull/675, but ideally a smaller/simpler change (that doesn't require any math) that matches the patterns in flax/haiku (see: https://github.com/google-deepmind/dm-haiku/blob/main/haiku/_src/batch_norm.py#L42%23L206, https://github.com/google-deepmind/dm-haiku/blob/main/haiku/_src/moving_averages.py#L41%23L139). Has some hardcoded defaults (e.g. I don't support warmup iterations at all), but should help the users of batch norm. In addition to the stability in the initial example, here is an example on an AlphaZero model playing 9x9 Go: 


<img width="837" alt="Screenshot 2025-02-09 at 9 37 30 PM" src="https://github.com/user-attachments/assets/ea38b96f-af3f-4e97-939d-a8f4a5dd8dc8" />


This screenshot (and code) also comes from this PR: https://github.com/sotetsuk/pgx/pull/1300
