### PR TITLE
Cache `WeightNorm._norm` so that identical modules compare equal

### DIFF
--- a/equinox/nn/_weight_norm.py
+++ b/equinox/nn/_weight_norm.py
@@ -21,6 +21,18 @@ def _norm_except_axis(v: Array, norm: Callable[[Array], Scalar], axis: int | Non
         return jax.vmap(norm, in_axes=axis, out_axes=axis)(v)
 
 
+@ft.cache
+def _make_norm(axis: int | None) -> Callable[[Array], Scalar]:
+    # Cached so that two `WeightNorm`s with the same `axis` share the same callable,
+    # and so compare equal under `eqx.tree_equal`.
+    # https://github.com/patrick-kidger/equinox/issues/965
+    return ft.partial(
+        _norm_except_axis,
+        norm=ft.partial(jnp.linalg.norm, keepdims=True),
+        axis=axis,
+    )
+
+
 class WeightNorm(Module, Generic[_Layer]):
     r"""Applies weight normalisation to a given parameter.
 
@@ -88,11 +100,7 @@ class WeightNorm(Module, Generic[_Layer]):
         self.weight_name = weight_name
         self.axis = axis
 
-        self._norm = ft.partial(
-            _norm_except_axis,
-            norm=ft.partial(jnp.linalg.norm, keepdims=True),
-            axis=axis,
-        )
+        self._norm = _make_norm(axis)
         self.g = self._norm(getattr(layer, weight_name))
 
     @named_scope("eqx.nn.WeightNorm")

--- a/tests/test_nn.py
+++ b/tests/test_nn.py
@@ -1321,6 +1321,29 @@ def test_weight_norm(getkey):
     assert jnp.any(grads.g)
 
 
+# https://github.com/patrick-kidger/equinox/issues/965
+def test_weight_norm_equality(getkey):
+    linear = eqx.nn.Linear(4, 4, key=getkey())
+
+    for axis in (0, None):
+        m1 = eqx.nn.WeightNorm(layer=linear, weight_name="weight", axis=axis)
+        m2 = eqx.nn.WeightNorm(layer=linear, weight_name="weight", axis=axis)
+        assert eqx.tree_equal(m1, m2)
+
+    num_traces = 0
+
+    @eqx.filter_jit
+    def f(model, x):
+        nonlocal num_traces
+        num_traces += 1
+        return model(x)
+
+    x = jrandom.normal(getkey(), (4,))
+    f(eqx.nn.WeightNorm(layer=linear), x)
+    f(eqx.nn.WeightNorm(layer=linear), x)
+    assert num_traces == 1
+
+
 def test_maxpool1d():
     x = jnp.arange(14).reshape(1, 14)
     max_pool = eqx.nn.MaxPool1d(2, 3)


### PR DESCRIPTION
Fixes #965.

`WeightNorm.__init__` built a fresh `ft.partial` for `_norm` on every
instantiation, which (as suspected in the issue) only ever compares by
identity. Of the two options suggested there, this takes the cache-on-`axis`
route: `_norm` is now produced by a module-level `_make_norm(axis)` factory
wrapped in `ft.cache`, so instances with the same `axis` share one callable
and `tree_equal` holds.

I went with caching rather than `eqx.Partial` because the leaf stays a plain
`functools.partial`: the pytree structure is unchanged (friendlier to existing
treedefs and serialised models), and `_norm` remains a dynamic field that can
be patched with `eqx.tree_at` as before.

One extra finding from investigating: the per-instance callable also made
`eqx.filter_jit` retrace once per `WeightNorm` instance; traces are now
shared.

Added `test_weight_norm_equality` covering `tree_equal` for `axis=0` /
`axis=None` and a single-trace check under `filter_jit`. `tests/test_nn.py`,
`tests/test_tree.py` and `tests/test_serialisation.py` all pass locally (CPU).
