### PR TITLE
Add annotation for eqx.field

### DIFF
--- a/equinox/_module/_field.py
+++ b/equinox/_module/_field.py
@@ -8,8 +8,8 @@ def field(
     *,
     converter: Callable[[Any], Any] | None = None,
     static: bool = False,
-    **kwargs,
-):
+    **kwargs: Any,
+) -> Any:
     """Equinox supports extra functionality on top of the default dataclasses.
 
     **Arguments:**


### PR DESCRIPTION
This silences all the `reportUnknownVariableType` errors by pyright in strict mode caused by `eqx.field`

Discussed in #1013 