### PR TITLE
Add support for creating weak references to Flatten()

### DIFF
--- a/equinox/internal/_primitive.py
+++ b/equinox/internal/_primitive.py
@@ -98,7 +98,7 @@ def _make_spec(x, y):
 
 
 class Flatten:
-    __slots__ = ("treedef_out", "static_out")
+    __slots__ = ("treedef_out", "static_out", "__weakref__")
 
     def called(self):
         return hasattr(self, "treedef_out")


### PR DESCRIPTION
This fixes the error reported in https://github.com/patrick-kidger/equinox/issues/1081. 

This seems to fix https://github.com/patrick-kidger/lineax/issues/169 as well: 

- With the Equinox fix, using `eqx.debug.assert_max_traces`: no error thrown for repeated calls to `lx.linear_solve`
- Without the Equinox fix, `assert_max_traces` reports recompilation when using JAX 0.7.0 for `lx.linear_solve`