### PR TITLE
fix: use jax.typeof instead of deprecated jax.core.get_aval

### DIFF
--- a/equinox/_ad.py
+++ b/equinox/_ad.py
@@ -872,7 +872,7 @@ def _none_to_zero(ct, x):
         if x is None:
             return None
         else:
-            aval = jax.core.get_aval(x)
+            aval = jax.typeof(x)
             if hasattr(aval, "to_tangent_aval"):
                 # Earlier versions of JAX were internally inconsistent, and expected
                 # e.g. integer primals to have integer tangents from `custom_{jvp,vjp}`

--- a/equinox/internal/_primitive.py
+++ b/equinox/internal/_primitive.py
@@ -60,7 +60,7 @@ def _is_array_like_internal(x):
 
 def _zero_from_primal(p):
     assert type(p) is not ad.UndefinedPrimal
-    aval = jax.core.get_aval(p)
+    aval = jax.typeof(p)
     if hasattr(aval, "to_tangent_aval"):
         # JAX >=0.4.34
         aval = aval.to_tangent_aval()  # pyright: ignore


### PR DESCRIPTION
`jax.core.get_aval` [has been deprecated in jax 0.8.2 release](https://docs.jax.dev/en/latest/changelog.html#jax-0-8-2-december-18-2025).
This PR replaces it with `jax.typeof`, fixing newly failing tests in optimistix.

Context: [bumping jax in nixpkgs](https://github.com/NixOS/nixpkgs/pull/472927).
