### PR TITLE
perf: speed up module (un)flattening

### DIFF
--- a/tests/test_pformat.py
+++ b/tests/test_pformat.py
@@ -40,11 +40,11 @@ def test_function():
     i = jax.custom_vjp(f)
     j = jax.custom_jvp(f)
 
-    assert eqx.tree_pformat(f) == "<function f>"
-    assert eqx.tree_pformat(g) == "<wrapped function f>"
-    assert eqx.tree_pformat(h) == "partial(<function f>)"
-    assert eqx.tree_pformat(i) == "<function f>"
-    assert eqx.tree_pformat(j) == "<function f>"
+    assert eqx.tree_pformat(f) == "<function test_function.<locals>.f>"
+    assert eqx.tree_pformat(g) == "<wrapped function test_function.<locals>.f>"
+    assert eqx.tree_pformat(h) == "partial(<function test_function.<locals>.f>)"
+    assert eqx.tree_pformat(i) == "<function test_function.<locals>.f>"
+    assert eqx.tree_pformat(j) == "<function test_function.<locals>.f>"
 
 
 def test_struct_as_array():


### PR DESCRIPTION
Partly addresses #961.

I don't see a benchmarking suite, e.g. using https://pypi.org/project/pytest-codspeed/, so in the attached notebook (attached as a ZIP because GH doesn't support directly attaching ipynb) I'm finding ~25% speedup towards matching the raw jax (around a 10% speedup overall).
[overhead.ipynb.zip](https://github.com/user-attachments/files/19694256/overhead.ipynb.zip)

This PR:

1. removes `_flatten_module` in favor of one defined in `_ActualModuleMeta.__new__` allowing for many aspects of the flattening to be pre-computed.
2. add slots to `_FlattenedData`, which should provide a minuscule speedup and reduction in memory use. Didn't hurt so 🤷.
3. Combined the `wrapper_field_names` and `wrapper_field_values` into a single field of `_FlattenedData` since it's only  ever used as a zipped combo. Also changed to pre-determined size for `wrapper_field_names_and_values` by storing the sentinel value. The sentinel is then used for skipping assignment when unflattening. In testing this did provide a speedup. 
4. Same as 3. for the static field names and values.


For future PRs...
- figure out how to not filter on `__dict__` so that `dynamic_fs = data_fs` and tuple sizes are pre-determined.
- try a namedtuple `_FlattenedData` to see if that speeds things up further.
- JAX dataclass-related speedups.
