### PR TITLE
Fix eager `error_if` hanging when inputs are sharded over multiple devices

### DIFF
--- a/equinox/_errors.py
+++ b/equinox/_errors.py
@@ -287,6 +287,39 @@ def _error_outer(
 _error_outer_jit = _jit.filter_jit(_error_outer)
 
 
+def _eager_single_device(leaf) -> jax.Device | None:  # pyright: ignore[reportInvalidTypeForm]
+    # The device to gather `leaf` onto for an eager error check, or `None` to leave it
+    # untouched. Only a fully-addressable array spread over more than one device needs
+    # moving; single-device inputs (the common case) are left untouched.
+    if isinstance(leaf, jax.core.Tracer):
+        return None
+    if isinstance(leaf, jax.Array) and leaf.is_fully_addressable:
+        devices: set[jax.Device] = leaf.sharding.device_set  # pyright: ignore[reportInvalidTypeForm]
+        if len(devices) > 1:
+            return min(devices, key=lambda d: d.id)
+    return None
+
+
+def _to_single_device(leaf):
+    device = _eager_single_device(leaf)
+    return leaf if device is None else jax.device_put(leaf, device)
+
+
+def _restore_sharding(out: PyTree, like: PyTree) -> PyTree:
+    def restore(out_leaf, like_leaf):
+        if (
+            isinstance(out_leaf, jax.Array)
+            and isinstance(like_leaf, jax.Array)
+            and not isinstance(out_leaf, jax.core.Tracer)
+            and not isinstance(like_leaf, jax.core.Tracer)
+            and out_leaf.sharding != like_leaf.sharding
+        ):
+            return jax.device_put(out_leaf, like_leaf.sharding)
+        return out_leaf
+
+    return jtu.tree_map(restore, out, like)
+
+
 def _error_impl(
     x: PyTree,
     pred: Bool[ArrayLike, ""],
@@ -300,7 +333,18 @@ def _error_impl(
     # a bool and an int.
     # This ensures we can use `error_if` before init_google.
     if any(is_array(leaf) for leaf in leaves):
-        return _error_outer_jit(x, pred, msg, on_error=on_error, category=category)
+        # In eager mode the error check below is jitted. If an input is sharded over
+        # multiple devices this compiles an SPMD program, and when the error fires the
+        # exception raised inside `pure_callback` tears down one device whilst its peers
+        # hang forever at the next collective, aborting the whole process.
+        # (https://github.com/patrick-kidger/equinox/issues/1232)
+        # Pin the eager check to a single device -- a no-op when the inputs already live
+        # on one -- then put each output leaf back onto its original sharding.
+        single_x, single_pred = jtu.tree_map(_to_single_device, (x, pred))
+        out = _error_outer_jit(
+            single_x, single_pred, msg, on_error=on_error, category=category
+        )
+        return _restore_sharding(out, x)
     else:
         return _error_outer(x, pred, msg, on_error=on_error, category=category)
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -195,6 +195,44 @@ def test_traceback_runtime_custom():
         assert "EQX_ON_ERROR" not in str(e)
 
 
+# https://github.com/patrick-kidger/equinox/issues/1232
+def test_multi_device_eager():
+    # Without the fix, the error cases below deadlock at an XLA collective and then
+    # abort the whole process. `conftest.py` runs the suite with two CPU devices.
+    mesh = jax.sharding.Mesh(jax.devices("cpu"), ("x",))
+    replicated = jax.sharding.NamedSharding(mesh, jax.sharding.PartitionSpec())
+    x = jax.device_put(jnp.array(1.0), replicated)
+    true_pred = jax.device_put(jnp.array(True), replicated)
+    false_pred = jax.device_put(jnp.array(False), replicated)
+
+    # (x sharded, pred sharded), (only x sharded), (only pred sharded).
+    for x_i, pred_i in [(x, true_pred), (x, True), (jnp.array(1.0), true_pred)]:
+        with pytest.raises(eqx.EquinoxRuntimeError, match="oops"):
+            eqx.error_if(x_i, pred_i, "oops")
+
+    # Non-replicated shardings as well.
+    sharded = jax.sharding.NamedSharding(mesh, jax.sharding.PartitionSpec("x"))
+    y = jax.device_put(jnp.arange(4.0), sharded)
+    with pytest.raises(eqx.EquinoxRuntimeError, match="oops"):
+        eqx.error_if(y, jnp.all(y >= 0), "oops")
+
+    # No error: pass through unchanged, keeping the original sharding.
+    out = eqx.error_if(x, false_pred, "oops")
+    assert out.sharding == replicated
+    assert jnp.array_equal(out, jnp.array(1.0))
+
+    # Non-raising modes keep the original sharding too.
+    out = eqx.error_if(x, true_pred, "oops", on_error="nan")
+    assert out.sharding == replicated
+    assert jnp.isnan(out).all()
+    out = eqx.error_if(y, true_pred, "oops", on_error="nan")
+    assert out.sharding == sharded
+    assert jnp.isnan(out).all()
+    out = eqx.error_if(x, true_pred, "oops", on_error="off")
+    assert out.sharding == replicated
+    assert jnp.array_equal(out, jnp.array(1.0))
+
+
 def test_msg_callable():
     def _msg(x):
         return f"got bad value {x.item()}"


### PR DESCRIPTION
Fixes #1232.

The hang happens because eager `error_if` routes through `filter_jit`, so a
multi-device-sharded input compiles an SPMD program over every device in the
sharding. The all-reduce in the abort trace sits inside the `lax.cond` error
branch: once the exception from `jax.pure_callback` kills one device's
execution thread, its peers never reach the collective and XLA aborts the
process when the rendezvous times out.

This PR handles that case before the jit: if every input is concrete (no
tracers) and fully addressable, and at least one is sharded over more than one
device, then the predicate is evaluated on the host. On error, the inputs are
copied to the host and passed to the existing `branched_error_if_impl_jit`,
which then compiles a single-device program -- so the usual
`EquinoxRuntimeError` reporting is unchanged. For the non-raising `on_error`
modes, each output leaf's original sharding is restored with `jax.device_put`.
Traced or non-fully-addressable inputs fall through to the current behaviour.

One known limitation: `error_if` under a user's `jax.jit` over multi-device
inputs still aborts in the same way (verified locally). There the multi-device
program is what the user asked for, and the underlying problem -- a raising
callback inside an SPMD program -- doesn't look fixable from inside `error_if`.
This PR covers eager mode, as reported.

Tested with the two CPU devices already configured in `tests/conftest.py`: the
new test aborts the process (exit 134) without the fix and passes with it,
covering replicated and non-replicated shardings, each of `x`/`pred` sharded
alone, and sharding preservation on the false-predicate and
`on_error="nan"`/`"off"` paths.
