### PR TITLE
perf: enable module flatten/unflatten fastpath

### DIFF
--- a/equinox/_module/_flatten.py
+++ b/equinox/_module/_flatten.py
@@ -34,7 +34,10 @@ def flatten(obj: module_cls) -> {return_annotation}:
     
     {fields_info}
     """
-    return {dynamic_vals}, {aux}
+    return (
+        {dynamic_vals},
+        {aux}
+    )
 '''
 
 FLAT_KEYS_NAME = "<generated_flatten_with_keys_{0}>"
@@ -45,7 +48,10 @@ def flatten_with_keys(obj: module_cls) -> {return_annotation}:
     
     {fields_info}
     """
-    return {key_tuple}, {aux}
+    return (
+        {key_tuple},
+        {aux}
+    )
 '''
 
 UNFLAT_NAME = "<generated_unflatten_{0}>"
@@ -155,6 +161,7 @@ def _generate_flatten_functions(cls: type, fields: tuple[dataclasses.Field[Any],
     exec(compile(flat_code, FLAT_FUNC_NAME.format(clsname), "exec"), flat_ns)
     flat_fn = flat_ns["flatten"]
     flat_fn.__module__ = module_name
+    flat_fn.__source__ = flat_code
 
     # -------------------------------------------
     # Generate flatten_with_keys function
@@ -179,6 +186,7 @@ def _generate_flatten_functions(cls: type, fields: tuple[dataclasses.Field[Any],
     exec(compile(flat_w_keys_code, FLAT_KEYS_NAME.format(clsname), "exec"), flat_ns)
     flat_w_keys_fn = flat_ns["flatten_with_keys"]
     flat_w_keys_fn.__module__ = module_name
+    flat_w_keys_fn.__source__ = flat_w_keys_code
 
     # -------------------------------------------
     # Generate unflatten function - directly set fields by index
@@ -214,6 +222,7 @@ def _generate_flatten_functions(cls: type, fields: tuple[dataclasses.Field[Any],
     exec(compile(unflat_code, UNFLAT_NAME.format(clsname), "exec"), unflat_ns)
     unflat_fn = unflat_ns["unflatten"]
     unflat_fn.__module__ = module_name
+    unflat_fn.__source__ = unflat_code
 
     # -------------------------------------------
 

--- a/equinox/_module/_flatten.py
+++ b/equinox/_module/_flatten.py
@@ -8,14 +8,12 @@ from typing import Any, Final, Literal, TypeVar
 import jax.tree_util as jtu
 
 
-class Sentinel(Enum):
-    """Sentinel values for flattening/unflattening."""
+# Names for generated functions
+FLAT_FUNC_NAME = "<generated_flatten_{0}>"
+FLAT_KEYS_NAME = "<generated_flatten_with_keys_{0}>"
+UNFLAT_NAME = "<generated_unflatten_{0}>"
 
-    MISSING = "MISSING"
-
-
-MISSING = Sentinel.MISSING
-
+# Fields of Module wrappers to always include
 _WRAPPER_FIELD_NAMES: Final = (
     "__module__",
     "__name__",
@@ -24,43 +22,61 @@ _WRAPPER_FIELD_NAMES: Final = (
     "__annotations__",
 )
 
+# Indentation for generated code
 INDENT: Final = " " * 4
 
-FIELDS_INFO = f"""
-    Dynamic fields: {{dynamic}}
-    Static fields: {{static}}
-    Wrapper fields: {_WRAPPER_FIELD_NAMES}
-"""[1:-1]  # (trim leading and trailing newlines)
+
+# Sentinel values for flattening/unflattening
+class Sentinel(Enum):
+    """Sentinel values for flattening/unflattening."""
+
+    MISSING = "MISSING"
 
 
-FLAT_FUNC_NAME = "<generated_flatten_{0}>"
-FLAT_KEYS_NAME = "<generated_flatten_with_keys_{0}>"
-FLAT_WRAPPER = ", ".join(
+MISSING = Sentinel.MISSING
+
+# Code template for flattening the wrapper fields
+FLAT_WRAPPERS = ", ".join(
     [f"getattr(self, {name!r}, MISSING)" for name in _WRAPPER_FIELD_NAMES]
 )
-FLAT_CODE_BASE = f'''
+
+# Code template for flatten function
+FLAT_CODE = f'''
 def {{func_name}}(obj: module_cls) -> {{return_annotation}}:
     """Generated {{func_name}} function for {{qualname}}.
     
-{{fields_info}}
+    Dynamic fields: {{dynamic_fs}}
+    Static fields: {{static_fs}}
+    Wrapper fields: {_WRAPPER_FIELD_NAMES}
     """
     return (
         {{dynamic_vals}},
         (
-            MISSING if '__module__' not in obj.__dict__ else ({FLAT_WRAPPER}),
+            MISSING if '__module__' not in obj.__dict__ else ({FLAT_WRAPPERS}),
             {{static_vals}}
         )
     )
 '''
 
-
-UNFLAT_NAME = "<generated_unflatten_{0}>"
-
-UNFLAT_WRAPPERS: Final = "\n".join(
+# Code template for setting wrapper fields during unflattening
+SET_WRAPPERS: Final = "\n".join(
     f"self.__dict__[{name}] = waux[{i}]" for i, name in enumerate(_WRAPPER_FIELD_NAMES)
 )
 
-UNFLAT_FUNC_BASE = f'''
+# Code template for setting dynamic fields during unflattening
+SET_DYNAMIC = """
+if data[{i}] is not MISSING:
+    object.__setattr__(self, {name!r}, data[{i}])
+"""[1:-1]  # (trim leading and trailing newlines)
+
+# Code template for setting static fields during unflattening
+SET_STATIC = """
+if aux[{i}] is not MISSING:
+    object.__setattr__(self, {name!r}, aux[{i}])
+"""[1:-1]  # (trim leading and trailing newlines)
+
+# Code template for unflatten function
+UNFLAT_FUNC = f'''
 def unflatten(
     module_cls: type[T],
     aux: {{aux_type}},
@@ -68,27 +84,19 @@ def unflatten(
 ) -> T:
     """Generated unflatten function for {{qualname}}.
 
-{{fields_info}}
+    Dynamic fields: {{dynamic_fs}}
+    Static fields: {{static_fs}}
+    Wrapper fields: {_WRAPPER_FIELD_NAMES}
     """
     self = object.__new__(module_cls)
     # Set fields directly by index
 {{setters_dynamic}}
     if aux[0] is not MISSING:
         waux = aux[0]
-{textwrap.indent(UNFLAT_WRAPPERS, INDENT * 2)}
+{textwrap.indent(SET_WRAPPERS, INDENT * 2)}
 {{setters_static}}
     return self
 '''
-
-SET_DYNAMIC_BASE = """
-if data[{i}] is not MISSING:
-    object.__setattr__(self, {name!r}, data[{i}])
-"""[1:-1]  # (trim leading and trailing newlines)
-
-SET_AUX_BASE = """
-if aux[{i}] is not MISSING:
-    object.__setattr__(self, {name!r}, aux[{i}])
-"""[1:-1]  # (trim leading and trailing newlines)
 
 NS_BASE = {
     "object": object,
@@ -119,10 +127,6 @@ def _generate_flatten_functions(cls: type, fields: tuple[dataclasses.Field[Any],
         else:
             _dynamic_fs.append(f.name)
     dynamic_fs, static_fs = tuple(_dynamic_fs), tuple(_static_fs)
-    # aux_fs = _WRAPPER_FIELD_NAMES + static_fs
-
-    # Build field info for docs
-    fields_info = FIELDS_INFO.format(dynamic=dynamic_fs, static=static_fs)
 
     # Extract the generated functions from respective namespaces to
     # set the proper module reference.
@@ -139,7 +143,7 @@ def _generate_flatten_functions(cls: type, fields: tuple[dataclasses.Field[Any],
         dynamic_vals = "()"
 
     # For static fields, we need to store their values in aux data
-    static_exprs = [f"getattr(obj, {k!r}, MISSING)" for k in static_fs]
+    static_exprs = [f"getattr(obj,{k!r},MISSING)" for k in static_fs]
     static_vals = f"{', '.join(static_exprs)}"
 
     # Build return type annotation
@@ -148,23 +152,23 @@ def _generate_flatten_functions(cls: type, fields: tuple[dataclasses.Field[Any],
     static_type = f"tuple[{wrapper_type}, {', '.join(['Any'] * len(static_fs))}]"
     clsname = cls.__qualname__
 
-    flat_code = FLAT_CODE_BASE.format(
+    # Generate flatten function code
+    flat_code = FLAT_CODE.format(
         func_name="flatten",
         return_annotation=f"tuple[{dynamic_type}, {static_type}]",
         qualname=clsname,
-        fields_info=fields_info,
+        dynamic_fs=dynamic_fs,
+        static_fs=static_fs,
         dynamic_vals=dynamic_vals,
         static_vals=static_vals,
     )
 
-    # Namespace for flatten functions (they need module_cls)
-    flat_ns = NS_BASE | {"jtu": jtu, "module_cls": cls}
-
     # make flatten func
+    flat_ns = NS_BASE | {"module_cls": cls}
     exec(compile(flat_code, FLAT_FUNC_NAME.format(clsname), "exec"), flat_ns)
     flat_fn = flat_ns["flatten"]
     flat_fn.__module__ = module_name
-    flat_fn.__source__ = flat_code
+    object.__setattr__(flat_fn, "__source__", flat_code)
 
     # -------------------------------------------
     # Generate flatten_with_keys function
@@ -177,40 +181,42 @@ def _generate_flatten_functions(cls: type, fields: tuple[dataclasses.Field[Any],
 
     keys_dynamic_type = make_tuple_type(len(dynamic_fs), "tuple[jtu.GetAttrKey, str]")
 
-    flat_w_keys_code = FLAT_CODE_BASE.format(
+    # Generate flatten_with_keys function code
+    flat_k_code = FLAT_CODE.format(
         func_name="flatten_with_keys",
         return_annotation=f"tuple[{keys_dynamic_type}, {static_type}]",
         qualname=clsname,
-        fields_info=fields_info,
+        dynamic_fs=dynamic_fs,
+        static_fs=static_fs,
         dynamic_vals=dynamic_key_vals,
         static_vals=static_vals,
     )
 
     # flatten with keys func
-    exec(compile(flat_w_keys_code, FLAT_KEYS_NAME.format(clsname), "exec"), flat_ns)
-    flat_w_keys_fn = flat_ns["flatten_with_keys"]
-    flat_w_keys_fn.__module__ = module_name
-    flat_w_keys_fn.__source__ = flat_w_keys_code
+    flat_k_ns = NS_BASE | {"jtu": jtu, "module_cls": cls}
+    exec(compile(flat_k_code, FLAT_KEYS_NAME.format(clsname), "exec"), flat_k_ns)
+    flat_k_fn = flat_k_ns["flatten_with_keys"]
+    flat_k_fn.__module__ = module_name
+    object.__setattr__(flat_k_fn, "__source__", flat_k_code)
 
     # -------------------------------------------
     # Generate unflatten function - directly set fields by index
     # Extract types from flatten return type: tuple[dynamic_type, static_type]
 
-    # Set dynamic fields directly by index
-    unflat_dynamic = [
-        SET_DYNAMIC_BASE.format(i=i, name=k) for i, k in enumerate(dynamic_fs)
-    ]
-    # Set static fields from aux_data by index. Offset by 1 for wrapper
-    # auxiliary field.
+    # Set dynamic fields by index
+    unflat_dynamic = [SET_DYNAMIC.format(i=i, name=k) for i, k in enumerate(dynamic_fs)]
+    # Set static fields by index. Offset by 1 for wrapper auxiliary field.
     unflat_aux = [
-        SET_AUX_BASE.format(i=i, name=k) for i, k in enumerate(static_fs, start=1)
+        SET_STATIC.format(i=i, name=k) for i, k in enumerate(static_fs, start=1)
     ]
 
-    unflat_code = UNFLAT_FUNC_BASE.format(
+    # Generate unflatten function code
+    unflat_code = UNFLAT_FUNC.format(
         aux_type=static_type,
         dynamic_type=dynamic_type,
         qualname=clsname,
-        fields_info=fields_info,
+        dynamic_fs=dynamic_fs,
+        static_fs=static_fs,
         setters_dynamic=textwrap.indent("\n".join(unflat_dynamic), INDENT),
         setters_static=textwrap.indent("\n".join(unflat_aux), INDENT),
     )
@@ -221,8 +227,8 @@ def _generate_flatten_functions(cls: type, fields: tuple[dataclasses.Field[Any],
     exec(compile(unflat_code, UNFLAT_NAME.format(clsname), "exec"), unflat_ns)
     unflat_fn = unflat_ns["unflatten"]
     unflat_fn.__module__ = module_name
-    unflat_fn.__source__ = unflat_code
+    object.__setattr__(unflat_fn, "__source__", unflat_code)
 
     # -------------------------------------------
 
-    return flat_fn, flat_w_keys_fn, unflat_fn
+    return flat_fn, flat_k_fn, unflat_fn

--- a/equinox/_module/_flatten.py
+++ b/equinox/_module/_flatten.py
@@ -1,10 +1,5 @@
 """Utilities for generating optimized flatten/unflatten functions for Module."""
 
-__all__ = (
-    "WRAPPER_FIELD_NAMES",
-    "generate_flatten_functions",
-)
-
 import dataclasses
 import textwrap
 from typing import Any, Final, TypeVar
@@ -14,7 +9,7 @@ import jax.tree_util as jtu
 
 MISSING = object()
 
-WRAPPER_FIELD_NAMES: Final = (
+_WRAPPER_FIELD_NAMES: Final = (
     "__module__",
     "__name__",
     "__qualname__",
@@ -27,7 +22,7 @@ INDENT: Final = 4
 FIELDS_INFO = f"""
     Dynamic fields: {{dynamic}}
     Static fields: {{static}}
-    Wrapper fields: {WRAPPER_FIELD_NAMES}
+    Wrapper fields: {_WRAPPER_FIELD_NAMES}
 """[1:-1]  # (trim leading and trailing newlines)
 
 
@@ -86,7 +81,7 @@ if (aux[{i}] is not MISSING) and (getattr(self,{name!r},MISSING) != aux[{i}]):
 """[1:-1]  # (trim leading and trailing newlines)
 
 SET_WRAPPER_LINES = "\n".join(
-    SET_WRAPPER_BASE.format(i=i, name=k) for i, k in enumerate(WRAPPER_FIELD_NAMES)
+    SET_WRAPPER_BASE.format(i=i, name=k) for i, k in enumerate(_WRAPPER_FIELD_NAMES)
 )
 
 NS_BASE = {"object": object, "Any": Any, "tuple": tuple, "MISSING": MISSING}
@@ -102,7 +97,7 @@ def make_tuple_type(count: int, element_type: str = "Any") -> str:
         return f"tuple[{', '.join([element_type] * count)}]"
 
 
-def generate_flatten_functions(cls: type, fields: tuple[dataclasses.Field[Any], ...]):
+def _generate_flatten_functions(cls: type, fields: tuple[dataclasses.Field[Any], ...]):
     """Generate optimized flatten/unflatten functions for a specific field config."""
     # Separate dynamic and static fields
     _dynamic_fs, _static_fs = [], []
@@ -112,7 +107,7 @@ def generate_flatten_functions(cls: type, fields: tuple[dataclasses.Field[Any], 
         else:
             _dynamic_fs.append(f.name)
     dynamic_fs, static_fs = tuple(_dynamic_fs), tuple(_static_fs)
-    # aux_fs = WRAPPER_FIELD_NAMES + static_fs
+    # aux_fs = _WRAPPER_FIELD_NAMES + static_fs
 
     # Build field info for docs
     fields_info = FIELDS_INFO.format(dynamic=dynamic_fs, static=static_fs)[INDENT:]
@@ -201,7 +196,7 @@ def generate_flatten_functions(cls: type, fields: tuple[dataclasses.Field[Any], 
     # Set static fields from aux_data
     unflatten_lines.extend(
         SET_AUX_BASE.format(i=i, name=k)
-        # for i, k in enumerate(static_fs, start=len(WRAPPER_FIELD_NAMES))
+        # for i, k in enumerate(static_fs, start=len(_WRAPPER_FIELD_NAMES))
         for i, k in enumerate(static_fs, start=0)
     )
 

--- a/equinox/_module/_flatten.py
+++ b/equinox/_module/_flatten.py
@@ -1,0 +1,225 @@
+"""Utilities for generating optimized flatten/unflatten functions for Module."""
+
+__all__ = (
+    "WRAPPER_FIELD_NAMES",
+    "generate_flatten_functions",
+)
+
+import dataclasses
+import textwrap
+from typing import Any, Final, TypeVar
+
+import jax.tree_util as jtu
+
+
+MISSING = object()
+
+WRAPPER_FIELD_NAMES: Final = (
+    "__module__",
+    "__name__",
+    "__qualname__",
+    "__doc__",
+    "__annotations__",
+)
+
+INDENT: Final = 4
+
+FIELDS_INFO = f"""
+    Dynamic fields: {{dynamic}}
+    Static fields: {{static}}
+    Wrapper fields: {WRAPPER_FIELD_NAMES}
+"""[1:-1]  # (trim leading and trailing newlines)
+
+
+FLAT_FUNC_NAME = "<generated_flatten_{0}>"
+
+FLAT_CODE_BASE = '''
+def flatten(obj: module_cls) -> {return_annotation}:
+    """Generated flatten function for {qualname}.
+    
+    {fields_info}
+    """
+    return {dynamic_vals}, {aux}
+'''
+
+FLAT_KEYS_NAME = "<generated_flatten_with_keys_{0}>"
+
+FLAT_WITH_KEYS_CODE_BASE = '''
+def flatten_with_keys(obj: module_cls) -> {return_annotation}:
+    """Generated flatten_with_keys function for {qualname}.
+    
+    {fields_info}
+    """
+    return {key_tuple}, {aux}
+'''
+
+UNFLAT_NAME = "<generated_unflatten_{0}>"
+
+UNFLAT_FUNC_BASE = '''
+def unflatten(
+    module_cls: type[T],
+    aux: {aux_type},
+    data: {dynamic_type},
+) -> T:
+    """Generated unflatten function for {qualname}.
+
+    {fields_info}
+    """
+    self = object.__new__(module_cls)
+    {setters}
+    return self
+'''
+
+SET_DYNAMIC_BASE = """
+if data[{i}] is not MISSING:
+    object.__setattr__(self, {name!r}, data[{i}])
+"""[1:-1]  # (trim leading and trailing newlines)
+
+SET_AUX_BASE = """
+if aux[{i}] is not MISSING:
+    object.__setattr__(self, {name!r}, aux[{i}])
+"""[1:-1]  # (trim leading and trailing newlines)
+
+SET_WRAPPER_BASE = """
+if (aux[{i}] is not MISSING) and (getattr(self,{name!r},MISSING) != aux[{i}]):
+    object.__setattr__(self, {name!r}, aux[{i}])
+"""[1:-1]  # (trim leading and trailing newlines)
+
+SET_WRAPPER_LINES = "\n".join(
+    SET_WRAPPER_BASE.format(i=i, name=k) for i, k in enumerate(WRAPPER_FIELD_NAMES)
+)
+
+NS_BASE = {"object": object, "Any": Any, "tuple": tuple, "MISSING": MISSING}
+
+
+def make_tuple_type(count: int, element_type: str = "Any") -> str:
+    """Generate a tuple type annotation string for a given count of elements."""
+    if count == 0:
+        return "tuple[()]"
+    elif count == 1:
+        return f"tuple[{element_type}]"
+    else:
+        return f"tuple[{', '.join([element_type] * count)}]"
+
+
+def generate_flatten_functions(cls: type, fields: tuple[dataclasses.Field[Any], ...]):
+    """Generate optimized flatten/unflatten functions for a specific field config."""
+    # Separate dynamic and static fields
+    _dynamic_fs, _static_fs = [], []
+    for f in fields:
+        if f.metadata.get("static", False):
+            _static_fs.append(f.name)
+        else:
+            _dynamic_fs.append(f.name)
+    dynamic_fs, static_fs = tuple(_dynamic_fs), tuple(_static_fs)
+    # aux_fs = WRAPPER_FIELD_NAMES + static_fs
+
+    # Build field info for docs
+    fields_info = FIELDS_INFO.format(dynamic=dynamic_fs, static=static_fs)[INDENT:]
+
+    # Extract the generated functions from respective namespaces to
+    # set the proper module reference.
+    module_name = getattr(cls, "__module__", "equinox._module._module")
+
+    # -------------------------------------------
+    # Generate flatten function
+
+    # Directly access dynamic fields by name
+    if dynamic_fs:
+        dynamic_exprs = [f"getattr(obj,{name!r},MISSING)" for name in dynamic_fs]
+        dynamic_vals = f"({', '.join(dynamic_exprs)},)"
+    else:
+        dynamic_vals = "()"
+
+    # For static fields, we need to store their values in aux data
+    # static_exprs = [f"getattr(obj, {k!r}, MISSING)" for k in aux_fs]
+    # static_aux = f"({', '.join(static_exprs)},)"
+    if static_fs:
+        static_exprs = [f"getattr(obj, {k!r}, MISSING)" for k in static_fs]
+        static_aux = f"({', '.join(static_exprs)},)"
+    else:
+        static_aux = "()"
+
+    # Build return type annotation
+    dynamic_type = make_tuple_type(len(dynamic_fs))
+    static_type = make_tuple_type(len(static_fs))
+    clsname = cls.__qualname__
+
+    flat_code = FLAT_CODE_BASE.format(
+        return_annotation=f"tuple[{dynamic_type}, {static_type}]",
+        qualname=clsname,
+        fields_info=fields_info,
+        dynamic_vals=dynamic_vals,
+        aux=static_aux,
+    )
+
+    # Namespace for flatten functions (they need module_cls)
+    flat_ns = NS_BASE | {"jtu": jtu, "module_cls": cls}
+
+    # make flatten func
+    exec(compile(flat_code, FLAT_FUNC_NAME.format(clsname), "exec"), flat_ns)
+    flat_fn = flat_ns["flatten"]
+    flat_fn.__module__ = module_name
+
+    # -------------------------------------------
+    # Generate flatten_with_keys function
+
+    if dynamic_fs:
+        key_exprs = [f"(jtu.GetAttrKey({name!r}), obj.{name})" for name in dynamic_fs]
+        dynamic_key_vals = f"({', '.join(key_exprs)},)"
+    else:
+        dynamic_key_vals = "()"
+
+    keys_dynamic_type = make_tuple_type(len(dynamic_fs), "tuple[jtu.GetAttrKey, str]")
+
+    flat_w_keys_code = FLAT_WITH_KEYS_CODE_BASE.format(
+        return_annotation=f"tuple[{keys_dynamic_type}, {static_type}]",
+        qualname=clsname,
+        fields_info=fields_info,
+        key_tuple=dynamic_key_vals,
+        aux=static_aux,
+    )
+
+    # flatten with keys func
+    exec(compile(flat_w_keys_code, FLAT_KEYS_NAME.format(clsname), "exec"), flat_ns)
+    flat_w_keys_fn = flat_ns["flatten_with_keys"]
+    flat_w_keys_fn.__module__ = module_name
+
+    # -------------------------------------------
+    # Generate unflatten function - directly set fields by index
+    # Extract types from flatten return type: tuple[dynamic_type, static_type]
+
+    unflatten_lines: list[str] = []
+    if dynamic_fs or static_fs:
+        unflatten_lines.append("# Set dynamic fields directly by index")
+    # Set dynamic fields directly by index
+    unflatten_lines.extend(
+        SET_DYNAMIC_BASE.format(i=i, name=k) for i, k in enumerate(dynamic_fs)
+    )
+    # # Set wrapper fields from aux_data
+    # unflatten_lines.append(SET_WRAPPER_LINES)
+    # Set static fields from aux_data
+    unflatten_lines.extend(
+        SET_AUX_BASE.format(i=i, name=k)
+        # for i, k in enumerate(static_fs, start=len(WRAPPER_FIELD_NAMES))
+        for i, k in enumerate(static_fs, start=0)
+    )
+
+    unflat_code = UNFLAT_FUNC_BASE.format(
+        aux_type=static_type,
+        dynamic_type=dynamic_type,
+        qualname=clsname,
+        fields_info=fields_info,
+        setters=textwrap.indent("\n".join(unflatten_lines), " " * INDENT)[INDENT:],
+    )
+
+    # Namespace for unflatten function (takes module_cls as parameter)
+    unflat_ns = NS_BASE | {"type": type, "T": TypeVar("T")}
+    # unflatten
+    exec(compile(unflat_code, UNFLAT_NAME.format(clsname), "exec"), unflat_ns)
+    unflat_fn = unflat_ns["unflatten"]
+    unflat_fn.__module__ = module_name
+
+    # -------------------------------------------
+
+    return flat_fn, flat_w_keys_fn, unflat_fn

--- a/equinox/_module/_module.py
+++ b/equinox/_module/_module.py
@@ -18,7 +18,7 @@ from .._pretty_print import tree_pformat
 from .._tree import tree_equal
 from ._better_abstract import better_dataclass, BetterABCMeta
 from ._field import field
-from ._flatten import generate_flatten_functions, WRAPPER_FIELD_NAMES
+from ._flatten import _generate_flatten_functions, _WRAPPER_FIELD_NAMES
 
 
 # Legacy compatibility API, passed to `strict` below.
@@ -312,7 +312,7 @@ class _ModuleMeta(BetterABCMeta):
 
         # Generate optimized flatten/unflatten functions
         flatten_func, flatten_with_keys_func, unflatten_func = (
-            generate_flatten_functions(cls, fields)  # pyright: ignore[reportArgumentType]
+            _generate_flatten_functions(cls, fields)  # pyright: ignore[reportArgumentType]
         )
 
         jtu.register_pytree_with_keys(
@@ -547,7 +547,7 @@ class Module(Hashable, metaclass=_ModuleMeta):
 
         def __setattr__(self, name: str, value: Any) -> None:
             if self in _currently_initialising and (
-                name in _module_info[type(self)] or name in WRAPPER_FIELD_NAMES
+                name in _module_info[type(self)] or name in _WRAPPER_FIELD_NAMES
             ):
                 _error_method_assignment(self, value)
                 _warn_jax_transformed_function(type(self), value)
@@ -667,7 +667,7 @@ def module_update_wrapper(
     # PyTree.
     _currently_initialising.add(wrapper)
     try:
-        for field_name in WRAPPER_FIELD_NAMES:
+        for field_name in _WRAPPER_FIELD_NAMES:
             try:
                 value = getattr(wrapped, field_name)
             except AttributeError:

--- a/equinox/_module/_module.py
+++ b/equinox/_module/_module.py
@@ -41,7 +41,7 @@ WRAPPER_FIELD_NAMES: Final = {
 _abstract_module_registry = weakref.WeakSet()
 _has_dataclass_init = weakref.WeakKeyDictionary()
 _module_info = weakref.WeakKeyDictionary()
-_flatten_sentinel = object()
+_MISSING = object()
 
 
 # Used to provide a pretty repr when doing `jtu.tree_structure(SomeModule(...))`.
@@ -76,15 +76,15 @@ class _ModuleFlattener:
         dynamic_fs = []
         dynamic_vs = []
         for k in self.dynamic_fs:
-            v = get(k, _flatten_sentinel)
-            if v is _flatten_sentinel:
+            v = get(k, _MISSING)
+            if v is _MISSING:
                 continue
             dynamic_fs.append(k)
             dynamic_vs.append(v)
         aux = _FlattenedData(
             tuple(dynamic_fs),
-            tuple([(k, get(k, _flatten_sentinel)) for k in self.static_fs]),
-            tuple([(k, get(k, _flatten_sentinel)) for k in WRAPPER_FIELD_NAMES]),
+            tuple([(k, get(k, _MISSING)) for k in self.static_fs]),
+            tuple([(k, get(k, _MISSING)) for k in WRAPPER_FIELD_NAMES]),
         )
         return tuple(dynamic_vs), aux
 
@@ -95,15 +95,15 @@ class _ModuleFlattener:
         dynamic_fs = []
         dynamic_vs = []
         for k in self.dynamic_fs:
-            v = get(k, _flatten_sentinel)
-            if v is _flatten_sentinel:
+            v = get(k, _MISSING)
+            if v is _MISSING:
                 continue
             dynamic_fs.append(k)
             dynamic_vs.append((jtu.GetAttrKey(k), v))
         aux = _FlattenedData(
             tuple(dynamic_fs),
-            tuple([(k, get(k, _flatten_sentinel)) for k in self.static_fs]),
-            tuple([(k, get(k, _flatten_sentinel)) for k in WRAPPER_FIELD_NAMES]),
+            tuple([(k, get(k, _MISSING)) for k in self.static_fs]),
+            tuple([(k, get(k, _MISSING)) for k in WRAPPER_FIELD_NAMES]),
         )
         return tuple(dynamic_vs), aux
 
@@ -122,7 +122,7 @@ class _ModuleFlattener:
         for name, value in zip(aux.dynamic_field_names, dynamic_field_values):
             object.__setattr__(module, name, value)
         for name, value in itertools.chain(aux.static_fields, aux.wrapper_fields):
-            if value is not _flatten_sentinel:
+            if value is not _MISSING:
                 object.__setattr__(module, name, value)
         return module
 

--- a/equinox/_module/_module.py
+++ b/equinox/_module/_module.py
@@ -21,7 +21,7 @@ from ._better_abstract import better_dataclass, BetterABCMeta
 from ._field import field
 
 
-# Legacy compatibibility API, passed to `strict` below.
+# Legacy compatibility API, passed to `strict` below.
 def StrictConfig(
     force_abstact: bool = False, **kwargs: object
 ) -> Literal[False] | None:

--- a/equinox/_module/_module.py
+++ b/equinox/_module/_module.py
@@ -1,7 +1,6 @@
 import dataclasses
 import functools as ft
 import inspect
-import textwrap
 import types
 import warnings
 import weakref
@@ -19,6 +18,7 @@ from .._pretty_print import tree_pformat
 from .._tree import tree_equal
 from ._better_abstract import better_dataclass, BetterABCMeta
 from ._field import field
+from ._flatten import generate_flatten_functions, WRAPPER_FIELD_NAMES
 
 
 # Legacy compatibility API, passed to `strict` below.
@@ -29,212 +29,9 @@ def StrictConfig(
     return None if force_abstact else False
 
 
-WRAPPER_FIELD_NAMES: Final = (
-    "__module__",
-    "__name__",
-    "__qualname__",
-    "__doc__",
-    "__annotations__",
-)
-
-
 _abstract_module_registry = weakref.WeakSet()
 _has_dataclass_init = weakref.WeakKeyDictionary()
 _module_info = weakref.WeakKeyDictionary()
-_MISSING = object()
-
-
-def _make_tuple_type(count: int, element_type: str = "Any") -> str:
-    """Generate a tuple type annotation string for a given count of elements."""
-    if count == 0:
-        return "tuple[()]"
-    elif count == 1:
-        return f"tuple[{element_type}]"
-    else:
-        return f"tuple[{', '.join([element_type] * count)}]"
-
-
-INDENT: Final = 4
-
-FIELDS_INFO = f"""
-    Dynamic fields: {{dynamic}}
-    Static fields: {{static}}
-    Wrapper fields: {WRAPPER_FIELD_NAMES}
-"""[1:-1]  # (trim leading and trailing newlines)
-
-
-FLATTEN_CODE_BASE = '''
-def flatten(obj: module_cls) -> {return_annotation}:
-    """Generated flatten function for {qualname}.
-    
-    {fields_info}
-    """
-    return {dynamic_vals}, {aux}
-'''
-
-
-FLATTEN_WITH_KEYS_CODE_BASE = '''
-def flatten_with_keys(obj: module_cls) -> {return_annotation}:
-    """Generated flatten_with_keys function for {qualname}.
-    
-    {fields_info}
-    """
-    return {key_tuple}, {aux}
-'''
-
-UNFLATTEN_FUNC_BASE = '''
-def unflatten(
-    module_cls: type[T],
-    aux_data: {aux_type},
-    children: {dynamic_type},
-) -> T:
-    """Generated unflatten function for {qualname}.
-
-    {fields_info}
-    """
-    self = object.__new__(module_cls)
-    {setters}
-    return self
-'''
-
-SET_DYNAMIC_BASE = """
-object.__setattr__(self, {name!r}, children[{i}])
-"""[1:-1]  # (trim leading and trailing newlines)
-
-SET_AUX_BASE = """
-if aux_data[{i}] is not _MISSING:
-    object.__setattr__(self, {name!r}, aux_data[{i}])
-"""[1:-1]  # (trim leading and trailing newlines)
-
-SET_WRAPPER_BASE = """
-if aux_data[{i}] is not _MISSING:
-    object.__setattr__(self, {name!r}, aux_data[{i}])
-"""[1:-1]
-
-SET_WRAPPER_LINES = "\n".join(
-    SET_WRAPPER_BASE.format(i=i, name=k) for i, k in enumerate(WRAPPER_FIELD_NAMES)
-)
-
-NS_BASE = {"object": object, "Any": Any, "tuple": tuple, "_MISSING": _MISSING}
-
-
-def _generate_flatten_functions(cls: type, fields: tuple[dataclasses.Field[Any], ...]):
-    """Generate optimized flatten/unflatten functions for a specific field config."""
-    # Separate dynamic and static fields
-    dynamic_fs_, static_fs_ = [], []
-    for f in fields:
-        if f.metadata.get("static", False):
-            static_fs_.append(f.name)
-        else:
-            dynamic_fs_.append(f.name)
-    dynamic_fs, static_fs = tuple(dynamic_fs_), tuple(static_fs_)
-    # aux_fs = WRAPPER_FIELD_NAMES + static_fs
-
-    # Build field info for docs
-    fields_info = FIELDS_INFO.format(dynamic=dynamic_fs, static=static_fs)[INDENT:]
-
-    # -------------------------------------------
-    # Generate flatten function
-
-    # Directly access dynamic fields by name
-    if dynamic_fs:
-        dynamic_exprs = [f"obj.{name}" for name in dynamic_fs]
-        dynamic_vals = f"({', '.join(dynamic_exprs)},)"
-    else:
-        dynamic_vals = "()"
-
-    # For static fields, we need to store their values in aux data
-    if static_fs:
-        static_exprs = [f"getattr(obj, {name!r}, _MISSING)" for name in static_fs]
-        static_aux = f"({', '.join(static_exprs)},)"
-    else:
-        static_aux = "()"
-
-    # Build return type annotation
-    dynamic_type = _make_tuple_type(len(dynamic_fs))
-    static_type = _make_tuple_type(len(static_fs))
-    qualname = cls.__qualname__
-
-    flatten_code = FLATTEN_CODE_BASE.format(
-        return_annotation=f"tuple[{dynamic_type}, {static_type}]",
-        qualname=qualname,
-        fields_info=fields_info,
-        dynamic_vals=dynamic_vals,
-        aux=static_aux,
-    )
-
-    # -------------------------------------------
-    # Generate flatten_with_keys function
-
-    key_exprs = [f"(jtu.GetAttrKey({name!r}), obj.{name})" for name in dynamic_fs]
-    key_tuple = f"({', '.join(key_exprs)},)" if dynamic_fs else "()"
-
-    keys_dynamic_type = _make_tuple_type(len(dynamic_fs), "tuple[Any, Any]")
-
-    flatten_with_keys_code = FLATTEN_WITH_KEYS_CODE_BASE.format(
-        return_annotation=f"tuple[{keys_dynamic_type}, {static_type}]",
-        qualname=qualname,
-        fields_info=fields_info,
-        key_tuple=key_tuple,
-        aux=static_aux,
-    )
-
-    # -------------------------------------------
-    # Generate unflatten function - directly set fields by index
-    # Extract types from flatten return type: tuple[dynamic_type, static_type]
-
-    unflatten_lines: list[str] = []
-    if dynamic_fs or static_fs:
-        unflatten_lines.append("# Set dynamic fields directly by index")
-    # Set dynamic fields directly by index
-    unflatten_lines.extend(
-        SET_DYNAMIC_BASE.format(i=i, name=k) for i, k in enumerate(dynamic_fs)
-    )
-    # Set wrapper fields from aux_data
-    # unflatten_lines.append(SET_WRAPPER_LINES)
-    # Set static fields from aux_data
-    unflatten_lines.extend(
-        SET_AUX_BASE.format(i=i, name=k)
-        # for i, k in enumerate(static_fs, start=len(WRAPPER_FIELD_NAMES))
-        for i, k in enumerate(static_fs, start=0)
-    )
-
-    unflatten_code = UNFLATTEN_FUNC_BASE.format(
-        aux_type=static_type,
-        dynamic_type=dynamic_type,
-        qualname=qualname,
-        fields_info=fields_info,
-        setters=textwrap.indent("\n".join(unflatten_lines), " " * INDENT)[INDENT:],
-    )
-
-    # -------------------------------------------
-    # Compile all functions
-
-    # Namespace for flatten functions (they need module_cls)
-    flatten_ns = NS_BASE | {"jtu": jtu, "module_cls": cls}
-
-    # Namespace for unflatten function (takes module_cls as parameter)
-    unflatten_ns = NS_BASE | {"type": type, "T": TypeVar("T")}
-
-    # Extract the generated functions from respective namespaces to
-    # set the proper module reference.
-    module_name = getattr(cls, "__module__", "equinox._module._module")
-    # flatten func
-    exec(compile(flatten_code, f"<generated_flatten_{qualname}>", "exec"), flatten_ns)
-    flatten_func = flatten_ns["flatten"]
-    flatten_func.__module__ = module_name
-    # flatten with keys func
-    func_name = f"<generated_flatten_with_keys_{qualname}>"
-    exec(compile(flatten_with_keys_code, func_name, "exec"), flatten_ns)
-    flatten_with_keys_func = flatten_ns["flatten_with_keys"]
-    flatten_with_keys_func.__module__ = module_name
-    # unflatten
-    func_name = f"<generated_unflatten_{qualname}>"
-    exec(compile(unflatten_code, func_name, "exec"), unflatten_ns)
-    unflatten_func = unflatten_ns["unflatten"]
-    unflatten_func.__module__ = module_name
-
-    return flatten_func, flatten_with_keys_func, unflatten_func
 
 
 MSG_METHOD_IN_INIT: Final = """Cannot assign methods in __init__.
@@ -426,7 +223,7 @@ class _ModuleMeta(BetterABCMeta):
         is_abstract: bool = False,
         strict: None | bool = False,
         **kwargs: object,
-    ) -> type["_ModuleMeta"]:
+    ):
         if strict is None:
             # Legacy compatibility API. Checking that this has the desired behaviour:
             #
@@ -515,7 +312,7 @@ class _ModuleMeta(BetterABCMeta):
 
         # Generate optimized flatten/unflatten functions
         flatten_func, flatten_with_keys_func, unflatten_func = (
-            _generate_flatten_functions(cls, fields)  # pyright: ignore[reportArgumentType]
+            generate_flatten_functions(cls, fields)  # pyright: ignore[reportArgumentType]
         )
 
         jtu.register_pytree_with_keys(

--- a/equinox/_module/_module.py
+++ b/equinox/_module/_module.py
@@ -28,13 +28,13 @@ def StrictConfig(
     return None if force_abstact else False
 
 
-WRAPPER_FIELD_NAMES: Final = {
+WRAPPER_FIELD_NAMES: Final = (
     "__module__",
     "__name__",
     "__qualname__",
     "__doc__",
     "__annotations__",
-}
+)
 
 
 _abstract_module_registry = weakref.WeakSet()

--- a/equinox/_module/_module.py
+++ b/equinox/_module/_module.py
@@ -29,7 +29,7 @@ def StrictConfig(
     return None if force_abstact else False
 
 
-wrapper_field_names: Final = {
+WRAPPER_FIELD_NAMES: Final = {
     "__module__",
     "__name__",
     "__qualname__",
@@ -84,7 +84,7 @@ class _ModuleFlattener:
         aux = _FlattenedData(
             tuple(dynamic_fs),
             tuple([(k, get(k, _flatten_sentinel)) for k in self.static_fs]),
-            tuple([(k, get(k, _flatten_sentinel)) for k in wrapper_field_names]),
+            tuple([(k, get(k, _flatten_sentinel)) for k in WRAPPER_FIELD_NAMES]),
         )
         return tuple(dynamic_vs), aux
 
@@ -103,7 +103,7 @@ class _ModuleFlattener:
         aux = _FlattenedData(
             tuple(dynamic_fs),
             tuple([(k, get(k, _flatten_sentinel)) for k in self.static_fs]),
-            tuple([(k, get(k, _flatten_sentinel)) for k in wrapper_field_names]),
+            tuple([(k, get(k, _flatten_sentinel)) for k in WRAPPER_FIELD_NAMES]),
         )
         return tuple(dynamic_vs), aux
 
@@ -636,7 +636,7 @@ class Module(Hashable, metaclass=_ModuleMeta):
 
         def __setattr__(self, name: str, value: Any) -> None:
             if self in _currently_initialising and (
-                name in _module_info[type(self)] or name in wrapper_field_names
+                name in _module_info[type(self)] or name in WRAPPER_FIELD_NAMES
             ):
                 _error_method_assignment(self, value)
                 _warn_jax_transformed_function(type(self), value)
@@ -756,7 +756,7 @@ def module_update_wrapper(
     # PyTree.
     _currently_initialising.add(wrapper)
     try:
-        for field_name in wrapper_field_names:
+        for field_name in WRAPPER_FIELD_NAMES:
             try:
                 value = getattr(wrapped, field_name)
             except AttributeError:

--- a/equinox/_module/_prebuilt.py
+++ b/equinox/_module/_prebuilt.py
@@ -6,7 +6,7 @@ import jax.tree_util as jtu
 from jaxtyping import PyTreeDef
 
 from ._field import field
-from ._module import Module, wrapper_field_names
+from ._module import Module, WRAPPER_FIELD_NAMES
 
 
 # Not using `jax.tree_util.Partial` as it doesn't implement __eq__ very well. See #480.
@@ -20,7 +20,7 @@ class BoundMethod(Module):
     __self__: Module
 
     def __post_init__(self):
-        for field_name in wrapper_field_names:
+        for field_name in WRAPPER_FIELD_NAMES:
             try:
                 value = getattr(self.__func__, field_name)
             except AttributeError:

--- a/equinox/_module/_prebuilt.py
+++ b/equinox/_module/_prebuilt.py
@@ -6,7 +6,7 @@ import jax.tree_util as jtu
 from jaxtyping import PyTreeDef
 
 from ._field import field
-from ._module import Module, WRAPPER_FIELD_NAMES
+from ._module import _WRAPPER_FIELD_NAMES, Module
 
 
 # Not using `jax.tree_util.Partial` as it doesn't implement __eq__ very well. See #480.
@@ -20,7 +20,7 @@ class BoundMethod(Module):
     __self__: Module
 
     def __post_init__(self):
-        for field_name in WRAPPER_FIELD_NAMES:
+        for field_name in _WRAPPER_FIELD_NAMES:
             try:
                 value = getattr(self.__func__, field_name)
             except AttributeError:


### PR DESCRIPTION
This PR enables power users to write their own flattening/unflattening procedures.
The advantage is that `Module` can be sped up to be as fast as custom pytree structures and jax arrays.
I'm attaching a Jupyter Notebook showing that in this example we achieve a ~50% speedup, which is ~100% of the overhead, making raw arrays, simple pytrees, and `Module` all equivalently fast.

I'm happy to add documentation / tests.

[overhead.ipynb.zip](https://github.com/user-attachments/files/22870041/overhead.ipynb.zip)
