### PR TITLE
Add ignored `key` argument to `eqx.nn.PReLU.__call__` so it composes with `Sequential`

### DIFF
--- a/equinox/nn/_activations.py
+++ b/equinox/nn/_activations.py
@@ -1,6 +1,6 @@
 import jax
 import jax.numpy as jnp
-from jaxtyping import Array
+from jaxtyping import Array, PRNGKeyArray
 
 from .._module import Module
 from ._misc import named_scope
@@ -30,10 +30,13 @@ class PReLU(Module):
         self.negative_slope = jnp.asarray(init_alpha)
 
     @named_scope("eqx.nn.PReLU")
-    def __call__(self, x: Array) -> Array:
+    def __call__(self, x: Array, *, key: PRNGKeyArray | None = None) -> Array:
         r"""**Arguments:**
 
         - `x`: The input.
+        - `key`: Ignored; provided for compatibility with the rest of the
+            Equinox API. (Note: this layer is now actually used by
+            [`equinox.nn.Sequential`][].)
 
         **Returns:**
 

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -1560,6 +1560,23 @@ def test_prelu(getkey):
     assert activation.negative_slope.shape == (x.shape[-1],)
     assert jnp.all(output == expected_multi_output)
 
+    # Test key argument is accepted and ignored
+    output = eqx.nn.PReLU()(jnp.array([1.0, -1.0]), key=jrandom.PRNGKey(0))
+    assert jnp.all(output == jnp.array([1.0, -0.25]))
+
+    # Test compatibility with Sequential, which forwards a key to each layer
+    net = eqx.nn.Sequential(
+        [
+            eqx.nn.Linear(2, 2, key=getkey()),
+            eqx.nn.PReLU(),
+        ]
+    )
+    x = jnp.ones(2)
+    output = net(x, key=None)
+    assert output.shape == (2,)
+    output = net(x, key=jrandom.PRNGKey(0))
+    assert output.shape == (2,)
+
 
 def test_rope_embeddings_shapes(getkey):
     embedding_size = 32


### PR DESCRIPTION
## Summary

Single-line addition to `eqx.nn.PReLU.__call__` plus a test.

1. In `equinox/nn/_activations.py`, change

   ```python
   @named_scope("eqx.nn.PReLU")
   def __call__(self, x: Array) -> Array:
       r"""**Arguments:**

       - `x`: The input.

       **Returns:**

       A JAX array of the same shape as the input.
       """
   ```

   to

   ```python
   @named_scope("eqx.nn.PReLU")
   def __call__(
       self, x: Array, *, key: PRNGKeyArray | None = None
   ) -> Array:
       r"""**Arguments:**

       - `x`: The input.
       - `key`: Ignored; provided for compatibility with the rest of the
           Equinox API. (Note: this layer is now actually used by
           [`equinox.nn.Sequential`][].)

       **Returns:**

       A JAX array of the same shape as the input.
       """
   ```

   The body of `__call__` is unchanged - the new `key` argument is intentionally unused, matching the pattern already used by `eqx.nn.Lambda.__call__` in `_sequential.py`.

2. Add `from jaxtyping import Array, PRNGKeyArray` (the file currently imports only `Array`).

3. In `tests/test_nn.py`, add a test that constructs `eqx.nn.Sequential([eqx.nn.Linear(2, 2, key=...), eqx.nn.PReLU()])` and invokes it both with `key=None` and with `key=jr.PRNGKey(0)`. Assert the output shape is `(2,)` and that the call does not raise. Also add a direct test that `PReLU()(jnp.array([1.0, -1.0]), key=jr.PRNGKey(0))` returns the expected `[1.0, -0.25]` (default `init_alpha=0.25`).

4. PR title: `Allow eqx.nn.PReLU to compose with eqx.nn.Sequential by accepting (and ignoring) a key argument`

   PR body (concise, factual):

   > Closes #1024.
   >
   > `Sequential.__call__` always forwards `key=` to non-stateful children, but `PReLU.__call__` did not accept a `key` parameter, so wrapping `PReLU` inside a `Sequential` raised `TypeError`. This adds an ignored `key: PRNGKeyArray | None = None` keyword-only argument to `PReLU.__call__`, matching the pattern used by `Lambda` and the other activation-shaped layers.
   >
   > The alternative discussed in the issue (have `Sequential` inspect each layer's call signature) is intentionally not pursued, as you noted that crosses into "too much magic".
   >
   > Tests added: `Sequential([Linear, PReLU])` with `key=None` and with an actual key, plus a direct invocation with the new keyword.

## Why this matters

`eqx.nn.Sequential.__call__` unconditionally passes a `key=` kwarg to every non-stateful child layer (see `_sequential.py` around line 105: `x = layer(x, key=key)`). `eqx.nn.PReLU.__call__` is currently declared as `def __call__(self, x: Array) -> Array:` with no `key` parameter, so putting `PReLU` inside a `Sequential` raises `TypeError: __call__() got an unexpected keyword argument 'key'` whenever the user threads a key through the sequence.

The issue author (SimonKoop) proposed the trivial fix - add an ignored `key` argument - and patrick-kidger confirmed in https://github.com/patrick-kidger/equinox/issues/1024#issuecomment that this is the right call and that the more ambitious "have Sequential inspect each layer's call signature" alternative is "too much magic" and will not be accepted. Later commenter Logon27 said they would open a PR, but never did - the issue remains open and the function is unchanged at HEAD.

`PReLU` has a learnable `negative_slope` parameter, so the standard workaround (`eqx.nn.Lambda(jax.nn.prelu)`) does not apply - the parameter is bound to the module instance and must travel with it.

## Testing

- `uv run pytest tests/test_nn.py -k PReLU` passes; new test for `Sequential` containing `PReLU` runs in both `key=None` and `key=jr.PRNGKey(...)` modes.
- `uv run pytest` full suite passes - no other test relied on `PReLU.__call__` rejecting unknown kwargs.
- `uv run pyright equinox/nn/_activations.py` passes - the new signature matches `Lambda` which is already typed identically.
- Manual smoke test:

  ```python
  import jax.random as jr, jax.numpy as jnp
  import equinox as eqx
  m = eqx.nn.Sequential([eqx.nn.Linear(2, 2, key=jr.PRNGKey(0)), eqx.nn.PReLU()])
  m(jnp.ones(2), key=jr.PRNGKey(1))  # currently TypeError, after the patch returns Array
  ```
- `grep -n "key:" equinox/nn/_activations.py` shows the new keyword on the `PReLU.__call__` line; no other behavior change.

Fixes #1024

AI was used for assistance.
