### PR TITLE
Add GPJax to list

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ If you found this library to be useful in academic work, then please cite: ([arX
 [BlackJAX](https://github.com/blackjax-devs/blackjax): probabilistic+Bayesian sampling.  
 [sympy2jax](https://github.com/patrick-kidger/sympy2jax): SymPy<->JAX conversion; train symbolic expressions via gradient descent.  
 [PySR](https://github.com/milesCranmer/PySR): symbolic regression. (Non-JAX honourable mention!)  
+[GPjax](https://github.com/thomaspinder/gpjax): Gaussian processes models.
 
 **Awesome JAX**  
 [Awesome Equinox](https://docs.kidger.site/equinox/awesome-list/)  

--- a/README.md
+++ b/README.md
@@ -99,7 +99,6 @@ If you found this library to be useful in academic work, then please cite: ([arX
 [BlackJAX](https://github.com/blackjax-devs/blackjax): probabilistic+Bayesian sampling.  
 [sympy2jax](https://github.com/patrick-kidger/sympy2jax): SymPy<->JAX conversion; train symbolic expressions via gradient descent.  
 [PySR](https://github.com/milesCranmer/PySR): symbolic regression. (Non-JAX honourable mention!)  
-[GPjax](https://github.com/thomaspinder/gpjax): Gaussian processes models.
 
 **Awesome JAX**  
 [Awesome Equinox](https://docs.kidger.site/equinox/awesome-list/)  

--- a/docs/awesome-list.md
+++ b/docs/awesome-list.md
@@ -111,8 +111,8 @@ Parametric modeling in JAX + Equinox.
 **ParamRF**: [Github](https://github.com/gvcallen/paramrf)  
 Parametric radio frequency modeling, optimization and sampling.
 
-+**Peex**: [Github](https://github.com/sammccallum/peex)  
-+Runtime hooks for Equinox modules.
+**Peex**: [Github](https://github.com/sammccallum/peex)  
+Runtime hooks for Equinox modules.
 
-+**GPJax**: [Github](https://github.com/thomaspinder/gpjax)  
-+Gaussian process models in JAX and Equinox.
+**GPJax**: [Github](https://github.com/thomaspinder/gpjax)  
+Gaussian process models in JAX and Equinox.

--- a/docs/awesome-list.md
+++ b/docs/awesome-list.md
@@ -113,3 +113,6 @@ Parametric radio frequency modeling, optimization and sampling.
 
 +**Peex**: [Github](https://github.com/sammccallum/peex)  
 +Runtime hooks for Equinox modules.
+
++**GPJax**: [Github](https://github.com/thomaspinder/gpjax)  
++Gaussian process models in JAX and Equinox.


### PR DESCRIPTION
GPJax now builds upon Equinox. It would be nice to be featured in the corresponding lists.