### PR TITLE
perf: cache dataclass field names in _ModuleMeta

### DIFF
--- a/equinox/_module/_module.py
+++ b/equinox/_module/_module.py
@@ -40,6 +40,7 @@ wrapper_field_names: Final = {
 
 _abstract_module_registry = weakref.WeakSet()
 _has_dataclass_init = weakref.WeakKeyDictionary()
+_module_info = weakref.WeakKeyDictionary()
 _flatten_sentinel = object()
 
 
@@ -394,6 +395,9 @@ class _ModuleMeta(BetterABCMeta):
         if has_dataclass_init:
             cls.__init__.__doc__ = init_doc  # pyright: ignore[reportPossiblyUnboundVariable]
 
+        # Cache the field names for later use.
+        _module_info[cls] = frozenset(f.name for f in fields)
+
         flattener = _ModuleFlattener(fields)  # pyright: ignore[reportArgumentType]
         jtu.register_pytree_with_keys(
             cls,
@@ -626,15 +630,13 @@ class Module(Hashable, metaclass=_ModuleMeta):
     if not TYPE_CHECKING:
 
         def __setattr__(self, name: str, value: Any) -> None:
-            if self in _currently_initialising:
-                allowed_names = frozenset(
-                    {f.name for f in dataclasses.fields(self)}
-                ).union(wrapper_field_names)
-                if name in allowed_names:
-                    _error_method_assignment(self, value)
-                    _warn_jax_transformed_function(type(self), value)
-                    object.__setattr__(self, name, value)
-                    return
+            if self in _currently_initialising and (
+                name in _module_info[type(self)] or name in wrapper_field_names
+            ):
+                _error_method_assignment(self, value)
+                _warn_jax_transformed_function(type(self), value)
+                object.__setattr__(self, name, value)
+                return
             # Allow:
             # ```
             # class SomeModule(eqx.Module, Generic[T]): ...


### PR DESCRIPTION
 This PR, as named, increased performance during initialization by pre-computing the list of allowed field names and avoiding doing set unions before checking membership. `dataclasses.fields` does stuff beyond returning `__dataclass_fields__`, so it's performant to skip calling this function once per `__setattribute__` call.
@patrick-kidger I've happy to incorporate changes s.t. `__dataclass_field_names__` isn't stored on the class.