### PR TITLE
Shameless plug: add typinox to awesome-list

### DIFF
--- a/docs/awesome-list.md
+++ b/docs/awesome-list.md
@@ -88,10 +88,13 @@ Normalizing flows and probabilistic machine learning.
 Converts PyTorch `state_dict`s into Equinox pytrees.
 
 **boltz-binder-design**: [GitHub](https://github.com/escalante-bio/boltz-binder-design)   
-Protein design by multi-objective hallucination (~ColabDesign in Equinox). 
+Protein design by multi-objective hallucination (~ColabDesign in Equinox).
 
 **ksim**: [GitHub](https://github.com/kscalelabs/ksim)  
 MJX robotics simulation library.
 
 **Mutax**: [GitHub](https://github.com/gerlero/mutax)  
 Differential evolution–based global optimization (with support for parallel evaluation).
+
+**Typinox**: [GitHub](https://github.com/EtaoinWu/typinox) [Docs](https://typinox.readthedocs.io/latest/)  
+Enhanced `beartype` run-time typechecking for `jaxtyping` annotated `equinox` Modules.


### PR DESCRIPTION
So I made this library (Currently at its very early stages!) that allows you to write this:

```python
class AffineMap(TypedModule):
    k: Float[Array, "n m"]
    b: Float[Array, "n"]

    def __call__(self: Self, x: Float[Array, "m"]) -> Float[Array, "n"]:
        return jnp.dot(self.k, x) + self.b

f = AffineMap(k=jnp.ones((3, 2), dtype=float), b=jnp.zeros(3))
f(jnp.array([1., 2.]))
```

The initializer and member methods will automatically type-check at runtime. 