### PR TITLE
Fix for warning of jnp.shape(:jax.ShapeDtypeStuct)

### DIFF
--- a/equinox/_ad.py
+++ b/equinox/_ad.py
@@ -631,7 +631,7 @@ class _ClosureConvert(Module):
         )
         assert len(out_dynamic_flat) == len(out_dynamic_struct_flat)
         for o1, o2 in zip(out_dynamic_flat, out_dynamic_struct_flat):
-            assert jnp.shape(o1) == jnp.shape(o2)
+            assert jnp.shape(o1) == o2.shape
             assert jnp.result_type(o1) == jnp.result_type(o2)
         out = jtu.tree_unflatten(out_dynamic_treedef, out_dynamic_flat)
         out = combine(out, self_out_static)


### PR DESCRIPTION
Fix for #979