### PR TITLE
perf: localize init check

### DIFF
--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -730,7 +730,7 @@ def test_init_fields():
     class A(eqx.Module):
         x: int = eqx.field(init=False)
 
-    with pytest.raises(TypeError, match="The following fields were not initialised"):
+    with pytest.raises(TypeError, match="Field 'x' was not initialized."):
         A()
 
     class B(eqx.Module):
@@ -739,7 +739,7 @@ def test_init_fields():
         def __post_init__(self):
             pass
 
-    with pytest.raises(TypeError, match="The following fields were not initialised"):
+    with pytest.raises(TypeError, match="Field 'x' was not initialized."):
         B()
 
     class C(eqx.Module):
@@ -751,7 +751,7 @@ def test_init_fields():
                 self.x = 1
 
     C(flag=True)
-    with pytest.raises(TypeError, match="The following fields were not initialised"):
+    with pytest.raises(TypeError, match="Field 'x' was not initialized."):
         C(flag=False)
 
 


### PR DESCRIPTION
Avoids `dir` call to reduce initialization time by 55 percentage points!

Top is with this PR.
Bottom is before.

<img width="1186" height="810" alt="CleanShot 2025-11-04 at 12 16 26@2x" src="https://github.com/user-attachments/assets/ca2afcdc-6f15-4173-81b1-56e715ffff04" />
