### PR TITLE
Python 3.14 compatibility

### DIFF
--- a/equinox/_module/_better_abstract.py
+++ b/equinox/_module/_better_abstract.py
@@ -8,6 +8,7 @@ is the public API. But the two pieces aren't directly related under-the-hood.)
 
 import abc
 import dataclasses
+import inspect
 from typing import (
     Annotated,
     ClassVar,
@@ -243,7 +244,7 @@ class BetterABCMeta(abc.ABCMeta):
 def better_dataclass(**kwargs):
     def make_dataclass(cls):
         try:
-            annotations = cls.__dict__["__annotations__"]
+            annotations = inspect.get_annotations(cls)
         except KeyError:
             cls = dataclasses.dataclass(**kwargs)(cls)
         else:


### PR DESCRIPTION
Python 3.14 has deprecated the use of `cls.__dict__["__annotations__"]` in favour of either `inspect.get_annotations` (Python 3.10+) or `annotationlib.get_annotations` (Python 3.14+).

This is documented in [this ruff rule](https://docs.astral.sh/ruff/rules/access-annotations-from-class-dict/) in [PEP 749](https://peps.python.org/pep-0749/#new-annotationlib-module). See also this CPython issue: https://github.com/python/cpython/issues/139140

IIUC the above CPython issue (+PEP 749) correctly then the `annotationlib` function is the 'recommended' option, but as a practical matter they'll become the same function, and the `inspect` option is already available on older Pythons.

Fixes https://github.com/patrick-kidger/equinox/issues/1096 and https://github.com/patrick-kidger/optimistix/issues/168, hopefully.