### PR TITLE
Minor optimization in hashable_partition

### DIFF
--- a/equinox/_compile_utils.py
+++ b/equinox/_compile_utils.py
@@ -20,9 +20,17 @@ def hashable_filter(pytree: PyTree, filter_fn: Callable):
 
 def hashable_partition(pytree: PyTree, filter_fn: Callable):
     leaves, treedef = jtu.tree_flatten(pytree)
-    dynamic_leaves = tuple(x if filter_fn(x) else None for x in leaves)
-    static_leaves = tuple(None if filter_fn(x) else x for x in leaves)
-    return dynamic_leaves, (static_leaves, treedef)
+    length = len(leaves)
+    a = [None] * length
+    b = [None] * length
+
+    for i, x in enumerate(leaves):
+        if filter_fn(x):
+            a[i] = x
+        else:
+            b[i] = x
+
+    return tuple(a), (tuple(b), treedef)
 
 
 def hashable_combine(dynamic_leaves, static) -> PyTree:


### PR DESCRIPTION
This is just a very small change to `hashable_partition` that avoids calling `filter_fn` twice for every leaf.

On my machine this saves 200μs on the MLP example (~260 leaves).

All tests are passing and there should be no behavior change.

Old: 

```Python
%timeit -r7 -n500 fwd_eqx(dyn_flat, x).block_until_ready()
2.36 ms ± 58.1 μs per loop (mean ± std. dev. of 7 runs, 500 loops each)
```

New:

```Python
%timeit -r7 -n500 fwd_eqx(dyn_flat, x).block_until_ready()
2.16 ms ± 47 μs per loop (mean ± std. dev. of 7 runs, 500 loops each)
```