### PR TITLE
Treat JAX and NumPy arrays as interchangeable when deserialising

### DIFF
--- a/equinox/_serialisation.py
+++ b/equinox/_serialisation.py
@@ -186,13 +186,22 @@ def _maybe_open(
         yield path_or_file
 
 
+def _is_array_type(x) -> bool:
+    return isinstance(x, type) and issubclass(x, (np.ndarray, np.generic, jax.Array))
+
+
 def _assert_same(array_impl_type):
     def _assert_same_impl(path, new, old):
         typenew = type(new)
         typeold = type(old)
         if typeold is jax.ShapeDtypeStruct:
             typeold = array_impl_type
-        if typenew is not typeold:
+        # All kinds of JAX and NumPy array are interchangeable here: a
+        # `filter_spec` may legitimately leave a deserialised leaf on the host
+        # rather than on a device. The shape and dtype checks below still apply.
+        if typenew is not typeold and not (
+            _is_array_type(typenew) and _is_array_type(typeold)
+        ):
             raise RuntimeError(
                 f"Deserialised leaf at path '{jtu.keystr(path)}' has changed type from "
                 f"{type(old)} in `like` to {type(new)} on disk."

--- a/tests/test_serialisation.py
+++ b/tests/test_serialisation.py
@@ -262,3 +262,20 @@ def test_eval_shape(getkey, tmp_path):
     model3 = eqx.tree_deserialise_leaves(tmp_path, model2)
 
     assert eqx.tree_equal(model, model3, typematch=True)
+
+
+def test_eval_shape_deserialise_to_host(getkey, tmp_path):
+    # A `filter_spec` may leave the deserialised leaves on the host, in which
+    # case they are NumPy rather than JAX arrays. That should not be treated as
+    # a change of type relative to the `ShapeDtypeStruct`s in `like`.
+    model = eqx.nn.MLP(2, 2, 2, 2, key=getkey())
+    eqx.tree_serialise_leaves(tmp_path, model)
+
+    def filter_spec(f, x):
+        return jax.device_get(eqx.default_deserialise_filter_spec(f, x))
+
+    model2 = eqx.filter_eval_shape(eqx.nn.MLP, 2, 2, 2, 2, key=getkey())
+    model3 = eqx.tree_deserialise_leaves(tmp_path, model2, filter_spec=filter_spec)
+
+    assert isinstance(model3.layers[0].weight, np.ndarray)
+    assert eqx.tree_equal(model, model3)


### PR DESCRIPTION
Fixes #861.

### Problem

Deserialising into a `filter_eval_shape` skeleton fails if the `filter_spec`
puts the result on the host:

```python
like = eqx.filter_eval_shape(eqx.nn.Linear, 2, 2, key=key)
eqx.tree_deserialise_leaves(
    path, like,
    filter_spec=lambda f, x: jax.device_get(eqx.default_deserialise_filter_spec(f, x)),
)
# RuntimeError: Deserialised leaf at path '.weight' has changed type from
# <class 'jax.ShapeDtypeStruct'> in `like` to <class 'numpy.ndarray'> on disk.
```

Shape and dtype match. Only the array kind differs.

### Cause

`_assert_same_impl` substitutes the concrete array type for a
`ShapeDtypeStruct` in `like`, then compares with `typenew is not typeold`. That
identity check leaves no room for a `filter_spec` to hand back a NumPy array
instead of a JAX one.

### Fix

Compare array leaves by array-ness instead of exact type, which is what you
suggested in the issue: "Maybe we just consider all kinds of JAX and NumPy array
interchangeable?".

Every non-array leaf keeps the strict identity check, and the shape and dtype
checks immediately below are untouched, so real mismatches still raise. I
verified both: a shape mismatch still errors, and the behaviour for a
non-array `like` leaf is byte-for-byte the same as on `main`.

### Test plan

- New `test_eval_shape_deserialise_to_host` in `tests/test_serialisation.py`.
  It fails on `main` with the `RuntimeError` above and passes with this change.
- Full suite: 472 passed, 4 skipped (baseline on a clean checkout was 471
  passed, 4 skipped, so the only difference is the added test).
- `ruff check` and `ruff format --check` clean on both files.
