### PR TITLE
types: is_array(_like) provides TypeGuard

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
         files: ^pyproject\.toml$
         additional_dependencies: ["toml-sort==0.23.1"]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.13.0
+    rev: v0.14.7
     hooks:
       - id: ruff-format # formatter
         types_or: [python, pyi, jupyter, toml]
@@ -16,7 +16,7 @@ repos:
         types_or: [python, pyi, jupyter, toml]
         args: [--fix]
   - repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.406
+    rev: v1.1.407
     hooks:
       - id: pyright
         additional_dependencies:

--- a/equinox/_doc_utils.py
+++ b/equinox/_doc_utils.py
@@ -26,14 +26,11 @@ class WithRepr(type):
 _T = TypeVar("_T")
 
 
-def doc_repr(obj: _T, string: str) -> _T:
-    if TYPE_CHECKING:
-        return obj
-    else:
-        if hasattr(typing, "GENERATING_DOCUMENTATION"):
-            return WithRepr(obj, string)
-        else:
-            return obj
+def doc_repr(obj: _T, string: str, /) -> _T:
+    if not TYPE_CHECKING and hasattr(typing, "GENERATING_DOCUMENTATION"):
+        return WithRepr(obj, string)
+
+    return obj
 
 
 def doc_remove_args(*args):

--- a/equinox/_serialisation.py
+++ b/equinox/_serialisation.py
@@ -86,7 +86,8 @@ def default_serialise_filter_spec(f: BinaryIO, x: Any) -> None:
         np.save(f, x)
     elif is_array_like(x):
         # Important to use `jnp` here to handle `bfloat16`.
-        jnp.save(f, x)
+        # jnp.asarray handles all array-like types including HasJaxArray
+        jnp.save(f, jnp.asarray(x))
     else:
         pass
 

--- a/equinox/_serialisation.py
+++ b/equinox/_serialisation.py
@@ -86,8 +86,7 @@ def default_serialise_filter_spec(f: BinaryIO, x: Any) -> None:
         np.save(f, x)
     elif is_array_like(x):
         # Important to use `jnp` here to handle `bfloat16`.
-        # jnp.asarray handles all array-like types including HasJaxArray
-        jnp.save(f, jnp.asarray(x))
+        jnp.save(f, x)
     else:
         pass
 

--- a/equinox/nn/_mlp.py
+++ b/equinox/nn/_mlp.py
@@ -1,9 +1,8 @@
 from collections.abc import Callable
-from typing import (
-    Literal,
-)
+from typing import Literal
 
 import jax.nn as jnn
+import jax.numpy as jnp
 import jax.random as jrandom
 import jax.tree_util as jtu
 from jaxtyping import Array, PRNGKeyArray
@@ -139,7 +138,9 @@ class MLP(Module):
         for i, layer in enumerate(self.layers[:-1]):
             x = layer(x)
             layer_activation = jtu.tree_map(
-                lambda x: x[i] if is_array(x) else x, self.activation
+                # `asarray` needed for `is_array` -> np.number / np.bool_
+                lambda x: jnp.asarray(x)[i] if is_array(x) else x,
+                self.activation,
             )
             x = filter_vmap(lambda a, b: a(b))(layer_activation, x)
         x = self.layers[-1](x)

--- a/tests/test_jit.py
+++ b/tests/test_jit.py
@@ -1,4 +1,5 @@
 import warnings
+from typing import cast
 
 import equinox as eqx
 import jax
@@ -6,6 +7,7 @@ import jax.numpy as jnp
 import jax.random as jrandom
 import jax.tree_util as jtu
 import pytest
+from jaxtyping import ArrayLike
 
 from .helpers import tree_allclose
 
@@ -32,7 +34,8 @@ def test_filter_jit(donate, getkey):
 
     array_tree_ = jtu.tree_map(jnp.copy, array_tree)
     general_tree_ = jtu.tree_map(
-        lambda x: jnp.copy(x) if eqx.is_array(x) else x, general_tree
+        lambda x: jnp.copy(cast(ArrayLike, x)) if eqx.is_array(x) else x,
+        general_tree,
     )
 
     @eqx.filter_jit(donate=donate)

--- a/tests/test_pmap.py
+++ b/tests/test_pmap.py
@@ -224,7 +224,9 @@ def test_map_non_jax():
 
     def maybe_replicate(value):
         if eqx.is_array(value):
-            return jax.device_put(value[None], device=cpu)
+            # TODO: remove the explicit jnp.asarray call once numpy/numpy#30335
+            # is part of the minimum supported numpy version
+            return jax.device_put(jnp.asarray(value)[None], device=cpu)
         else:
             return value
 


### PR DESCRIPTION
This PR:

1. enhances the return type annotations for `is_array` and `is_arraylike` so that they do better type narrowing.
2. updates pyright to get rid of a CI warning (ruff also got updated as part of `uv run pre-commit autoupdate`)
3. simplifies a few functions I saw while addressing pyright errors