### PR TITLE
feat: compiler options

### DIFF
--- a/equinox/_compile_utils.py
+++ b/equinox/_compile_utils.py
@@ -112,9 +112,9 @@ class Lowered(Module):
     def as_text(self):
         return self.lowered.as_text()
 
-    def compile(self):
+    def compile(self, /, compiler_options: dict[str, str | bool] | None = None):
         return Compiled(
-            self.lowered.compile(),
+            self.lowered.compile(compiler_options=compiler_options),
             self.info,
             self.preprocess,  # pyright: ignore
             self.postprocess,  # pyright: ignore


### PR DESCRIPTION
Good morning, Patrick!

Hope you are doing well. I recently needed to use some compiler options with `.compile()` - mainly because of some issues with XLA leading to autotune spiking the memory consumption. Right now we have an ugly piece of code in our codebase that is just a simplified ad-hoc `eqx.filter_jit`. 

So I was wondering if we could upstream the compile options passing into eqx.filter_jit? There are probably a lot of sharp corners I'm cutting here, so I'm wondering if you think there is anything lacking.

Cheers,
Roman