### PR TITLE
fix(lib): allow DocTest to discover methods from subclasses `Module`

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -27,7 +27,7 @@ jobs:
           python -m pip install -r ./tests/requirements.txt
 
       - name: Checks with pre-commit
-        uses: pre-commit/action@v2.0.3
+        uses: pre-commit/action@v3.0.1
 
       - name: Test with pytest
         run: |

--- a/equinox/_module.py
+++ b/equinox/_module.py
@@ -681,6 +681,15 @@ class _wrap_method:
         if getattr(self.method, "__isabstractmethod__", False):
             self.__isabstractmethod__ = self.method.__isabstractmethod__
 
+    # Fixes https://github.com/patrick-kidger/equinox/issues/1016
+    @property
+    def __module__(self):
+        return self.method.__module__
+
+    @property
+    def __doc__(self):
+        return self.method.__doc__
+
     def __get__(self, instance, owner):
         del owner
         if instance is None:


### PR DESCRIPTION
Closes #1016.

In the end, there were two issues: (1) `DocTestFinder._from_module` was returning `False` because the `__module__` attribute was not correct, and (2) the documentation was not copied to the wrapper class so doctests could not be discovered.

My solution is inspired from what Python is doing with their own decorators, see https://github.com/python/cpython/blob/4617d68d73409e83d6ab31106d10421d44048787/Lib/functools.py#L1033-L1049