### PR TITLE
Ability to modify `EQX_ON_ERROR` after import time

### DIFF
--- a/equinox/_config.py
+++ b/equinox/_config.py
@@ -1,28 +1,39 @@
+import functools as ft
 import os
 import warnings
 from typing import Literal
 
 
-EQX_ON_ERROR: Literal["raise", "breakpoint", "nan", "off"] = os.environ.get(
-    "EQX_ON_ERROR", "raise"
-)  # pyright: ignore
-if EQX_ON_ERROR not in ("raise", "breakpoint", "nan", "off"):
-    raise ValueError(
-        "Unrecognised value for `EQX_ON_ERROR`. Valid values are `EQX_ON_ERROR=raise`, "
-        "`EQX_ON_ERROR=breakpoint`, `EQX_ON_ERROR=nan`, and `EQX_ON_ERROR=off`."
-    )
-if EQX_ON_ERROR == "breakpoint":
-    warnings.warn(
-        "The environment variable `EQX_ON_ERROR=breakpoint` is currently set. Note "
-        "that this should only be used for debugging, as it slows down runtime speed."
-    )
+@ft.lru_cache(maxsize=1)
+def get_eqx_on_error() -> Literal["raise", "breakpoint", "nan", "off"]:
+    EQX_ON_ERROR = os.environ.get("EQX_ON_ERROR", "raise")
+    if EQX_ON_ERROR not in ("raise", "breakpoint", "nan", "off"):
+        raise ValueError(
+            "Unrecognised value for `EQX_ON_ERROR`. Valid values are "
+            "`EQX_ON_ERROR=raise`, `EQX_ON_ERROR=breakpoint`, `EQX_ON_ERROR=nan`, "
+            "and `EQX_ON_ERROR=off`."
+        )
+    if EQX_ON_ERROR == "breakpoint":
+        warnings.warn(
+            "The environment variable `EQX_ON_ERROR=breakpoint` is currently set. "
+            "Note that this should only be used for debugging, as it slows down "
+            "runtime speed."
+        )
+    return EQX_ON_ERROR
 
 
-EQX_ON_ERROR_BREAKPOINT_FRAMES = os.environ.get("EQX_ON_ERROR_BREAKPOINT_FRAMES", None)
-if EQX_ON_ERROR_BREAKPOINT_FRAMES is None:
-    EQX_ON_ERROR_BREAKPOINT_FRAMES = 1
-else:
-    EQX_ON_ERROR_BREAKPOINT_FRAMES = int(EQX_ON_ERROR_BREAKPOINT_FRAMES)
+@ft.lru_cache(maxsize=1)
+def get_eqx_on_error_breakpoint_frames():
+    EQX_ON_ERROR_BREAKPOINT_FRAMES = os.environ.get(
+        "EQX_ON_ERROR_BREAKPOINT_FRAMES", None
+    )
+    if EQX_ON_ERROR_BREAKPOINT_FRAMES is None:
+        EQX_ON_ERROR_BREAKPOINT_FRAMES = 1
+    else:
+        EQX_ON_ERROR_BREAKPOINT_FRAMES = int(EQX_ON_ERROR_BREAKPOINT_FRAMES)
+
+    return EQX_ON_ERROR_BREAKPOINT_FRAMES
+
 
 try:
     EQX_GETKEY_SEED = int(os.environ["EQX_GETKEY_SEED"])


### PR DESCRIPTION
This PR adds the ability to modify `EQX_ON_ERROR` after import time. This makes it possible to run

```python
import os
import equinox

os.environ["EQX_ON_ERROR"] = "nan"
```

which has a similar feel to `jax.config`, and as discussed in #1163 gives downstream packages the ability to set their own default value. Under the hood, we evaluate the value of `EQX_ON_ERROR` on the first call to `error_if` and cache its value.

In #1163 we discuss that the JAX bug on the behavior of the "breakpoint" option presents some difficult on how exactly to implement this PR. I think it suffices to only support the old behavior with "breakpoint" and throw errors if the user tries to modify `EQX_TO_ERROR` to/from this value.

I have tested things out in my terminal and things look good. Since we are dealing with environmental variables, I was unsure if there is a test that can be added! Would be good if someone can double check things work as expected.