### PR TITLE
Fix `docs/examples/train_rnn.ipynb` to run on JAX 0.9 + recent Optax (filter non-array leaves out of opt state)

### DIFF
--- a/docs/examples/train_rnn.ipynb
+++ b/docs/examples/train_rnn.ipynb
@@ -123,7 +123,10 @@
    "id": "eb040df3-58c0-4546-b64d-c25147173e4b",
    "metadata": {},
    "source": [
-    "And finally the training loop."
+    "And finally the training loop.\n",
+    "\n",
+    "We pass `eqx.filter",
+    "(model, eqx.is_array)` to both `optim.init` and `optim.update` so that Optax only sees the trainable JAX arrays, not the rest of the PyTree (which includes non-array leaves such as activation functions)."
    ]
   },
   {
@@ -159,12 +162,14 @@
     "    @eqx.filter_jit\n",
     "    def make_step(model, x, y, opt_state):\n",
     "        loss, grads = compute_loss(model, x, y)\n",
-    "        updates, opt_state = optim.update(grads, opt_state)\n",
+    "        updates, opt_state = optim.update(\n",
+    "            grads, opt_state, eqx.filter(model, eqx.is_array)\n",
+    "        )\n",
     "        model = eqx.apply_updates(model, updates)\n",
     "        return loss, model, opt_state\n",
     "\n",
     "    optim = optax.adam(learning_rate)\n",
-    "    opt_state = optim.init(model)\n",
+    "    opt_state = optim.init(eqx.filter(model, eqx.is_array))\n",
     "    for step, (x, y) in zip(range(steps), iter_data):\n",
     "        loss, model, opt_state = make_step(model, x, y, opt_state)\n",
     "        loss = loss.item()\n",


### PR DESCRIPTION
## Summary

Edit the single notebook cell that sets up the optimizer + training loop.

1. Change `opt_state = optim.init(model)` to:

   ```python
   opt_state = optim.init(eqx.filter(model, eqx.is_array))
   ```

2. Change the optax update call inside `make_step` to pass the filtered params, so optax can cast against array-only leaves:

   ```python
   updates, opt_state = optim.update(
       grads, opt_state, eqx.filter(model, eqx.is_array)
   )
   ```

3. Leave `compute_loss`, the `@eqx.filter_value_and_grad` decorator, the `RNN` module definition, the data loop, and the final inference cells unchanged.

4. Verify the notebook still trains and that the printed `step=` / `loss=` lines match the existing narrative direction (loss decreases). The example's claim "RNN-MWE solves the parity task" must remain true.

5. Add a one-line markdown clarification above the optimizer cell:

   > We pass `eqx.filter(model, eqx.is_array)` to both `optim.init` and `optim.update` so that Optax only sees the trainable JAX arrays, not the rest of the PyTree (which includes non-array leaves such as activation functions).

   This matches the explanation already given in `docs/examples/mnist.ipynb` and stops the issue from recurring whenever JAX/Optax tighten tree semantics.

PR title: `Fix train_rnn.ipynb under JAX 0.9 + Optax >=0.2.7 by filtering non-array leaves out of opt_state`

PR body (concise, factual):

> Closes #1199.
>
> Under JAX `>=0.9.0`, `optax.tree.cast_like` no longer treats `None` as a tree-prefix of non-None values, so passing the full `RNN` module to `optim.init` / `optim.update` raises `ValueError: Expected None, got JitTracer(~int32[])`. The fix is the idiomatic Equinox pattern already used in `docs/examples/mnist.ipynb` and the project README: pass `eqx.filter(model, eqx.is_array)` so Optax only sees the array-valued leaves.
>
> Verified the notebook runs end-to-end on `jax==0.9.1`, `optax==0.2.7`, `equinox==0.13.8` and that the final accuracy on the parity task matches the previous narrative.
>
> No source-code changes; this is a notebook-only fix.

## Why this matters

The RNN tutorial notebook at `docs/examples/train_rnn.ipynb` fails on JAX `>=0.9.0` with the following stack:

```
ValueError: Expected None, got JitTracer(~int32[]).
```

raised from `optax.tree.cast_like` because JAX 0.9 stopped treating `None` as a tree-prefix of non-None values. The notebook passes the *entire* `RNN` module (which contains non-array leaves like activation callables) to both `optim.init(model)` and `optim.update(grads, opt_state)`. Older optax + JAX tolerated that; new ones do not.

The fix is the standard Equinox pattern: separate the array-valued parameters from the rest of the module via `eqx.partition` / `eqx.filter`. The same pattern is already used elsewhere in `equinox`'s own docs (e.g. `docs/examples/mnist.ipynb`) and in the README's "Quick example" block. This makes the notebook consistent with the project's own recommendation, not just a workaround.

The currently-affected cells in `train_rnn.ipynb` (confirmed by reading the live HEAD):

```python
optim = optax.adam(learning_rate)
opt_state = optim.init(model)
...
@eqx.filter_jit
def make_step(model, x, y, opt_state):
    loss, grads = compute_loss(model, x, y)
    updates, opt_state = optim.update(grads, opt_state)
    model = eqx.apply_updates(model, updates)
    return loss, model, opt_state
```

`optim.init(model)` and `optim.update(grads, opt_state)` both need the array-only view of the model.

## Testing

- `uv run jupyter nbconvert --execute docs/examples/train_rnn.ipynb --to notebook --output /tmp/train_rnn_out.ipynb` completes without exception against `jax==0.9.1` and `optax==0.2.7`.
- The final `final_accuracy` printout in the executed notebook is >= 0.95 (matches the example's pedagogical claim of "solves parity").
- Running the reproducer from the issue body (`rnn_mwe.py` with the same model + loss + step + adam setup but the filtered `init`/`update`) completes 1000 steps without the `ValueError: Expected None, got JitTracer(~int32[])`.
- `grep -n "eqx.filter(model" docs/examples/train_rnn.ipynb` returns two matches (one in `optim.init`, one in `optim.update`).
- `uv run mkdocs build` succeeds and the rendered tutorial page still renders the cell with no markdown-syntax breakage.
- Diff scope: only `docs/examples/train_rnn.ipynb` is modified. `git diff --name-only` shows exactly that one file.

Fixes #1199

AI was used for assistance.
