### PR TITLE
perf: short-circuit Module.__getattribute__ on non-method access

### DIFF
--- a/equinox/_module/_module.py
+++ b/equinox/_module/_module.py
@@ -616,10 +616,14 @@ class Module(Hashable, metaclass=_ModuleMeta):
             # run(SomeModule().some_method)
             # ```
             # works.
+            #
+            # The type check goes first so that non-method accesses (the common
+            # case) short-circuit before the `_is_magic` string scan. Bound methods
+            # are always exactly `types.MethodType`, so `is` matches `isinstance`.
             if (
-                not _is_magic(name)
-                and isinstance(out, types.MethodType)
+                type(out) is types.MethodType
                 and out.__self__ is self
+                and not _is_magic(name)
             ):
                 out = BoundMethod(object.__getattribute__(out, "__func__"), self)
             return out


### PR DESCRIPTION
### Summary

`Module.__getattribute__` runs on **every** attribute access and wraps bound methods in a `BoundMethod` so `jax.jit(module.method)` treats them as pytrees. The guard currently evaluates `not _is_magic(name)` first:

```python
if (
    not _is_magic(name)
    and isinstance(out, types.MethodType)
    and out.__self__ is self
):
```

So every read — including the overwhelmingly common case of reading a **field** — pays for the `_is_magic` string scan (`startswith`/`endswith`) before the cheap type discriminator can reject it.

This PR reorders the conditions so the type check runs first, letting field access short-circuit:

```python
if (
    type(out) is types.MethodType
    and out.__self__ is self
    and not _is_magic(name)
):
```

The boolean result is **identical** — a name is wrapped iff it is a non-magic bound method of `self`; only the evaluation order changes. Bound methods are always exactly `types.MethodType` (no subclasses), so the identity check is equivalent to the previous `isinstance`. (If you'd prefer to keep `isinstance` and only move `not _is_magic(name)` to last, that still captures the field-access win — happy to switch.)

### Benchmarks

Reading a field on a `Module` subclass (best of 3 × 1e6 iters, py3.14):

| | ns / access |
|---|---:|
| before | 209.6 |
| after | 141.7 |
| | **1.48×** |

Downstream, in [quax](https://github.com/patrick-kidger/quax)'s eager (non-jit) multiple-dispatch tracer over a mixed `add`/`matmul` workload (`cProfile`, 4000 calls): `_is_magic` drops from ~224k calls / 0.078 s to ~0, `Module.__getattribute__` tottime 0.140 → 0.114 s, and total Python tottime falls ~3.7%.

### Correctness

Verified that the wrapping behaviour is unchanged: field access returns the field; method access returns a `BoundMethod` bound to `self`; `jax.jit(module.method)` still works; magic methods (e.g. `__init__`) are not wrapped.

I couldn't run the full `tests/test_module.py` locally — collection hits an unrelated `jaxtyping`/py3.14 `issubclass()` error in this environment — so I verified the four behaviours above with a focused script. Glad to add a regression test (e.g. asserting field access doesn't invoke `_is_magic`) if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)