### PR TITLE
Avoid calling _wrap_method.__get__ on _JitWrapper

### DIFF
--- a/equinox/_jit.py
+++ b/equinox/_jit.py
@@ -223,8 +223,10 @@ class _JitWrapper(Module):
             return self
         return Partial(self, instance)
 
-# _call is not a member method of _JitWrapper (even though it effectively does the same thing)
-# because we want to avoid _call being wrapped in a _wrap_method, which adds about ~90μs per call.
+
+# _call is not a member method of _JitWrapper (even though it effectively does
+# the same thing) because we want to avoid _call being wrapped in a _wrap_method,
+# which adds about ~90μs per call.
 def _call(jit_wrapper: _JitWrapper, is_lower, args, kwargs):
     __tracebackhide__ = True
     # Used by our error messages when figuring out where to stop walking the stack.


### PR DESCRIPTION
This is the second (and last) patch related to #973 and should hopefully be a little simpler than #976.

The idea here is that for certain wrapped methods (mainly `_JitWrapper._call`) we recompute the BoundMethod every time. This patch caches the BoundMethod.

This should be safe, as the cached entry is used if and only if the instance is the same Module and since Modules are immutable the BoundMethod is the same.

With this patch equinox is within a few tens of milliseconds of jax (will update PR later with proper numbers). 