### PR TITLE
perf: add fastpaths in `_ModuleMeta.__call__`

### DIFF
--- a/equinox/_module/_module.py
+++ b/equinox/_module/_module.py
@@ -66,6 +66,10 @@ class _ModuleInfo(NamedTuple):
     # can never hold a JAX-transformed callable. When False, the jtu.tree_leaves
     # scan in __call__ is skipped entirely.
     may_receive_callable_args: bool
+    # When True, _ModuleMeta.__call__ skips all checks/warnings (other than the
+    # abstract check) and only creates the instance, applies converters, and
+    # removes from _currently_initialising.
+    unchecked_init: bool
 
 
 # ---------------------------------------------------------------------------
@@ -323,6 +327,7 @@ class _ModuleMeta(BetterABCMeta):
         *,
         is_abstract: bool = False,
         strict: None | bool = False,
+        unchecked_init: bool = False,
         **kwargs: object,
     ):
         if strict is None:
@@ -456,6 +461,7 @@ class _ModuleMeta(BetterABCMeta):
             check_init_methods=check_init_methods,
             unchecked_init_false_names=unchecked_init_false_names,
             may_receive_callable_args=may_receive_callable_args,
+            unchecked_init=unchecked_init,
         )
 
         # Generate optimized flatten/unflatten functions
@@ -479,6 +485,19 @@ class _ModuleMeta(BetterABCMeta):
             raise TypeError("Cannot instantiate abstract `equinox.Module`.")
 
         info = _module_info[cls]
+
+        if info.unchecked_init:
+            tryself = None
+            try:
+                self = tryself = super().__call__(*args, **kwargs)  # pyright: ignore[reportAttributeAccessIssue]
+            finally:
+                if tryself is not None:
+                    _currently_initialising.remove(tryself)
+                del tryself
+            for name, converter in info.converter_fields:
+                object.__setattr__(self, name, converter(getattr(self, name)))
+            return self
+
         has_dcls_init = _has_dataclass_init[cls]
         if has_dcls_init and info.may_receive_callable_args:
             for x in jtu.tree_leaves((args, kwargs)):

--- a/equinox/_module/_module.py
+++ b/equinox/_module/_module.py
@@ -66,6 +66,9 @@ class _ModuleInfo(NamedTuple):
     # can never hold a JAX-transformed callable. When False, the jtu.tree_leaves
     # scan in __call__ is skipped entirely.
     may_receive_callable_args: bool
+    # Mirrors _has_dataclass_init[cls]: cached here to avoid a second
+    # WeakKeyDictionary lookup in the hot __call__ path.
+    has_dataclass_init: bool
     # When True, _ModuleMeta.__call__ skips all checks/warnings (other than the
     # abstract check) and only creates the instance, applies converters, and
     # removes from _currently_initialising.
@@ -231,11 +234,11 @@ class _IdSet:
         self._dict: dict[int, Module] = {}
 
     def __contains__(self, key: "Module") -> bool:
-        return id(key) in self._dict.keys()
+        return id(key) in self._dict
 
     def add(self, key: "Module") -> None:
-        if key not in self:
-            id_key = id(key)
+        id_key = id(key)
+        if id_key not in self._dict:
             # Hold on to `key` to be sure that `id(key)` does not get reallocated.
             self._dict[id_key] = key
 
@@ -461,6 +464,7 @@ class _ModuleMeta(BetterABCMeta):
             check_init_methods=check_init_methods,
             unchecked_init_false_names=unchecked_init_false_names,
             may_receive_callable_args=may_receive_callable_args,
+            has_dataclass_init=has_dataclass_init,
             unchecked_init=unchecked_init,
         )
 
@@ -498,7 +502,7 @@ class _ModuleMeta(BetterABCMeta):
                 object.__setattr__(self, name, converter(getattr(self, name)))
             return self
 
-        has_dcls_init = _has_dataclass_init[cls]
+        has_dcls_init = info.has_dataclass_init
         if has_dcls_init and info.may_receive_callable_args:
             for x in jtu.tree_leaves((args, kwargs)):
                 _warn_jax_transformed_function(cls, x)
@@ -534,12 +538,12 @@ class _ModuleMeta(BetterABCMeta):
         # Warn about init=False fields containing inexact arrays.
         for name in info.non_init_field_names:
             val = getattr(self, name)
-            if any(jtu.tree_map(is_inexact_array_like, jtu.tree_leaves(val))):
+            if any(map(is_inexact_array_like, jtu.tree_leaves(val))):
                 warnings.warn(_MSG_FIELD_INIT_FALSE, stacklevel=2)
 
         # Warn about static fields containing JAX arrays (post-converter values).
         for name in info.static_field_names:
-            if any(jtu.tree_map(is_array, jtu.tree_leaves(getattr(self, name)))):
+            if any(map(is_array, jtu.tree_leaves(getattr(self, name)))):
                 warnings.warn(
                     "A JAX array is being set as static! This can result "
                     "in unexpected behavior and is usually a mistake to do.",
@@ -678,9 +682,10 @@ class Module(Hashable, metaclass=_ModuleMeta):
 
         def __setattr__(self, name: str, value: Any) -> None:
             if self in _currently_initialising:
-                if name in _module_info[type(self)].names_set:
+                cls = type(self)
+                if name in _module_info[cls].names_set:
                     _error_method_assignment(self, value)
-                    _warn_jax_transformed_function(type(self), value)
+                    _warn_jax_transformed_function(cls, value)
                     object.__setattr__(self, name, value)
                     return
                 elif name in WRAPPER_FIELD_NAMES:
@@ -713,9 +718,9 @@ class Module(Hashable, metaclass=_ModuleMeta):
             # ```
             # works.
             if (
-                not _is_magic(name)
-                and isinstance(out, types.MethodType)
+                isinstance(out, types.MethodType)
                 and out.__self__ is self
+                and not _is_magic(name)
             ):
                 out = BoundMethod(object.__getattribute__(out, "__func__"), self)
             return out

--- a/equinox/_module/_module.py
+++ b/equinox/_module/_module.py
@@ -658,14 +658,17 @@ class Module(Hashable, metaclass=_ModuleMeta):
     if not TYPE_CHECKING:
 
         def __setattr__(self, name: str, value: Any) -> None:
-            if self in _currently_initialising and (
-                name in _module_info[type(self)].names_set
-                or name in WRAPPER_FIELD_NAMES
-            ):
-                _error_method_assignment(self, value)
-                _warn_jax_transformed_function(type(self), value)
-                object.__setattr__(self, name, value)
-                return
+            if self in _currently_initialising:
+                if name in _module_info[type(self)].names_set:
+                    _error_method_assignment(self, value)
+                    _warn_jax_transformed_function(type(self), value)
+                    object.__setattr__(self, name, value)
+                    return
+                elif name in WRAPPER_FIELD_NAMES:
+                    # Allow setting wrapper fields without warning, because they
+                    # are ignored by the PyTree machinery.
+                    object.__setattr__(self, name, value)
+                    return
             # Allow:
             # ```
             # class SomeModule(eqx.Module, Generic[T]): ...

--- a/equinox/_module/_module.py
+++ b/equinox/_module/_module.py
@@ -9,11 +9,15 @@ from typing import (
     Any,
     cast,
     Final,
+    get_args,
+    get_origin,
+    get_type_hints,
     Literal,
     NamedTuple,
     ParamSpec,
     TYPE_CHECKING,
     TypeVar,
+    Union,
 )
 from typing_extensions import dataclass_transform
 
@@ -58,6 +62,36 @@ class _ModuleInfo(NamedTuple):
     # check these; for all other (init=True) fields the generated __init__
     # guarantees they are set.
     unchecked_init_false_names: tuple[str, ...]
+    # Fastpath: False when every init=True field is annotated with a type that
+    # can never hold a JAX-transformed callable. When False, the jtu.tree_leaves
+    # scan in __call__ is skipped entirely.
+    may_receive_callable_args: bool
+
+
+# ---------------------------------------------------------------------------
+# Callable-warning scan helpers
+# ---------------------------------------------------------------------------
+
+_SAFE_FROM_CALLABLE_TYPES: frozenset[type] = frozenset(
+    {int, float, str, bool, bytes, complex, type(None), np.ndarray, jax.Array}
+)
+
+# types.UnionType (``X | Y`` syntax) is available from Python 3.10 onwards.
+_UNION_TYPE: type | None = getattr(types, "UnionType", None)
+
+
+def _is_safe_from_callable_warning(annotation: object, /) -> bool:
+    """True only if no value with this annotation can be a JAX-transformed callable."""
+    if annotation is Any or annotation is object:
+        return False
+    if annotation in _SAFE_FROM_CALLABLE_TYPES:
+        return True
+    origin = get_origin(annotation)
+    if origin is Union or (
+        _UNION_TYPE is not None and isinstance(annotation, _UNION_TYPE)
+    ):
+        return all(_is_safe_from_callable_warning(a) for a in get_args(annotation))
+    return False
 
 
 MSG_METHOD_IN_INIT: Final = """Cannot assign methods in __init__.
@@ -401,6 +435,18 @@ class _ModuleMeta(BetterABCMeta):
             and f.default is dataclasses.MISSING
             and f.default_factory is dataclasses.MISSING  # pyright: ignore[reportAttributeAccessIssue]
         )
+        # Precompute whether any init=True field could hold a JAX-transformed
+        # callable. On failure (e.g. unresolvable forward refs) fall back to
+        # True so the scan is never incorrectly skipped.
+        try:
+            hints = get_type_hints(cls)
+        except Exception:
+            hints = {}
+        may_receive_callable_args = not all(
+            _is_safe_from_callable_warning(hints.get(f.name, Any))
+            for f in fields  # pyright: ignore[reportArgumentType]
+            if f.init
+        )
         _module_info[cls] = _ModuleInfo(
             names_tuple=names,
             names_set=frozenset(names),
@@ -409,6 +455,7 @@ class _ModuleMeta(BetterABCMeta):
             non_init_field_names=non_init_field_names,
             check_init_methods=check_init_methods,
             unchecked_init_false_names=unchecked_init_false_names,
+            may_receive_callable_args=may_receive_callable_args,
         )
 
         # Generate optimized flatten/unflatten functions
@@ -431,7 +478,9 @@ class _ModuleMeta(BetterABCMeta):
             # Any other is-abstract checks will be handled in super().__call__.
             raise TypeError("Cannot instantiate abstract `equinox.Module`.")
 
-        if has_dcls_init := _has_dataclass_init[cls]:
+        info = _module_info[cls]
+        has_dcls_init = _has_dataclass_init[cls]
+        if has_dcls_init and info.may_receive_callable_args:
             for x in jtu.tree_leaves((args, kwargs)):
                 _warn_jax_transformed_function(cls, x)
 
@@ -443,8 +492,6 @@ class _ModuleMeta(BetterABCMeta):
                 _currently_initialising.remove(tryself)
             del tryself
         assert not is_abstract_module(cls)  # pyright: ignore[reportArgumentType]
-
-        info = _module_info[cls]
 
         # Check all fields were initialized.
         # Fastpath: when using the dataclass-generated __init__ every init=True

--- a/equinox/_module/_module.py
+++ b/equinox/_module/_module.py
@@ -52,6 +52,12 @@ class _ModuleInfo(NamedTuple):
     static_field_names: tuple[str, ...]  # names of static=True fields
     non_init_field_names: tuple[str, ...]  # names of init=False fields
     check_init_methods: tuple[Any, ...]  # unbound __check_init__ funcs from MRO
+    # Fastpath: init=False fields that have NO default/default_factory and
+    # therefore are not guaranteed to be set by the dataclass-generated
+    # __init__.  When the class uses the dataclass __init__ we only need to
+    # check these; for all other (init=True) fields the generated __init__
+    # guarantees they are set.
+    unchecked_init_false_names: tuple[str, ...]
 
 
 MSG_METHOD_IN_INIT: Final = """Cannot assign methods in __init__.
@@ -384,6 +390,17 @@ class _ModuleMeta(BetterABCMeta):
             for parent_cls in cls.__mro__  # pyright: ignore[reportGeneralTypeIssues]
             if "__check_init__" in parent_cls.__dict__
         )
+        # Precompute fastpath: init=False fields without a default or
+        # default_factory are the only ones NOT guaranteed to be set by the
+        # dataclass-generated __init__, so those are the ones we still have to
+        # check even on the fastpath.
+        unchecked_init_false_names = tuple(
+            f.name
+            for f in fields  # pyright: ignore[reportArgumentType]
+            if not f.init
+            and f.default is dataclasses.MISSING
+            and f.default_factory is dataclasses.MISSING  # pyright: ignore[reportAttributeAccessIssue]
+        )
         _module_info[cls] = _ModuleInfo(
             names_tuple=names,
             names_set=frozenset(names),
@@ -391,6 +408,7 @@ class _ModuleMeta(BetterABCMeta):
             static_field_names=static_field_names,
             non_init_field_names=non_init_field_names,
             check_init_methods=check_init_methods,
+            unchecked_init_false_names=unchecked_init_false_names,
         )
 
         # Generate optimized flatten/unflatten functions
@@ -412,7 +430,8 @@ class _ModuleMeta(BetterABCMeta):
         if cls in _abstract_module_registry:
             # Any other is-abstract checks will be handled in super().__call__.
             raise TypeError("Cannot instantiate abstract `equinox.Module`.")
-        if _has_dataclass_init[cls]:
+
+        if has_dcls_init := _has_dataclass_init[cls]:
             for x in jtu.tree_leaves((args, kwargs)):
                 _warn_jax_transformed_function(cls, x)
 
@@ -428,7 +447,15 @@ class _ModuleMeta(BetterABCMeta):
         info = _module_info[cls]
 
         # Check all fields were initialized.
-        for name in info.names_tuple:
+        # Fastpath: when using the dataclass-generated __init__ every init=True
+        # field is guaranteed to be set, and every init=False field that has a
+        # default/default_factory is also set.  Only init=False fields without
+        # any default can be missing, so we only iterate over those.
+        # With a custom __init__ we fall back to checking everything.
+        names_to_check = (
+            info.unchecked_init_false_names if has_dcls_init else info.names_tuple
+        )
+        for name in names_to_check:
             try:
                 getattr(self, name)
             except AttributeError as err:

--- a/equinox/_module/_module.py
+++ b/equinox/_module/_module.py
@@ -69,10 +69,6 @@ class _ModuleInfo(NamedTuple):
     # Mirrors _has_dataclass_init[cls]: cached here to avoid a second
     # WeakKeyDictionary lookup in the hot __call__ path.
     has_dataclass_init: bool
-    # When True, _ModuleMeta.__call__ skips all checks/warnings (other than the
-    # abstract check) and only creates the instance, applies converters, and
-    # removes from _currently_initialising.
-    unchecked_init: bool
 
 
 # ---------------------------------------------------------------------------
@@ -330,7 +326,6 @@ class _ModuleMeta(BetterABCMeta):
         *,
         is_abstract: bool = False,
         strict: None | bool = False,
-        unchecked_init: bool = False,
         **kwargs: object,
     ):
         if strict is None:
@@ -465,7 +460,6 @@ class _ModuleMeta(BetterABCMeta):
             unchecked_init_false_names=unchecked_init_false_names,
             may_receive_callable_args=may_receive_callable_args,
             has_dataclass_init=has_dataclass_init,
-            unchecked_init=unchecked_init,
         )
 
         # Generate optimized flatten/unflatten functions
@@ -489,18 +483,6 @@ class _ModuleMeta(BetterABCMeta):
             raise TypeError("Cannot instantiate abstract `equinox.Module`.")
 
         info = _module_info[cls]
-
-        if info.unchecked_init:
-            tryself = None
-            try:
-                self = tryself = super().__call__(*args, **kwargs)  # pyright: ignore[reportAttributeAccessIssue]
-            finally:
-                if tryself is not None:
-                    _currently_initialising.remove(tryself)
-                del tryself
-            for name, converter in info.converter_fields:
-                object.__setattr__(self, name, converter(getattr(self, name)))
-            return self
 
         has_dcls_init = info.has_dataclass_init
         if has_dcls_init and info.may_receive_callable_args:

--- a/equinox/_module/_prebuilt.py
+++ b/equinox/_module/_prebuilt.py
@@ -23,7 +23,7 @@ class _FuncDescriptor(Protocol[_Return_co]):
 
 
 # Not using `jax.tree_util.Partial` as it doesn't implement __eq__ very well. See #480.
-class BoundMethod(Module, Generic[_Return]):
+class BoundMethod(Module, Generic[_Return], unchecked_init=True):
     """Just like a normal Python bound method... except that this one is a PyTree!
 
     This stores `__self__` as a subnode.
@@ -48,7 +48,7 @@ class BoundMethod(Module, Generic[_Return]):
         )
 
 
-class Partial(Module, Generic[_Return]):
+class Partial(Module, Generic[_Return], unchecked_init=True):
     """Like `functools.partial`, but treats the wrapped function, and partially-applied
     args and kwargs, as a PyTree.
 
@@ -92,7 +92,7 @@ class Partial(Module, Generic[_Return]):
 _Value = TypeVar("_Value")
 
 
-class Static(Module, Generic[_Value]):
+class Static(Module, Generic[_Value], unchecked_init=True):
     """Wraps a value into a `eqx.field(static=True)`.
 
     This is useful to treat something as just static metadata with respect to a JAX

--- a/equinox/_module/_prebuilt.py
+++ b/equinox/_module/_prebuilt.py
@@ -1,16 +1,84 @@
+import dataclasses
 from collections.abc import Callable
 from typing import Any, Generic, Protocol, runtime_checkable, TypeVar
+from typing_extensions import dataclass_transform
 
 import jax.tree_util as jtu
 from jaxtyping import PyTreeDef
 
 from ._field import field
 from ._flatten import WRAPPER_FIELD_NAMES
-from ._module import Module
+from ._module import (
+    _abstract_module_registry,
+    _currently_initialising,
+    _module_info,
+    _ModuleMeta,
+    Module,
+)
 
 
 _Return = TypeVar("_Return")
 _Return_co = TypeVar("_Return_co", covariant=True)
+
+
+@dataclass_transform(field_specifiers=(dataclasses.field, field))
+class _FastModuleMeta(_ModuleMeta):
+    """Metaclass for internal Modules created often enough that the
+    instantiation-time checks in `_ModuleMeta.__call__` are worth skipping.
+
+    Opting in is deliberately not inherited: a subclass of a class using this
+    metaclass goes through the usual `_ModuleMeta.__call__`, checks and all.
+    """
+
+    # Set on every class using this metaclass; True only for those opting in.
+    __fast_init__: bool
+
+    def __new__(
+        mcs,
+        name: str,
+        bases: tuple[type, ...],
+        namespace: dict[str, object],
+        **kwargs: Any,
+    ):
+        cls = super().__new__(mcs, name, bases, namespace, **kwargs)
+        # Only the class that explicitly asks for this metaclass gets the
+        # fastpath; anything inheriting from it does not.
+        cls.__fast_init__ = fast = not any(  # pyright: ignore[reportAttributeAccessIssue]
+            isinstance(b, _FastModuleMeta) for b in bases
+        )
+        if fast:
+            # These are the things the fastpath skips that would otherwise fail
+            # silently. Checked once, at class-creation time, so that a future
+            # edit to an opted-in class cannot quietly lose them.
+            info = _module_info[cls]
+            if (
+                info.converter_fields
+                or info.check_init_methods
+                or info.non_init_field_names
+            ):
+                raise TypeError(
+                    "`_FastModuleMeta` does not support converters, "
+                    "`__check_init__`, or `init=False` fields."
+                )
+            # The fastpath does not consult `_abstract_module_registry`, so an
+            # abstract class would silently become instantiable.
+            if cls in _abstract_module_registry:
+                raise TypeError("`_FastModuleMeta` classes cannot be abstract.")
+        return cls
+
+    def __call__(cls, *args: object, **kwargs: object):  # noqa: N805
+        __tracebackhide__ = True
+        if not cls.__fast_init__:
+            return super().__call__(*args, **kwargs)
+        tryself = None
+        try:
+            # Deliberately skipping `_ModuleMeta.__call__`.
+            self = tryself = super(_ModuleMeta, cls).__call__(*args, **kwargs)
+        finally:
+            if tryself is not None:
+                _currently_initialising.remove(tryself)
+            del tryself
+        return self
 
 
 @runtime_checkable
@@ -23,7 +91,7 @@ class _FuncDescriptor(Protocol[_Return_co]):
 
 
 # Not using `jax.tree_util.Partial` as it doesn't implement __eq__ very well. See #480.
-class BoundMethod(Module, Generic[_Return], unchecked_init=True):
+class BoundMethod(Module, Generic[_Return], metaclass=_FastModuleMeta):
     """Just like a normal Python bound method... except that this one is a PyTree!
 
     This stores `__self__` as a subnode.
@@ -48,7 +116,7 @@ class BoundMethod(Module, Generic[_Return], unchecked_init=True):
         )
 
 
-class Partial(Module, Generic[_Return], unchecked_init=True):
+class Partial(Module, Generic[_Return]):
     """Like `functools.partial`, but treats the wrapped function, and partially-applied
     args and kwargs, as a PyTree.
 
@@ -92,7 +160,7 @@ class Partial(Module, Generic[_Return], unchecked_init=True):
 _Value = TypeVar("_Value")
 
 
-class Static(Module, Generic[_Value], unchecked_init=True):
+class Static(Module, Generic[_Value]):
     """Wraps a value into a `eqx.field(static=True)`.
 
     This is useful to treat something as just static metadata with respect to a JAX

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -756,6 +756,64 @@ def test_init_fields():
         C(flag=False)
 
 
+def test_init_fastpath_metadata():
+    """_ModuleInfo precomputes which init=False fields need checking (RED test)."""
+    from equinox._module._module import _module_info
+
+    class AllInitTrue(eqx.Module):
+        x: int
+        y: float
+
+    # No init=False fields → nothing to check with dataclass-generated __init__
+    assert _module_info[AllInitTrue].unchecked_init_false_names == ()
+
+    class InitFalseNoDefault(eqx.Module):
+        x: int = eqx.field(init=False)
+
+    # init=False without a default → dataclass __init__ does NOT set it; must check
+    assert _module_info[InitFalseNoDefault].unchecked_init_false_names == ("x",)
+
+    class InitFalseWithDefault(eqx.Module):
+        x: int = eqx.field(init=False, default=42)
+
+    # init=False WITH a default → dataclass __init__ sets it; no need to check
+    assert _module_info[InitFalseWithDefault].unchecked_init_false_names == ()
+
+    class InitFalseWithFactory(eqx.Module):
+        x: list = eqx.field(init=False, default_factory=list)
+
+    # init=False WITH a default_factory → also initialized; no need to check
+    assert _module_info[InitFalseWithFactory].unchecked_init_false_names == ()
+
+
+def test_init_fastpath_correctness():
+    """The fastpath still catches errors that custom __init__ leaves fields unset."""
+
+    # Custom __init__ that forgets to set a field → must still raise
+    class CustomForgetsX(eqx.Module):
+        x: int
+
+        def __init__(self):
+            pass  # deliberately forgets self.x
+
+    with pytest.raises(TypeError, match="Field 'x' was not initialized."):
+        CustomForgetsX()
+
+    # Dataclass init + init=False without default → must still raise
+    class DataclassInitFalseNoDefault(eqx.Module):
+        x: int = eqx.field(init=False)
+
+    with pytest.raises(TypeError, match="Field 'x' was not initialized."):
+        DataclassInitFalseNoDefault()
+
+    # Dataclass init + all init=True → no error (common fast path)
+    class DataclassAllInitTrue(eqx.Module):
+        x: int
+
+    m = DataclassAllInitTrue(42)
+    assert m.x == 42
+
+
 @pytest.mark.parametrize("field", (dataclasses.field, eqx.field))
 def test_init_as_abstract(field):
     # Before the introduction of AbstractVar, it was possible to sort-of get the same

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -814,6 +814,76 @@ def test_init_fastpath_correctness():
     assert m.x == 42
 
 
+def test_callable_warning_scan_metadata():
+    """_ModuleInfo.may_receive_callable_args is False only when all init=True
+    fields have annotations that can never hold a JAX-transformed callable."""
+    from equinox._module._module import _module_info
+
+    class SafeAnnotations(eqx.Module):
+        a: int
+        b: float
+        c: str
+
+    assert _module_info[SafeAnnotations].may_receive_callable_args is False
+
+    class HasAny(eqx.Module):
+        x: Any
+
+    assert _module_info[HasAny].may_receive_callable_args is True
+
+    class HasCallable(eqx.Module):
+        fn: Callable
+
+    assert _module_info[HasCallable].may_receive_callable_args is True
+
+    class HasOptionalInt(eqx.Module):
+        x: int | None
+
+    assert _module_info[HasOptionalInt].may_receive_callable_args is False
+
+    class HasUnionInt(eqx.Module):
+        x: int | None
+
+    assert _module_info[HasUnionInt].may_receive_callable_args is False
+
+    class AllInitFalse(eqx.Module):
+        x: int = eqx.field(init=False, default=0)
+
+    # No init=True fields → nothing passed as constructor args → no scan needed
+    assert _module_info[AllInitFalse].may_receive_callable_args is False
+
+
+def test_callable_warning_scan_correctness(capsys):
+    """When may_receive_callable_args is True the scan still runs; when False it
+    is skipped without changing observable behaviour for correctly-typed modules."""
+    from equinox._module._module import _module_info
+
+    # Safe-typed module: flag must be False (scan is skipped)
+    class SafeModule(eqx.Module):
+        x: int
+        y: float
+
+    assert _module_info[SafeModule].may_receive_callable_args is False
+    # Constructing with correct types must not warn
+    import warnings as _warnings
+
+    with _warnings.catch_warnings():
+        _warnings.simplefilter("error")
+        m = SafeModule(1, 2.0)
+    assert m.x == 1
+
+    # Any-typed module: flag must be True (scan runs as before)
+    class AnyModule(eqx.Module):
+        fn: Any
+
+    assert _module_info[AnyModule].may_receive_callable_args is True
+    # Constructing with a plain int must not warn (scan runs, finds nothing bad)
+    with _warnings.catch_warnings():
+        _warnings.simplefilter("error")
+        m2 = AnyModule(42)
+    assert m2.fn == 42
+
+
 @pytest.mark.parametrize("field", (dataclasses.field, eqx.field))
 def test_init_as_abstract(field):
     # Before the introduction of AbstractVar, it was possible to sort-of get the same

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -1367,3 +1367,113 @@ def test_class_attribute_of_static_field_with_abstract_property():
 
     model = ConcreteChild()
     assert jax.jit(f)(model) == 2
+
+
+def test_fast_module_meta_opt_in_is_not_inherited():
+    """Subclasses of a `_FastModuleMeta` class go through the normal codepath."""
+    from equinox._module._prebuilt import _FastModuleMeta, BoundMethod
+
+    assert BoundMethod.__fast_init__ is True
+
+    class Sub(BoundMethod):
+        pass
+
+    assert Sub.__fast_init__ is False
+    assert type(Sub) is _FastModuleMeta
+
+
+def test_fast_module_meta_subclass_still_checked():
+    """A subclass gets the full `_ModuleMeta.__call__` treatment."""
+    from equinox._module._prebuilt import _FastModuleMeta
+
+    class Fast(eqx.Module, metaclass=_FastModuleMeta):
+        x: int
+
+        def __init__(self, x):
+            self.x = x
+
+    called = []
+
+    class Sub(Fast):
+        y: int
+
+        def __init__(self):  # deliberately leaves `y` unset
+            self.x = 1
+
+        def __check_init__(self):
+            called.append(True)
+
+    # The opted-in class skips the missing-field check...
+    class FastMissing(eqx.Module, metaclass=_FastModuleMeta):
+        x: int
+
+        def __init__(self):
+            pass
+
+    FastMissing()  # no error
+
+    # ...but the subclass does not.
+    with pytest.raises(TypeError, match="Field 'y' was not initialized."):
+        Sub()
+    assert called == []  # __check_init__ runs after the field check
+
+
+def test_fast_module_meta_rejects_unsupported_fields():
+    """Opting in with anything the fastpath skips is an error at class creation."""
+    from equinox._module._prebuilt import _FastModuleMeta
+
+    with pytest.raises(TypeError, match="does not support converters"):
+
+        class WithCheckInit(eqx.Module, metaclass=_FastModuleMeta):
+            x: int
+
+            def __check_init__(self):
+                pass
+
+    with pytest.raises(TypeError, match="does not support converters"):
+
+        class WithConverter(eqx.Module, metaclass=_FastModuleMeta):
+            x: int = eqx.field(converter=int)
+
+    with pytest.raises(TypeError, match="does not support converters"):
+
+        class WithNonInitField(eqx.Module, metaclass=_FastModuleMeta):
+            x: int = eqx.field(init=False)
+
+
+def test_fast_module_meta_rejects_abstract():
+    """The fastpath does not consult `_abstract_module_registry`, so opting in
+    an abstract class must be rejected at class-creation time.
+    """
+    from equinox._module._prebuilt import _FastModuleMeta
+
+    with pytest.raises(TypeError, match="cannot be abstract"):
+
+        class Abstract(eqx.Module, metaclass=_FastModuleMeta, is_abstract=True):
+            x: int
+
+    # An abstract *subclass* is fine: it takes the normal codepath.
+    class Fast(eqx.Module, metaclass=_FastModuleMeta):
+        x: int
+
+    class AbstractSub(Fast, is_abstract=True):
+        pass
+
+    with pytest.raises(TypeError, match="Cannot instantiate abstract"):
+        AbstractSub(1)
+
+
+def test_fast_module_meta_clears_currently_initialising():
+    """The fastpath must still remove the instance from `_currently_initialising`,
+    so that post-`__init__` attribute assignment is rejected as usual.
+    """
+    from equinox._module._module import _currently_initialising
+    from equinox._module._prebuilt import _FastModuleMeta
+
+    class Fast(eqx.Module, metaclass=_FastModuleMeta):
+        x: int
+
+    obj = Fast(1)
+    assert obj not in _currently_initialising
+    with pytest.raises(AttributeError):
+        obj.x = 2


### PR DESCRIPTION
| Scenario | Baseline | C1: init-check fastpath | C2: callable-warning scan | C3: wrapper-field setattr | C4: unchecked_init | C5: has_dataclass_init merge | Speedup |
|---|---:|---:|---:|---:|---:|---:|---:|
| 3 init=True fields | 5.15 | 4.31 | 3.69 | 3.70 | 3.69 | 3.42 | **1.51x** |
| 1 converter field | 3.52 | 3.28 | 2.83 | 2.85 | 2.82 | 2.55 | **1.38x** |
| 1 field + `__check_init__` | 3.13 | 2.91 | 2.40 | 2.44 | 2.45 | 2.27 | **1.38x** |
| 3-level MRO + `__check_init__` | 3.23 | 2.98 | 2.53 | 2.54 | 2.53 | 2.32 | **1.39x** |
| 10 init=True fields | 11.80 | 9.20 | 9.30 | 9.50 | 9.27 | 8.78 | **1.34x** |
| static field + 2 normal | 6.00 | 5.53 | 4.83 | 4.90 | 4.74 | 3.64 | **1.65x** |
| module_update_wrapper | 11.86 | 11.75 | 11.76 | 10.52 | 10.47 | 9.36 | **1.27x** |
| BoundMethod init (direct) | 8.43 | 7.82 | 7.81 | 7.88 | 3.19 | 2.81 | **3.00x** |
| attr access (x1) | 8.77 | 8.17 | 8.29 | 8.24 | 3.58 | 3.23 | **2.72x** |
| attr access (x3) | 26.39 | 24.13 | 24.84 | 24.99 | 10.74 | 9.64 | **2.74x** |

```python
import json
import sys
import timeit
import types
from pathlib import Path
from typing import Any

import equinox as eqx
from equinox._module._prebuilt import BoundMethod


# ---------------------------------------------------------------------------
# Module definitions
# ---------------------------------------------------------------------------


class _Simple(eqx.Module):
    a: int
    b: float
    c: str


class _WithConverter(eqx.Module):
    x: int = eqx.field(converter=int)


class _WithCheckInit(eqx.Module):
    a: int

    def __check_init__(self):
        pass


class _DeepA(eqx.Module):
    a: int

    def __check_init__(self):
        pass


class _DeepB(_DeepA):
    def __check_init__(self):
        pass


class _DeepC(_DeepB):
    def __check_init__(self):
        pass


class _ManyFields(eqx.Module):
    f0: Any
    f1: Any
    f2: Any
    f3: Any
    f4: Any
    f5: Any
    f6: Any
    f7: Any
    f8: Any
    f9: Any


class _StaticField(eqx.Module):
    name: str = eqx.field(static=True)
    value: int


class _Wrapped(eqx.Module):
    fn: Any

    def __call__(self, *args, **kwargs):
        return self.fn(*args, **kwargs)

    @property
    def __wrapped__(self):
        return self.fn


def _make_wrapped():
    return eqx.module_update_wrapper(_Wrapped(lambda x: x))


class _Host(eqx.Module):
    x: float
    y: float

    def method(self):
        return self.x + self.y

    def method2(self):
        return self.x * self.y

    def method3(self):
        return self.x - self.y


_host = _Host(1.0, 2.0)
_func: types.FunctionType = _Host.method  # type: ignore[assignment]


# ---------------------------------------------------------------------------
# Benchmark runner
# ---------------------------------------------------------------------------

SCENARIOS: list[tuple[str, str, dict[str, Any]]] = [
    ("simple", "_Simple(1, 2.0, 'x')", {}),
    ("converter", "_WithConverter(42)", {}),
    ("check_init", "_WithCheckInit(7)", {}),
    ("deep_inherit", "_DeepC(3)", {}),
    (
        "many_fields",
        "_ManyFields(0, 1, 2, 3, 4, 5, 6, 7, 8, 9)",
        {},
    ),
    ("static_field", "_StaticField('hello', 99)", {}),
    ("module_update_wrapper", "_make_wrapped()", {}),
    (
        "BoundMethod_init",
        "BoundMethod(_func, _host)",
        {"BoundMethod": BoundMethod, "_func": _func, "_host": _host},
    ),
    (
        "attr_access_single",
        "_host.method",
        {"_host": _host},
    ),
    (
        "attr_access_three",
        "_host.method; _host.method2; _host.method3",
        {"_host": _host},
    ),
]

NUMBER = 200_000
REPEAT = 5


def run_benchmarks() -> dict[str, float]:
    g = {
        "_Simple": _Simple,
        "_WithConverter": _WithConverter,
        "_WithCheckInit": _WithCheckInit,
        "_DeepC": _DeepC,
        "_ManyFields": _ManyFields,
        "_StaticField": _StaticField,
        "_make_wrapped": _make_wrapped,
        "_host": _host,
        "_func": _func,
        "BoundMethod": BoundMethod,
    }
    results: dict[str, float] = {}
    for name, stmt, extra in SCENARIOS:
        times = timeit.repeat(
            stmt, globals={**g, **extra}, number=NUMBER, repeat=REPEAT
        )
        # µs per call
        results[name] = min(times) / NUMBER * 1e6
    return results


if __name__ == "__main__":
    out_path = Path(sys.argv[1]) if len(sys.argv) > 1 else None

    print(f"equinox version: {eqx.__version__}")
    print(f"number={NUMBER:,}  repeat={REPEAT}  (reporting min-of-repeats / call)\n")

    results = run_benchmarks()

    for name, us in results.items():
        print(f"  {name:<20s} {us:.4f} µs/call")

    if out_path is not None:
        out_path.write_text(json.dumps(results, indent=2))
        print(f"\nResults saved to {out_path}")

```

*AI disclosure: vibe engineered this. Looked over the code closely, but tests are Red/Green TDD.


