### PR TITLE
Fix broken arXiv link in `RMSNorm` documentation

### DIFF
--- a/equinox/nn/_normalisation.py
+++ b/equinox/nn/_normalisation.py
@@ -295,12 +295,11 @@ class RMSNorm(Module):
     where $\Vert x \Vert^2_2 = \sum_{i=1}^n x_i^2$, $n = \dim(x)$, and $\gamma$ is a
     learned array with the same shape as $x$ if `use_weight=True`, or
     $\gamma = 1$ if `use_weight=False`, as proposed in
-    [this paper](https://browse.arxiv.org/abs/2307.14995). `\beta` is an optional bias
-    term.
+    [this paper](https://arxiv.org/abs/2307.14995). `\beta` is an optional bias term.
 
     ??? cite
 
-        [Root Mean Square Layer Normalization](https://browse.arxiv.org/abs/1910.07467)
+        [Root Mean Square Layer Normalization](https://arxiv.org/abs/1910.07467)
 
         ```bibtex
         @article{zhang2019root,


### PR DESCRIPTION
The RMSNorm documentation currently links to a non-working arXiv URL. This PR updates the reference to a working URL for the cited paper.