### PR TITLE
Add missing axis type to documentation parallelism example

### DIFF
--- a/docs/examples/parallelism.ipynb
+++ b/docs/examples/parallelism.ipynb
@@ -106,7 +106,9 @@
    "outputs": [],
    "source": [
     "num_devices = len(jax.devices())\n",
-    "mesh = jax.make_mesh((num_devices,), (\"batch\",))\n",
+    "mesh = jax.make_mesh(\n",
+    "    (num_devices,), (\"batch\",), axis_types=(jax.sharding.AxisType.Auto,)\n",
+    ")\n",
     "data_sharding = jshard.NamedSharding(mesh, jshard.PartitionSpec(\"batch\"))\n",
     "model_sharding = jshard.NamedSharding(mesh, jshard.PartitionSpec())\n",
     "\n",


### PR DESCRIPTION
As mentioned and fixed for the test suite in https://github.com/patrick-kidger/equinox/pull/1146, [JAX 0.8.1](https://docs.jax.dev/en/latest/changelog.html#jax-0-8-1-november-18-2025) changed the default `axis_types` of `jax.make_mesh` to `jax.sharding.AxisType.Explicit`. This PR fixes the docs as well, which won't run with an up-to-date version of JAX.