### PR TITLE
Improve ConvTranspose gradient computation by like ~30x by replacing lhs_dilation by padding the input directly

### DIFF
--- a/equinox/nn/_conv.py
+++ b/equinox/nn/_conv.py
@@ -605,13 +605,29 @@ class ConvTranspose(Module):
         if self.padding_mode == "CIRCULAR":
             x, padding_t = self._circular_pad(x, padding_t)
 
+        # Replace the lhs_dilation by applying the
+        # interior padding and output padding directly on the input
+        # This way, XLA can use cuDNN's backward-filter path
+        # and not the slow "convForward" path
+        padding_t = tuple(
+            (low, high - output_padding)
+            for (low, high), output_padding in zip(
+                padding_t, self.output_padding, strict=True
+            )
+        )
+        padding_config = ((0, 0, 0),) + tuple(
+            (0, output_padding, stride - 1)
+            for stride, output_padding in zip(
+                self.stride, self.output_padding, strict=True
+            )
+        )
+        x = lax.pad(x, jnp.array(0, dtype=x.dtype), padding_config)
         x = jnp.expand_dims(x, axis=0)
         x = lax.conv_general_dilated(
             lhs=x,
             rhs=self.weight,
             window_strides=(1,) * self.num_spatial_dims,
             padding=padding_t,
-            lhs_dilation=self.stride,
             rhs_dilation=self.dilation,
             feature_group_count=self.groups,
         )


### PR DESCRIPTION
I looked at [this issue](https://github.com/jax-ml/jax/issues/31662) which stated that the `ConvTranspose` gradient computation was 32x slower compared to PyTorch. I looked a bit closer.

See this example:

```python
import jax
import jax.numpy as jnp
from jax import lax

x = jnp.array(
    [
        [
            [1.0, 2.0],
            [3.0, 4.0],
        ]
    ]
)
weight = jnp.ones((1, 1, 3, 3))
stride = (2, 2)
old_convolution_padding = ((1, 2), (1, 2))


def conv_wrapper(current_weight, values):
    return lax.conv_general_dilated(
        lhs=values[None],
        rhs=current_weight,
        window_strides=(1, 1),
        padding=old_convolution_padding,
        lhs_dilation=stride,
    )[0, 0]


old_output = conv_wrapper(weight, x)

def loss_fn(current_weight, values):
    return conv_wrapper(current_weight, values).mean()


grads = jax.jit(jax.grad(loss_fn))

weight_gradient = grads(weight, x)
hlo = grads.lower(weight, x).compile().as_text() or ""

print(hlo)
```

This prints out the following hlo:

(it's a bit long, so I collapsed it here)
<details>
<summary>Full HLO</summary>

```
(jax-conv-test) arturgalstyan@talon:~/Workspace/jax-conv-test$ python3 test.py
HloModule jit_loss_fn, is_scheduled=true, entry_computation_layout={(f32[1,2,2]{2,1,0})->f32[1,1,3,3]{3,2,1,0}}, allow_spmd_sharding_propagation_to_parameters={true}, allow_spmd_sharding_propagation_to_output={true}, frontend_attributes={fingerprint_before_lhs="5dade3103634c6a6c52e209606857497"}

FileNames
1 "/home/arturgalstyan/Workspace/jax-conv-test/test.py"

FunctionNames
1 "<module>"
2 "loss_fn"
3 "conv_wrapper"

FileLocations
1 {file_name_id=1 function_name_id=1 line=36 end_line=36 column=18 end_column=34}
2 {file_name_id=1 function_name_id=2 line=31 end_line=31 column=11 end_column=47}
3 {file_name_id=1 function_name_id=3 line=20 end_line=20 column=12 end_column=24}
4 {file_name_id=1 function_name_id=3 line=19 end_line=25 column=11 end_column=5}

StackFrames
1 {file_location_id=1 parent_frame_id=1}
2 {file_location_id=2 parent_frame_id=2}
3 {file_location_id=3 parent_frame_id=3}
4 {file_location_id=4 parent_frame_id=3}


%fused_pad (param_0.4: f32[1,2,2]) -> f32[1,3,3,1] {
  %param_0.4 = f32[1,2,2]{2,1,0} parameter(0)
  %bitcast.4.1 = f32[1,2,2,1]{3,2,1,0} bitcast(%param_0.4)
  %constant_5 = f32[] constant(0)
  ROOT %pad.2.1 = f32[1,3,3,1]{3,2,1,0} pad(%bitcast.4.1, %constant_5), padding=0_0_0x0_0_1x0_0_1x0_0_0, metadata={op_name="jit(loss_fn)/jvp()/broadcast_in_dim" stack_frame_id=3}
}

%fused_pad.1 () -> f32[5,5] {
  %constant_1_1 = f32[] constant(0.0625)
  %broadcast.1.1 = f32[4,4]{1,0} broadcast(%constant_1_1), dimensions={}
  %constant_4 = f32[] constant(0)
  ROOT %pad.clone.2 = f32[5,5]{1,0} pad(%broadcast.1.1, %constant_4), padding=0_1x0_1
}

ENTRY %main.1 (values.1: f32[1,2,2]) -> f32[1,1,3,3] {
  %values.1 = f32[1,2,2]{2,1,0} parameter(0), metadata={op_name="values"}
  %loop_pad_fusion = f32[1,3,3,1]{3,2,1,0} fusion(%values.1), kind=kLoop, calls=%fused_pad, metadata={op_name="jit(loss_fn)/jvp()/broadcast_in_dim" stack_frame_id=3}, backend_config={"device_type":"DEVICE_TYPE_INVALID","force_earliest_schedule":false,"native_emitter_backend_config":{"type":"NATIVE_EMITTER_TYPE_INVALID","unroll_factor":0},"operation_queue_id":"0","reification_cost":[]}
  %loop_pad_fusion.1 = f32[5,5]{1,0} fusion(), kind=kLoop, calls=%fused_pad.1, backend_config={"device_type":"DEVICE_TYPE_INVALID","force_earliest_schedule":false,"native_emitter_backend_config":{"type":"NATIVE_EMITTER_TYPE_INVALID","unroll_factor":0},"operation_queue_id":"0","reification_cost":[]}
  %bitcast.7.0 = f32[1,5,5,1]{3,2,1,0} bitcast(%loop_pad_fusion.1)
  %cudnn-conv.2 = (f32[1,3,3,1]{3,2,1,0}, u8[0]{0}) custom-call(%bitcast.7.0, %loop_pad_fusion), window={size=3x3 rhs_reversal=1x1}, dim_labels=b01f_o01i->b01f, custom_call_target="__cudnn$convForward", metadata={op_name="jit(loss_fn)/transpose(jvp())/conv_general_dilated" stack_frame_id=4}, backend_config={"cudnn_conv_backend_config":{"activation_mode":"kNone","algorithm":{"algo_id":"0","is_cudnn_frontend":false,"math_type":"DEFAULT_MATH","tuning_knobs":{},"workspace_size":"0"},"conv_result_scale":1,"leakyrelu_alpha":0,"side_input_scale":0},"device_type":"DEVICE_TYPE_INVALID","force_earliest_schedule":false,"operation_queue_id":"0","reification_cost":[]}
  %get-tuple-element.1.0 = f32[1,3,3,1]{3,2,1,0} get-tuple-element(%cudnn-conv.2), index=0
  ROOT %bitcast.19.0 = f32[1,1,3,3]{3,2,1,0} bitcast(%get-tuple-element.1.0), metadata={op_name="jit(loss_fn)/transpose(jvp())/conv_general_dilated" stack_frame_id=4}
}
```
</details>

The important bit is here:

```
%cudnn-conv.2 = (f32[1,3,3,1]{3,2,1,0}, u8[0]{0}) custom-call(%bitcast.7.0, %loop_pad_fusion), window={size=3x3 rhs_reversal=1x1}, dim_labels=b01f_o01i->b01f, custom_call_target="__cudnn$convForward"
```

Which shows that for the grads, the `__cudnn$convForward` fn is used. The grads are correct, but this is slow as heck.

The reason for that is the `lhs_dilation` argument of the `conv_general_dilated` function. AFAICT, the padding zeros are added somewhere in JAX's internals. But, if we just pad the input directly, we can circumvent this.


Consider this alternative:

```python
import jax
import jax.numpy as jnp
from jax import lax

x = jnp.array(
    [
        [
            [1.0, 2.0],
            [3.0, 4.0],
        ]
    ]
)
weight = jnp.ones((1, 1, 3, 3))
stride = (2, 2)
new_input_padding = (
    (0, 0, 0),
    (0, 1, 1),
    (0, 1, 1),
)
new_convolution_padding = ((1, 1), (1, 1))

def new_method(current_weight, values):
    expanded_values = lax.pad(
        values,
        jnp.array(0, dtype=values.dtype),
        new_input_padding,
    )
    return lax.conv_general_dilated(
        lhs=expanded_values[None],
        rhs=current_weight,
        window_strides=(1, 1),
        padding=new_convolution_padding,
    )[0, 0]

def loss_fn(current_weight, values):
    return new_method(current_weight, values).mean()

grads = jax.jit(jax.grad(loss_fn))
hlo = grads.lower(weight, x).compile().as_text() or ""

print(hlo)
```

This gives us this output:

<details>
<summary>Full HLO</summary>

```
(jax-conv-test) arturgalstyan@talon:~/Workspace/jax-conv-test$ python3 test2.py
HloModule jit_loss_fn, is_scheduled=true, entry_computation_layout={(f32[1,2,2]{2,1,0})->f32[1,1,3,3]{3,2,1,0}}, allow_spmd_sharding_propagation_to_parameters={true}, allow_spmd_sharding_propagation_to_output={true}, frontend_attributes={fingerprint_before_lhs="58aa9f2752d3467bbe120d092ea58eff"}

FileNames
1 "/home/arturgalstyan/Workspace/jax-conv-test/test2.py"

FunctionNames
1 "<module>"
2 "loss_fn"
3 "new_method"

FileLocations
1 {file_name_id=1 function_name_id=1 line=39 end_line=39 column=6 end_column=28}
2 {file_name_id=1 function_name_id=2 line=36 end_line=36 column=11 end_column=45}
3 {file_name_id=1 function_name_id=3 line=23 end_line=27 column=22 end_column=5}
4 {file_name_id=1 function_name_id=3 line=28 end_line=33 column=11 end_column=5}

StackFrames
1 {file_location_id=1 parent_frame_id=1}
2 {file_location_id=2 parent_frame_id=2}
3 {file_location_id=3 parent_frame_id=3}
4 {file_location_id=4 parent_frame_id=3}


%fused_pad (param_0: f32[1,2,2]) -> f32[1,4,4] {
  %param_0 = f32[1,2,2]{2,1,0} parameter(0)
  %constant_3_1 = f32[] constant(0)
  ROOT %pad.1.1 = f32[1,4,4]{2,1,0} pad(%param_0, %constant_3_1), padding=0_0_0x0_1_1x0_1_1, metadata={op_name="jit(loss_fn)/jvp()/pad" stack_frame_id=3}
}

%fused_broadcast () -> f32[1,4,4,1] {
  %constant_2_1 = f32[] constant(0.0625)
  ROOT %broadcast.3.1 = f32[1,4,4,1]{3,2,1,0} broadcast(%constant_2_1), dimensions={}
}

ENTRY %main.1 (values.1: f32[1,2,2]) -> f32[1,1,3,3] {
  %values.1 = f32[1,2,2]{2,1,0} parameter(0), metadata={op_name="values"}
  %loop_pad_fusion = f32[1,4,4]{2,1,0} fusion(%values.1), kind=kLoop, calls=%fused_pad, metadata={op_name="jit(loss_fn)/jvp()/pad" stack_frame_id=3}, backend_config={"device_type":"DEVICE_TYPE_INVALID","force_earliest_schedule":false,"native_emitter_backend_config":{"type":"NATIVE_EMITTER_TYPE_INVALID","unroll_factor":0},"operation_queue_id":"0","reification_cost":[]}
  %bitcast.4.0 = f32[1,4,4,1]{3,2,1,0} bitcast(%loop_pad_fusion)
  %loop_broadcast_fusion = f32[1,4,4,1]{3,2,1,0} fusion(), kind=kLoop, calls=%fused_broadcast, backend_config={"device_type":"DEVICE_TYPE_INVALID","force_earliest_schedule":false,"native_emitter_backend_config":{"type":"NATIVE_EMITTER_TYPE_INVALID","unroll_factor":0},"operation_queue_id":"0","reification_cost":[]}
  %cudnn-conv-bw-filter.1 = (f32[1,3,3,1]{3,2,1,0}, u8[0]{0}) custom-call(%bitcast.4.0, %loop_broadcast_fusion), window={size=3x3 pad=1_1x1_1}, dim_labels=b01f_o01i->b01f, custom_call_target="__cudnn$convBackwardFilter", metadata={op_name="jit(loss_fn)/transpose(jvp())/conv_general_dilated" stack_frame_id=4}, backend_config={"cudnn_conv_backend_config":{"activation_mode":"kNone","algorithm":{"algo_id":"0","is_cudnn_frontend":false,"math_type":"DEFAULT_MATH","tuning_knobs":{},"workspace_size":"0"},"conv_result_scale":1,"leakyrelu_alpha":0,"side_input_scale":0},"device_type":"DEVICE_TYPE_INVALID","force_earliest_schedule":false,"operation_queue_id":"0","reification_cost":[]}
  %get-tuple-element.1.0 = f32[1,3,3,1]{3,2,1,0} get-tuple-element(%cudnn-conv-bw-filter.1), index=0
  ROOT %bitcast.14.0 = f32[1,1,3,3]{3,2,1,0} bitcast(%get-tuple-element.1.0), metadata={op_name="jit(loss_fn)/transpose(jvp())/conv_general_dilated" stack_frame_id=4}
}
```
</details>

Now the target has switched to `custom_call_target="__cudnn$convBackwardFilter"` and this is fast!

Applying this to the OP's scripts from [the original issue from jax](https://github.com/jax-ml/jax/issues/31662), we get this output

```
{'grad_fn_batched_ms_per_iter': 1.251} << new method


for comparison
{'grad_fn_batched_ms_per_iter': 38.292} <<< old method
```

vs PyTorch
```
{'eager_ms_per_iter': 0.311, 'compiled_ms_per_iter': 0.31}
```

I ran these tests on an RTX 5090. 





P.S.: Ideally, XLA should just create the correct HLO. The other issue has been open for a long time and this patch gives a numerically equivalent and much faster (albeit slightly less elegant) solution. But it's merely a patch. The real issue is on JAX and XLA side. Because of that, I could totally understand you closing this w/o merging, since the slowdown not really Equinox's fault.