### PR TITLE
add module metaclass to typevar call

### DIFF
--- a/equinox/_module/_module.py
+++ b/equinox/_module/_module.py
@@ -385,7 +385,7 @@ class _ModuleMeta(BetterABCMeta):
 
         return cls
 
-    def __call__(cls, *args: object, **kwargs: object):  # noqa: N805
+    def __call__(cls: "type[_ModuleT]", *args: object, **kwargs: object) -> "_ModuleT":  # noqa: N805
         __tracebackhide__ = True
         if cls in _abstract_module_registry:
             # Any other is-abstract checks will be handled in super().__call__.


### PR DESCRIPTION
This addresses #1216, it's just a one line change to use the generic for `_ModuleMeta` in the `__call__` the same way it is used on `Module`'s `__new__` function