### PR TITLE
Don't warn about NumPy scalars in static fields

### DIFF
--- a/equinox/_module/_module.py
+++ b/equinox/_module/_module.py
@@ -444,9 +444,13 @@ class _ModuleMeta(BetterABCMeta):
             if any(jtu.tree_map(is_inexact_array_like, jtu.tree_leaves(val))):
                 warnings.warn(_MSG_FIELD_INIT_FALSE, stacklevel=2)
 
-        # Warn about static fields containing JAX arrays (post-converter values).
+        # Warn about static fields containing JAX or NumPy arrays (post-converter
+        # values). NumPy scalars (`np.generic`) are excluded: unlike arrays they are
+        # hashable, and so are safe to use as static fields.
+        # https://github.com/patrick-kidger/equinox/issues/863
         for name in info.static_field_names:
-            if any(jtu.tree_map(is_array, jtu.tree_leaves(getattr(self, name)))):
+            leaves = jtu.tree_leaves(getattr(self, name))
+            if any(is_array(x) and not isinstance(x, np.generic) for x in leaves):
                 warnings.warn(
                     "A JAX array is being set as static! This can result "
                     "in unexpected behavior and is usually a mistake to do.",

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -5,6 +5,7 @@ import doctest
 import functools as ft
 import inspect
 import pickle
+import warnings
 from collections.abc import Callable
 from dataclasses import InitVar
 from typing import Any, Generic, TypeVar
@@ -14,6 +15,7 @@ import equinox.internal as eqxi
 import jax
 import jax.numpy as jnp
 import jax.tree_util as jtu
+import numpy as np
 import pytest
 from jaxtyping import Array, Float
 
@@ -940,6 +942,19 @@ def test_no_jax_array_static():
         match="A JAX array is being set as static!",
     ):
         InvalidArr((), jnp.ones(10))
+
+    # NumPy arrays warn too...
+    with pytest.warns(
+        UserWarning,
+        match="A JAX array is being set as static!",
+    ):
+        InvalidTuple((np.ones(10),), jnp.ones(10))
+
+    # ...but NumPy scalars are hashable, so they're fine as static fields.
+    # https://github.com/patrick-kidger/equinox/issues/863
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        InvalidTuple(tuple(np.asarray((3, 2))), jnp.ones(10))
 
 
 # https://github.com/patrick-kidger/equinox/issues/832


### PR DESCRIPTION
Fixes #863.

The spurious warning comes from the static-field check in
`_ModuleMeta.__call__`, which maps `is_array` over the static leaves —
and `is_array` matches `np.generic`, so hashable NumPy scalars trip it
alongside actual arrays.

This implements the fix suggested in the thread: exclude `np.generic` from
that check. Static `np.ndarray`/`jax.Array` leaves still warn as before, and
the warning message text is unchanged so existing `filterwarnings` matches
keep working. (Happy to switch to the other option discussed — warning on any
unhashable leaf — if you'd prefer.)

Tests: extended `test_no_jax_array_static` with a still-warns case for a
static tuple containing an `np.ndarray`, and a must-not-warn case for a static
tuple of NumPy scalars; the latter fails before this change.
