### PR TITLE
use keypaths instead of ints for state keys

### DIFF
--- a/equinox/nn/_stateful.py
+++ b/equinox/nn/_stateful.py
@@ -55,9 +55,9 @@ class StateIndex(Module, Generic[_Value]):
     [`equinox.nn.BatchNorm`][] for further reference.
     """  # noqa: E501
 
-    # Starts off as None when initialised; later replaced with an `int` inside
-    # `make_with_state`.
-    marker: object | int = field(static=True)
+    # Starts off as object when initialised; later replaced with stringified KeyPath
+    # inside `make_with_state`.
+    marker: object | str = field(static=True)
     init: _Value | _Sentinel
 
     def __init__(self, init: _Value):
@@ -249,13 +249,7 @@ class State:
         if isinstance(self._state, _Sentinel):
             return wl.TextDoc("State(~old~)")
         else:
-            docs = wl.named_objs(
-                [
-                    (hex(id(key)), value)
-                    for key, value in self._state.items()  # pyright: ignore
-                ],
-                **kwargs,
-            )
+            docs = wl.named_objs(self._state.items(), **kwargs)  # pyright: ignore
             return wl.bracketed(
                 begin=wl.TextDoc("State("),
                 docs=docs,
@@ -373,14 +367,13 @@ def make_with_state(make_model: Callable[_P, _T]) -> Callable[_P, tuple[_T, Stat
 
             # Replace all markers with `int`s. This is needed to ensure that two calls
             # to `make_with_state` produce compatible models and states.
-            leaves, treedef = jtu.tree_flatten(model, is_leaf=_is_index)
-            counter = 0
+            key_leaves, treedef = jtu.tree_flatten_with_path(model, is_leaf=_is_index)
             new_leaves = []
-            for leaf in leaves:
+            for key, leaf in key_leaves:
                 if _is_index(leaf):
                     leaf = StateIndex(leaf.init)
-                    object.__setattr__(leaf, "marker", counter)
-                    counter += 1
+                    path_str = model.__class__.__name__ + jtu.keystr(key)
+                    object.__setattr__(leaf, "marker", path_str)
                 new_leaves.append(leaf)
             model = jtu.tree_unflatten(treedef, new_leaves)
 

--- a/equinox/nn/_stateful.py
+++ b/equinox/nn/_stateful.py
@@ -55,7 +55,7 @@ class StateIndex(Module, Generic[_Value]):
     [`equinox.nn.BatchNorm`][] for further reference.
     """  # noqa: E501
 
-    # Starts off as object when initialised; later replaced with a stringified 
+    # Starts off as object when initialised; later replaced with a stringified
     # jax.tree_util.KeyPath inside `make_with_state`.
     marker: object | str = field(static=True)
     init: _Value | _Sentinel
@@ -365,8 +365,8 @@ def make_with_state(make_model: Callable[_P, _T]) -> Callable[_P, tuple[_T, Stat
         def make_with_state_impl(*args, **kwargs) -> tuple[_T, State]:
             model = make_model(*args, **kwargs)
 
-            # Replace all markers with stringified key paths. This is needed to ensure that two calls
-            # to `make_with_state` produce compatible models and states.
+            # Replace all markers with stringified key paths. This is needed to ensure
+            # that two calls to `make_with_state` produce compatible models and states.
             key_leaves, treedef = jtu.tree_flatten_with_path(model, is_leaf=_is_index)
             new_leaves = []
             for key, leaf in key_leaves:

--- a/equinox/nn/_stateful.py
+++ b/equinox/nn/_stateful.py
@@ -55,8 +55,8 @@ class StateIndex(Module, Generic[_Value]):
     [`equinox.nn.BatchNorm`][] for further reference.
     """  # noqa: E501
 
-    # Starts off as object when initialised; later replaced with stringified KeyPath
-    # inside `make_with_state`.
+    # Starts off as object when initialised; later replaced with a stringified 
+    # jax.tree_util.KeyPath inside `make_with_state`.
     marker: object | str = field(static=True)
     init: _Value | _Sentinel
 
@@ -365,7 +365,7 @@ def make_with_state(make_model: Callable[_P, _T]) -> Callable[_P, tuple[_T, Stat
         def make_with_state_impl(*args, **kwargs) -> tuple[_T, State]:
             model = make_model(*args, **kwargs)
 
-            # Replace all markers with `int`s. This is needed to ensure that two calls
+            # Replace all markers with stringified key paths. This is needed to ensure that two calls
             # to `make_with_state` produce compatible models and states.
             key_leaves, treedef = jtu.tree_flatten_with_path(model, is_leaf=_is_index)
             new_leaves = []


### PR DESCRIPTION
See #1050.

With this change

```python
import equinox as eqx

class StatefulModule(eqx.Module):
    counter_index: eqx.nn.StateIndex

    def __init__(self):
        counter_init = 0
        self.counter_index = eqx.nn.StateIndex(counter_init)

    def __call__(self, x, state):
        counter = state.get(self.counter_index)
        counter = counter + 1
        state = state.set(self.counter_index, counter)
        return x, state


class TopModule(eqx.Module):
    stateful_mod: eqx.Module

    def __init__(self):
        self.stateful_mod = StatefulModule()

    def __call__(self, x, state):
       return self.stateful_mod(x, state)

proc, state = eqx.nn.make_with_state(TopModule)()
state, state._state, state.get(proc.stateful_mod.counter_index)
```

prints

```
(State(TopModule.stateful_mod.counter_index=weak_i32[]), {'TopModule.stateful_mod.counter_index': Array(0, dtype=int32, weak_type=True)}, Array(0, dtype=int32, weak_type=True))
```