### PR TITLE
Remove use of deprecated jax.interpreters.batching.NotMapped in Jax 0.7

### DIFF
--- a/equinox/_unvmap.py
+++ b/equinox/_unvmap.py
@@ -29,7 +29,7 @@ def _unvmap_all_abstract_eval(x):
 
 def _unvmap_all_batch(x, batch_axes):
     (x,) = x
-    return unvmap_all(x), batching.not_mapped
+    return unvmap_all(x), None
 
 
 unvmap_all_p.def_impl(_unvmap_all_impl)
@@ -60,7 +60,7 @@ def _unvmap_any_abstract_eval(x):
 
 def _unvmap_any_batch(x, batch_axes):
     (x,) = x
-    return unvmap_any(x), batching.not_mapped
+    return unvmap_any(x), None
 
 
 unvmap_any_p.def_impl(_unvmap_any_impl)
@@ -91,7 +91,7 @@ def _unvmap_max_abstract_eval(x):
 
 def _unvmap_max_batch(x, batch_axes):
     (x,) = x
-    return unvmap_max(x), batching.not_mapped
+    return unvmap_max(x), None
 
 
 unvmap_max_p.def_impl(_unvmap_max_impl)

--- a/equinox/internal/_loop/common.py
+++ b/equinox/internal/_loop/common.py
@@ -81,16 +81,16 @@ def _select_if_vmap_batch(axis_size, axis_name, trace, inputs, batch_axes):
     del axis_name, trace
     pred, x, y = inputs
     bp, bx, by = batch_axes
-    if bp is batching.not_mapped:
-        if bx is batching.not_mapped:
-            if by is batching.not_mapped:
+    if bp is None:
+        if bx is None:
+            if by is None:
                 out_axis = None
             else:
                 x = jnp.broadcast_to(x, (axis_size,) + x.shape)
                 y = jnp.moveaxis(y, by, 0)
                 out_axis = 0
         else:
-            if by is batching.not_mapped:
+            if by is None:
                 x = jnp.moveaxis(x, bx, 0)
                 y = jnp.broadcast_to(y, (axis_size,) + y.shape)
                 out_axis = 0

--- a/equinox/internal/_nontraceable.py
+++ b/equinox/internal/_nontraceable.py
@@ -126,12 +126,12 @@ def nondifferentiable_backward(
 def _cannot_batch(x, b, *, msg, allow_constant_across_batch):
     (x,) = x
     (b,) = b
-    if b is batching.not_mapped:
+    if b is None:
         return x, b
     else:
         if allow_constant_across_batch:
             x = error_if(x, jnp.min(x, axis=b) != jnp.max(x, axis=b), msg)
-            return jnp.take(x, 0, axis=b), batching.not_mapped
+            return jnp.take(x, 0, axis=b), None
         else:
             raise ValueError(msg)
 


### PR DESCRIPTION
As mentioned in https://github.com/patrick-kidger/equinox/issues/1084 the Jax 0.7 release is currently incompatible with Equinox. One change was the deprecation of `jax.interpreters.batching.NotMapped` which leads to a number of pipeline errors.

For example, running `pytest` for Equinox gives this:
```
============================================================================================== short test summary info ==============================================================================================
ERROR tests/test_abstract.py - DeprecationWarning: jax.interpreters.batching.NotMapped is deprecated.
ERROR tests/test_ad.py - DeprecationWarning: jax.interpreters.batching.NotMapped is deprecated.
ERROR tests/test_caches.py - DeprecationWarning: jax.interpreters.batching.NotMapped is deprecated.
ERROR tests/test_callback.py - DeprecationWarning: jax.interpreters.batching.NotMapped is deprecated.
ERROR tests/test_checkpoint.py - DeprecationWarning: jax.interpreters.batching.NotMapped is deprecated.
ERROR tests/test_closure_to_pytree.py - DeprecationWarning: jax.interpreters.batching.NotMapped is deprecated.
ERROR tests/test_debug.py - DeprecationWarning: jax.interpreters.batching.NotMapped is deprecated.
ERROR tests/test_enum.py - DeprecationWarning: jax.interpreters.batching.NotMapped is deprecated.
ERROR tests/test_errors.py - DeprecationWarning: jax.interpreters.batching.NotMapped is deprecated.
ERROR tests/test_eval_shape.py - DeprecationWarning: jax.interpreters.batching.NotMapped is deprecated.
ERROR tests/test_filters.py - DeprecationWarning: jax.interpreters.batching.NotMapped is deprecated.
ERROR tests/test_finalise_jaxpr.py - DeprecationWarning: jax.interpreters.batching.NotMapped is deprecated.
ERROR tests/test_jit.py - DeprecationWarning: jax.interpreters.batching.NotMapped is deprecated.
ERROR tests/test_make_jaxpr.py - DeprecationWarning: jax.interpreters.batching.NotMapped is deprecated.
ERROR tests/test_misc.py - DeprecationWarning: jax.interpreters.batching.NotMapped is deprecated.
ERROR tests/test_module.py - DeprecationWarning: jax.interpreters.batching.NotMapped is deprecated.
ERROR tests/test_nn.py - DeprecationWarning: jax.interpreters.batching.NotMapped is deprecated.
ERROR tests/test_noinline.py - DeprecationWarning: jax.interpreters.batching.NotMapped is deprecated.
ERROR tests/test_nontraceable.py - DeprecationWarning: jax.interpreters.batching.NotMapped is deprecated.
ERROR tests/test_onnx.py - DeprecationWarning: jax.interpreters.batching.NotMapped is deprecated.
ERROR tests/test_pformat.py - DeprecationWarning: jax.interpreters.batching.NotMapped is deprecated.
ERROR tests/test_pmap.py - DeprecationWarning: jax.interpreters.batching.NotMapped is deprecated.
ERROR tests/test_primitive.py - DeprecationWarning: jax.interpreters.batching.NotMapped is deprecated.
ERROR tests/test_scan.py - DeprecationWarning: jax.interpreters.batching.NotMapped is deprecated.
ERROR tests/test_serialisation.py - DeprecationWarning: jax.interpreters.batching.NotMapped is deprecated.
ERROR tests/test_sharding.py - DeprecationWarning: jax.interpreters.batching.NotMapped is deprecated.
ERROR tests/test_shared.py - DeprecationWarning: jax.interpreters.batching.NotMapped is deprecated.
ERROR tests/test_stateful.py - DeprecationWarning: jax.interpreters.batching.NotMapped is deprecated.
ERROR tests/test_str2jax.py - DeprecationWarning: jax.interpreters.batching.NotMapped is deprecated.
ERROR tests/test_tree.py - DeprecationWarning: jax.interpreters.batching.NotMapped is deprecated.
ERROR tests/test_update.py - DeprecationWarning: jax.interpreters.batching.NotMapped is deprecated.
ERROR tests/test_vmap.py - DeprecationWarning: jax.interpreters.batching.NotMapped is deprecated.
ERROR tests/test_while_loop.py - DeprecationWarning: jax.interpreters.batching.NotMapped is deprecated.
```

This PR replaces the deprecated class with `None` since it was just an alias for `None` in the first place. It also updates the functions that referenced it with checks against `None`. A different solution could be creating an Equinox version of `NotMapped`. This is my first foray into the internals of Equinox and it's likely I don't know the full scope of this so please review carefully and give lots of feedback.