### PR TITLE
perf: cache per-class field metadata in _ModuleInfo to speed up Module init

### DIFF
--- a/equinox/_module/_module.py
+++ b/equinox/_module/_module.py
@@ -371,9 +371,9 @@ class _ModuleMeta(BetterABCMeta):
         # Cache the field names and per-instantiation metadata for later use.
         names = tuple(f.name for f in fields)
         converter_fields = tuple(
-            (f.name, f.metadata["converter"])
+            (f.name, converter)
             for f in fields
-            if "converter" in f.metadata
+            if (converter := f.metadata.get("converter")) is not None
         )
         static_field_names = tuple(
             f.name for f in fields if f.metadata.get("static", False)

--- a/equinox/_module/_module.py
+++ b/equinox/_module/_module.py
@@ -48,6 +48,10 @@ class _ModuleInfo(NamedTuple):
 
     names_tuple: tuple[str, ...]
     names_set: frozenset[str]
+    converter_fields: tuple[tuple[str, Any], ...]  # (name, converter) pairs
+    static_field_names: tuple[str, ...]  # names of static=True fields
+    non_init_field_names: tuple[str, ...]  # names of init=False fields
+    check_init_methods: tuple[Any, ...]  # unbound __check_init__ funcs from MRO
 
 
 MSG_METHOD_IN_INIT: Final = """Cannot assign methods in __init__.
@@ -364,11 +368,29 @@ class _ModuleMeta(BetterABCMeta):
         if has_dataclass_init:
             cls.__init__.__doc__ = init_doc  # pyright: ignore[reportPossiblyUnboundVariable]
 
-        # Cache the field names for later use.
+        # Cache the field names and per-instantiation metadata for later use.
         names = tuple(f.name for f in fields)
+        converter_fields = tuple(
+            (f.name, f.metadata["converter"])
+            for f in fields
+            if "converter" in f.metadata
+        )
+        static_field_names = tuple(
+            f.name for f in fields if f.metadata.get("static", False)
+        )
+        non_init_field_names = tuple(f.name for f in fields if not f.init)
+        check_init_methods = tuple(
+            parent_cls.__dict__["__check_init__"]
+            for parent_cls in cls.__mro__  # pyright: ignore[reportGeneralTypeIssues]
+            if "__check_init__" in parent_cls.__dict__
+        )
         _module_info[cls] = _ModuleInfo(
             names_tuple=names,
             names_set=frozenset(names),
+            converter_fields=converter_fields,
+            static_field_names=static_field_names,
+            non_init_field_names=non_init_field_names,
+            check_init_methods=check_init_methods,
         )
 
         # Generate optimized flatten/unflatten functions
@@ -403,35 +425,36 @@ class _ModuleMeta(BetterABCMeta):
             del tryself
         assert not is_abstract_module(cls)  # pyright: ignore[reportArgumentType]
 
-        fields = dataclasses.fields(cls)  # pyright: ignore[reportArgumentType]
+        info = _module_info[cls]
 
-        for f in fields:
-            # Check the field was initialized.
+        # Check all fields were initialized.
+        for name in info.names_tuple:
             try:
-                val = getattr(self, f.name)
+                getattr(self, name)
             except AttributeError as err:
-                raise TypeError(f"Field {f.name!r} was not initialized.") from err
+                raise TypeError(f"Field {name!r} was not initialized.") from err
 
-            if (converter := f.metadata.get("converter")) is not None:
-                object.__setattr__(self, f.name, converter(getattr(self, f.name)))
-            if f.metadata.get("static", False):
-                if any(jtu.tree_map(is_array, jtu.tree_leaves(getattr(self, f.name)))):
-                    warnings.warn(
-                        "A JAX array is being set as static! This can result "
-                        "in unexpected behavior and is usually a mistake to do.",
-                        stacklevel=2,
-                    )
-            if not f.init:
-                if any(jtu.tree_map(is_inexact_array_like, jtu.tree_leaves(val))):
-                    warnings.warn(_MSG_FIELD_INIT_FALSE, stacklevel=2)
+        # Warn about init=False fields containing inexact arrays (pre-converter values).
+        for name in info.non_init_field_names:
+            val = getattr(self, name)
+            if any(jtu.tree_map(is_inexact_array_like, jtu.tree_leaves(val))):
+                warnings.warn(_MSG_FIELD_INIT_FALSE, stacklevel=2)
 
-        for parent_cls in cls.__mro__:
-            try:
-                check_init = parent_cls.__dict__["__check_init__"]
-            except KeyError:  # noqa: PERF203
-                pass
-            else:
-                check_init(self)
+        # Apply converters.
+        for name, converter in info.converter_fields:
+            object.__setattr__(self, name, converter(getattr(self, name)))
+
+        # Warn about static fields containing JAX arrays (post-converter values).
+        for name in info.static_field_names:
+            if any(jtu.tree_map(is_array, jtu.tree_leaves(getattr(self, name)))):
+                warnings.warn(
+                    "A JAX array is being set as static! This can result "
+                    "in unexpected behavior and is usually a mistake to do.",
+                    stacklevel=2,
+                )
+
+        for check_init in info.check_init_methods:
+            check_init(self)
 
         return self
 

--- a/equinox/_module/_module.py
+++ b/equinox/_module/_module.py
@@ -434,15 +434,15 @@ class _ModuleMeta(BetterABCMeta):
             except AttributeError as err:
                 raise TypeError(f"Field {name!r} was not initialized.") from err
 
-        # Warn about init=False fields containing inexact arrays (pre-converter values).
+        # Apply converters.
+        for name, converter in info.converter_fields:
+            object.__setattr__(self, name, converter(getattr(self, name)))
+
+        # Warn about init=False fields containing inexact arrays.
         for name in info.non_init_field_names:
             val = getattr(self, name)
             if any(jtu.tree_map(is_inexact_array_like, jtu.tree_leaves(val))):
                 warnings.warn(_MSG_FIELD_INIT_FALSE, stacklevel=2)
-
-        # Apply converters.
-        for name, converter in info.converter_fields:
-            object.__setattr__(self, name, converter(getattr(self, name)))
 
         # Warn about static fields containing JAX arrays (post-converter values).
         for name in info.static_field_names:


### PR DESCRIPTION
`_ModuleMeta.__call__` previously recomputed three things on every instantiation:
- dataclasses.fields(cls) — allocates a new tuple each call
- f.metadata.get("converter") / f.metadata.get("static") — per-field dict lookups
- for parent_cls in ``cls.__mro__``:`` __check_init__`` — full MRO scan each call

All three are now computed once at class-definition time in `_ModuleMeta.__new__` and stored in four new `_ModuleInfo` fields:
- converter_fields: tuple of (name, converter) pairs
- static_field_names: tuple of static=True field names
- non_init_field_names: tuple of init=False field names
- check_init_methods: tuple of unbound `__check_init__` functions from the MRO

``__call__`` now does a single `_module_info[cls]` lookup and iterates over pre-filtered tuples, which are empty for the common case (no converters, no static fields, no `__check_init__`).

Asking Copilot to speed test this PR against main in a few scenarios.
<img width="476" height="289" alt="CleanShot 2026-04-21 at 10 16 36" src="https://github.com/user-attachments/assets/53840a1d-5f8a-4ac3-8ec7-665b45d737c5" />

[bench_module_init.txt](https://github.com/user-attachments/files/26936518/bench_module_init.txt)